### PR TITLE
Refactor fragment update methods into one parametrized method

### DIFF
--- a/ebl/fragmentarium/application/fragment_repository.py
+++ b/ebl/fragmentarium/application/fragment_repository.py
@@ -75,23 +75,7 @@ class FragmentRepository(ABC):
         ...
 
     @abstractmethod
-    def update_transliteration(self, fragment: Fragment) -> None:
-        ...
-
-    @abstractmethod
-    def update_genres(self, fragment: Fragment) -> None:
-        ...
-
-    @abstractmethod
-    def update_lemmatization(self, fragment: Fragment) -> None:
-        ...
-
-    @abstractmethod
-    def update_references(self, fragment: Fragment) -> None:
-        ...
-
-    @abstractmethod
-    def update_introduction(self, fragment: Fragment) -> None:
+    def update_field(self, field: str, fragment: Fragment) -> None:
         ...
 
     def query_fragmentarium(

--- a/ebl/fragmentarium/application/fragment_updater.py
+++ b/ebl/fragmentarium/application/fragment_updater.py
@@ -47,7 +47,7 @@ class FragmentUpdater:
             else fragment.update_lowest_join_transliteration(transliteration, user)
         )
         self._create_changlelog(user, fragment, updated_fragment)
-        self._repository.update_transliteration(updated_fragment)
+        self._repository.update_field("transliteration", updated_fragment)
 
         return self._create_result(updated_fragment)
 
@@ -58,7 +58,7 @@ class FragmentUpdater:
         updated_fragment = fragment.set_introduction(introduction)
 
         self._create_changlelog(user, fragment, updated_fragment)
-        self._repository.update_introduction(updated_fragment)
+        self._repository.update_field("introduction", updated_fragment)
 
         return self._create_result(updated_fragment)
 
@@ -69,7 +69,7 @@ class FragmentUpdater:
         updated_fragment = fragment.set_genres(genres)
 
         self._create_changlelog(user, fragment, updated_fragment)
-        self._repository.update_genres(updated_fragment)
+        self._repository.update_field("genres", updated_fragment)
 
         return self._create_result(updated_fragment)
 
@@ -80,7 +80,7 @@ class FragmentUpdater:
         updated_fragment = fragment.update_lemmatization(lemmatization)
 
         self._create_changlelog(user, fragment, updated_fragment)
-        self._repository.update_lemmatization(updated_fragment)
+        self._repository.update_field("lemmatization", updated_fragment)
 
         return self._create_result(updated_fragment)
 
@@ -93,7 +93,7 @@ class FragmentUpdater:
         updated_fragment = fragment.set_references(references)
 
         self._create_changlelog(user, fragment, updated_fragment)
-        self._repository.update_references(updated_fragment)
+        self._repository.update_field("references", updated_fragment)
 
         return self._create_result(self._repository.query_by_museum_number(number))
 

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository.py
@@ -311,22 +311,29 @@ class MongoFragmentRepository(FragmentRepository):
             },
         )
 
-    def update_genres(self, fragment):
-        self._fragments.update_one(
-            fragment_is(fragment),
-            {"$set": FragmentSchema(only=("genres",)).dump(fragment)},
-        )
+    def update_field(self, field, fragment):
 
-    def update_lemmatization(self, fragment):
-        self._fragments.update_one(
-            fragment_is(fragment),
-            {"$set": FragmentSchema(only=("text",)).dump(fragment)},
-        )
+        fields_to_update = {
+            "introduction": ("introduction",),
+            "lemmatization": ("text",),
+            "genres": ("genres",),
+            "references": ("references",),
+            "transliteration": (
+                "text",
+                "notes",
+                "signs",
+                "record",
+                "line_to_vec",
+            ),
+        }
 
-    def update_introduction(self, fragment):
+        if field not in fields_to_update:
+            raise ValueError(
+                f"Unexpected update field {field}, must be one of {','.join(fields_to_update)}"
+            )
         self._fragments.update_one(
             fragment_is(fragment),
-            {"$set": FragmentSchema(only=("introduction",)).dump(fragment)},
+            {"$set": FragmentSchema(only=fields_to_update[field]).dump(fragment)},
         )
 
     def query_next_and_previous_folio(self, folio_name, folio_number, number):
@@ -430,12 +437,6 @@ class MongoFragmentRepository(FragmentRepository):
                 museum_number, all_museum_numbers, True
             )
         return FragmentPagerInfo(cast(MuseumNumber, prev), cast(MuseumNumber, next))
-
-    def update_references(self, fragment):
-        self._fragments.update_one(
-            fragment_is(fragment),
-            {"$set": FragmentSchema(only=("references",)).dump(fragment)},
-        )
 
     def _map_fragments(self, cursor) -> Sequence[Fragment]:
         return FragmentSchema(unknown=EXCLUDE, many=True).load(cursor)

--- a/ebl/tests/fragmentarium/test_fragment_repository.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository.py
@@ -256,7 +256,7 @@ def test_update_transliteration_with_record(fragment_repository, user):
         TransliterationUpdate(parse_atf_lark("$ (the transliteration)"), "notes"), user
     )
 
-    fragment_repository.update_transliteration(updated_fragment)
+    fragment_repository.update_field("transliteration", updated_fragment)
     result = fragment_repository.query_by_museum_number(fragment.number)
 
     assert result == updated_fragment
@@ -265,7 +265,7 @@ def test_update_transliteration_with_record(fragment_repository, user):
 def test_update_update_transliteration_not_found(fragment_repository):
     transliterated_fragment = TransliteratedFragmentFactory.build()
     with pytest.raises(NotFoundError):
-        fragment_repository.update_transliteration(transliterated_fragment)
+        fragment_repository.update_field("transliteration", transliterated_fragment)
 
 
 def test_update_genres(fragment_repository):
@@ -274,7 +274,7 @@ def test_update_genres(fragment_repository):
     updated_fragment = fragment.set_genres(
         (Genre(["ARCHIVAL", "Administrative"], False),)
     )
-    fragment_repository.update_genres(updated_fragment)
+    fragment_repository.update_field("genres", updated_fragment)
     result = fragment_repository.query_by_museum_number(fragment.number)
 
     assert result == updated_fragment
@@ -288,7 +288,7 @@ def test_update_lemmatization(fragment_repository):
     lemmatization = Lemmatization(tokens)
     updated_fragment = transliterated_fragment.update_lemmatization(lemmatization)
 
-    fragment_repository.update_lemmatization(updated_fragment)
+    fragment_repository.update_field("lemmatization", updated_fragment)
     result = fragment_repository.query_by_museum_number(transliterated_fragment.number)
 
     assert result == updated_fragment
@@ -298,7 +298,7 @@ def test_update_introduction(fragment_repository: FragmentRepository):
     fragment: Fragment = FragmentFactory.build(introduction=Introduction("", tuple()))
     fragment_repository.create(fragment)
     updated_fragment = fragment.set_introduction("Introduction")
-    fragment_repository.update_introduction(updated_fragment)
+    fragment_repository.update_field("introduction", updated_fragment)
     result = fragment_repository.query_by_museum_number(fragment.number)
 
     assert result == updated_fragment
@@ -307,7 +307,7 @@ def test_update_introduction(fragment_repository: FragmentRepository):
 def test_update_update_lemmatization_not_found(fragment_repository):
     transliterated_fragment = TransliteratedFragmentFactory.build()
     with pytest.raises(NotFoundError):
-        fragment_repository.update_lemmatization(transliterated_fragment)
+        fragment_repository.update_field("lemmatization", transliterated_fragment)
 
 
 def test_statistics(database, fragment_repository):
@@ -635,7 +635,7 @@ def test_update_references(fragment_repository):
     references = (reference,)
     updated_fragment = fragment.set_references(references)
 
-    fragment_repository.update_references(updated_fragment)
+    fragment_repository.update_field("references", updated_fragment)
     result = fragment_repository.query_by_museum_number(fragment.number)
 
     assert result == updated_fragment
@@ -644,4 +644,4 @@ def test_update_references(fragment_repository):
 def test_update_update_references(fragment_repository):
     transliterated_fragment = TransliteratedFragmentFactory.build()
     with pytest.raises(NotFoundError):
-        fragment_repository.update_references(transliterated_fragment)
+        fragment_repository.update_field("references", transliterated_fragment)

--- a/ebl/tests/fragmentarium/test_fragment_updater.py
+++ b/ebl/tests/fragmentarium/test_fragment_updater.py
@@ -62,7 +62,7 @@ def test_update_transliteration(
     ).thenReturn()
     (
         when(fragment_repository)
-        .update_transliteration(transliterated_fragment)
+        .update_field("transliteration", transliterated_fragment)
         .thenReturn()
     )
 
@@ -128,7 +128,7 @@ def test_update_genres(
         {"_id": str(number), **SCHEMA.dump(fragment)},
         {"_id": str(number), **SCHEMA.dump(updated_fragment)},
     ).thenReturn()
-    when(fragment_repository).update_genres(updated_fragment).thenReturn()
+    when(fragment_repository).update_field("genres", updated_fragment).thenReturn()
 
     result = fragment_updater.update_genres(number, genres, user)
     assert result == (injected_fragment, False)
@@ -158,7 +158,9 @@ def test_update_lemmatization(
         {"_id": str(number), **SCHEMA.dump(transliterated_fragment)},
         {"_id": str(number), **SCHEMA.dump(lemmatized_fragment)},
     ).thenReturn()
-    when(fragment_repository).update_lemmatization(lemmatized_fragment).thenReturn()
+    when(fragment_repository).update_field(
+        "lemmatization", lemmatized_fragment
+    ).thenReturn()
 
     result = fragment_updater.update_lemmatization(number, lemmatization, user)
     assert result == (injected_fragment, False)
@@ -198,7 +200,7 @@ def test_update_references(
     when(fragment_repository).query_by_museum_number(number).thenReturn(
         fragment
     ).thenReturn(updated_fragment)
-    when(fragment_repository).update_references(updated_fragment).thenReturn()
+    when(fragment_repository).update_field("references", updated_fragment).thenReturn()
     when(changelog).create(
         "fragments",
         user.profile,
@@ -238,7 +240,9 @@ def test_update_introduction(
         {"_id": str(number), **SCHEMA.dump(fragment)},
         {"_id": str(number), **SCHEMA.dump(updated_fragment)},
     ).thenReturn()
-    when(fragment_repository).update_introduction(updated_fragment).thenReturn()
+    when(fragment_repository).update_field(
+        "introduction", updated_fragment
+    ).thenReturn()
 
     result = fragment_updater.update_introduction(number, introduction, user)
     assert result == (updated_fragment, False)


### PR DESCRIPTION
All `update_` methods were almost identical except of the `only` parameter, refactoring them into a single paremeterized method