### PR TITLE
Use build matrix in GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,20 +51,20 @@ jobs:
         run: poetry run python -m ebl.tests.downloader
 
       - name: Unit Tests
-        if: matrix.python-version != '3.7'
+        if: ${{ startsWith(matrix.python-version, 'pypy') }}
         env:
           CI: true
         run: poetry run pytest -n auto
 
       - name: Unit Tests with Coverage
         id: unit_tests
-        if: matrix.python-version == '3.7'
+        if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         env:
           CI: true
         run: poetry run pytest --cov=ebl --cov-report term --cov-report xml -n auto
           
       - uses: paambaati/codeclimate-action@v2.7.4
-        if: matrix.python-version == '3.7' && (success() || steps.unit_tests.outcome == 'failure')
+        if: ${{ !startsWith(matrix.python-version, 'pypy') && (success() || steps.unit_tests.outcome == 'failure') }}
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,18 +56,14 @@ jobs:
           CI: true
         run: poetry run pytest -n auto
 
-      - name: Unit Tests with Coverage
-        id: unit_tests
+      - name: Unit Tests with Coverage  
+        uses: paambaati/codeclimate-action@v3.0.0
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         env:
-          CI: true
-        run: poetry run pytest --cov=ebl --cov-report term --cov-report xml -n auto
-          
-      - uses: paambaati/codeclimate-action@v2.7.4
-        if: ${{ !startsWith(matrix.python-version, 'pypy') && (success() || steps.unit_tests.outcome == 'failure') }}
-        env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-      
+        with:
+          coverageCommand: poetry run pytest --cov=ebl --cov-report term --cov-report xml -n auto
+
       - uses: edge/simple-slack-notify@v1.1.1
         if: failure()
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,17 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', 'pypy-3.7']
+    name: Test Python ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 'pypy-3.7'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install
         id: install
@@ -47,13 +51,20 @@ jobs:
         run: poetry run python -m ebl.tests.downloader
 
       - name: Unit Tests
+        if: matrix.python-version != '3.7'
+        env:
+          CI: true
+        run: poetry run pytest -n auto
+
+      - name: Unit Tests with Coverage
         id: unit_tests
+        if: matrix.python-version == '3.7'
         env:
           CI: true
         run: poetry run pytest --cov=ebl --cov-report term --cov-report xml -n auto
           
       - uses: paambaati/codeclimate-action@v2.7.4
-        if: success() || steps.unit_tests.outcome == 'failure'
+        if: matrix.python-version == '3.7' && (success() || steps.unit_tests.outcome == 'failure')
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       

--- a/ebl/transliteration/domain/text_line_transformer.py
+++ b/ebl/transliteration/domain/text_line_transformer.py
@@ -3,6 +3,7 @@ from typing import Iterable, Sequence, Type
 from lark.lexer import Token
 from lark.tree import Tree
 from lark.visitors import v_args
+import pydash
 
 from ebl.transliteration.domain import atf
 from ebl.transliteration.domain.atf import Flag
@@ -95,7 +96,7 @@ class NormalizedAkkadianTransformer(EnclosureTransformer, SignTransformer):
     def ebl_atf_text_line__normalized_modifiers(
         self, modifiers: Iterable[Flag]
     ) -> Sequence[Flag]:
-        return tuple(set(modifiers))
+        return tuple(pydash.uniq(modifiers))
 
     @v_args(inline=True)
     def ebl_atf_text_line__normalized_modifier(self, modifier: Token) -> Flag:


### PR DESCRIPTION
Code Coverage is extremely slow in PyPy. Adding a build matrix and running coverage only with CPython, makes the build faster while keeping the coverage report.