### PR TITLE
Don't show '@' if reference has no pages

### DIFF
--- a/ebl/transliteration/domain/markup.py
+++ b/ebl/transliteration/domain/markup.py
@@ -128,9 +128,9 @@ class BibliographyPart(MarkupPart):
     @property
     def value(self) -> str:
         id = escape(self.reference.id)
-        pages = escape(self.reference.pages)
-        pages = '@'+pages if pages else pages
-        return f"@bib{{{id}{pages}}}"
+        pages = f"@{escape(self.reference.pages)}"
+
+        return f"@bib{{{id}{pages if pages != '@' else ''}}}"
 
     @staticmethod
     def of(id: BibliographyId, pages: str) -> "BibliographyPart":

--- a/ebl/transliteration/domain/markup.py
+++ b/ebl/transliteration/domain/markup.py
@@ -129,7 +129,8 @@ class BibliographyPart(MarkupPart):
     def value(self) -> str:
         id = escape(self.reference.id)
         pages = escape(self.reference.pages)
-        return f"@bib{{{id}@{pages}}}"
+        pages = '@'+pages if pages else pages
+        return f"@bib{{{id}{pages}}}"
 
     @staticmethod
     def of(id: BibliographyId, pages: str) -> "BibliographyPart":


### PR DESCRIPTION
The Parser would return `@bib{ref_id@}` if pages were not specified but shouldn't show `@` in that case.