### PR TITLE
Fix _sortKey index creation

### DIFF
--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Sequence
 import pymongo
 from marshmallow import EXCLUDE
 from pymongo.collation import Collation
+from pymongo.errors import OperationFailure
 
 from ebl.bibliography.infrastructure.bibliography import join_reference_documents
 from ebl.common.domain.scopes import Scope
@@ -57,7 +58,11 @@ class MongoFragmentRepository(FragmentRepository):
     def _create_sort_index(self) -> None:
         sortkey_index = [("_sortKey", pymongo.ASCENDING)]
 
-        self._fragments.drop_index(sortkey_index)
+        try:
+            self._fragments.drop_index(sortkey_index)
+        except OperationFailure:
+            print("No index found, creating from scratch...")
+
         self._fragments.aggregate(
             [
                 {"$project": {"museumNumber": True}},

--- a/ebl/mongo_collection.py
+++ b/ebl/mongo_collection.py
@@ -89,6 +89,9 @@ class MongoCollection:
     def create_index(self, index, **kwargs):
         return self.__get_collection().create_index(index, **kwargs)
 
+    def drop_index(self, index, **kwargs):
+        return self.__get_collection().drop_index(index, **kwargs)
+
     def get_all_values(self, field: str, query: Optional[dict] = None) -> Sequence[str]:
         return self.__get_collection().distinct(field, query or {})
 

--- a/ebl/tests/fragmentarium/test_fragment_repository.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository.py
@@ -893,3 +893,14 @@ def test_query_by_sort_key_no_index(fragment_repository):
 
     with pytest.raises(NotFoundError, match="Unable to find fragment with _sortKey 0"):
         fragment_repository.query_by_sort_key(0)
+
+
+def test_create_sort_index_with_new_fragment(fragment_repository):
+    fragment_repository._create_sort_index()
+
+    fragment = FragmentFactory.build()
+    data = FragmentSchema().dump(fragment)
+    fragment_repository._fragments.insert_one(data)
+    fragment_repository._create_sort_index()
+
+    assert fragment_repository.query_by_sort_key(0) == fragment.number


### PR DESCRIPTION
Manually adding new fragments causes an error due to duplicate `_sortKey`s. This fixes it by making the index non-unique (it doesn't have to be since `_sortKey` is only a utility field).