### PR TITLE
Add variant index positions

### DIFF
--- a/ebl/corpus/application/display_schemas.py
+++ b/ebl/corpus/application/display_schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, post_dump
 
 from ebl.corpus.application.id_schemas import ChapterIdSchema
 from ebl.corpus.application.record_schemas import RecordSchema
@@ -17,6 +17,10 @@ from ebl.transliteration.application.note_line_part_schemas import (
 )
 
 
+class LineVariantDisplaySchema(LineVariantSchema):
+    original_index = fields.Integer(data_key="originalIndex", dump_only=True)
+
+
 class LineDisplaySchema(Schema):
     number = fields.Nested(OneOfLineNumberSchema, required=True)
     old_line_numbers = fields.Nested(
@@ -28,7 +32,7 @@ class LineDisplaySchema(Schema):
     is_beginning_of_section = fields.Boolean(
         required=True, data_key="isBeginningOfSection"
     )
-    variants = fields.Nested(LineVariantSchema, many=True, required=True)
+    variants = fields.Nested(LineVariantDisplaySchema, many=True, required=True)
     translation = fields.List(
         fields.Nested(TranslationLineSchema), load_default=tuple(), allow_none=True
     )
@@ -43,6 +47,15 @@ class LineDisplaySchema(Schema):
             tuple(data["variants"]),
             tuple(data["translation"] or []),
         )
+
+    @post_dump
+    def add_variant_indexes(self, data: dict, **kwargs) -> dict:
+        data["variants"] = [
+            {**variant, "originalIndex": index}
+            for index, variant in enumerate(data["variants"])
+        ]
+
+        return data
 
 
 class ChapterDisplaySchema(Schema):

--- a/ebl/corpus/application/display_schemas.py
+++ b/ebl/corpus/application/display_schemas.py
@@ -23,6 +23,7 @@ class LineVariantDisplaySchema(LineVariantSchema):
 
 class LineDisplaySchema(Schema):
     number = fields.Nested(OneOfLineNumberSchema, required=True)
+    original_index = fields.Integer(data_key="originalIndex", dump_only=True)
     old_line_numbers = fields.Nested(
         OldLineNumberSchema, many=True, data_key="oldLineNumbers", load_default=tuple()
     )
@@ -80,3 +81,11 @@ class ChapterDisplaySchema(Schema):
             data["record"],
             tuple(data["manuscripts"]),
         )
+
+    @post_dump
+    def add_line_indexes(self, data: dict, **kwargs) -> dict:
+        data["lines"] = [
+            {**line, "originalIndex": index} for index, line in enumerate(data["lines"])
+        ]
+
+        return data

--- a/ebl/tests/corpus/test_chapter_display_schema.py
+++ b/ebl/tests/corpus/test_chapter_display_schema.py
@@ -78,8 +78,9 @@ def to_dict(
                 "translation": []
                 if missing_translation
                 else TranslationLineSchema().dump(line.translation, many=True),
+                **({} if for_loading else {"originalIndex": index}),
             }
-            for line in chapter.lines
+            for index, line in enumerate(chapter.lines)
         ],
         "record": RecordSchema().dump(chapter.record),
         "manuscripts": ManuscriptSchema().dump(chapter.manuscripts, many=True),

--- a/ebl/tests/corpus/test_chapter_display_schema.py
+++ b/ebl/tests/corpus/test_chapter_display_schema.py
@@ -1,7 +1,8 @@
 import attr
-
+from typing import Sequence
 from ebl.corpus.application.display_schemas import ChapterDisplaySchema
 from ebl.corpus.domain.chapter_display import ChapterDisplay
+from ebl.corpus.domain.line_variant import LineVariant
 from ebl.tests.factories.corpus import (
     ChapterFactory,
     TextFactory,
@@ -29,6 +30,26 @@ from ebl.corpus.application.schemas import ManuscriptSchema, ManuscriptLineSchem
 CHAPTER_DISPLAY = ChapterDisplay.of_chapter(TextFactory.build(), ChapterFactory.build())
 
 
+def variants_to_dict(
+    variants: Sequence[LineVariant], for_loading: bool
+) -> Sequence[dict]:
+    return [
+        {
+            "intertext": OneOfNoteLinePartSchema().dump(variant.intertext, many=True),
+            "reconstruction": OneOfTokenSchema().dump(
+                variant.reconstruction, many=True
+            ),
+            "note": variant.note and NoteLineSchema().dump(variant.note),
+            "manuscripts": ManuscriptLineSchema().dump(variant.manuscripts, many=True),
+            "parallelLines": ParallelLineSchema().dump(
+                variant.parallel_lines, many=True
+            ),
+            **({} if for_loading else {"originalIndex": index}),
+        }
+        for index, variant in enumerate(variants)
+    ]
+
+
 def to_dict(
     chapter: ChapterDisplay, missing_translation: bool = False, for_loading=False
 ) -> dict:
@@ -53,24 +74,7 @@ def to_dict(
                 ),
                 "isSecondLineOfParallelism": line.is_second_line_of_parallelism,
                 "isBeginningOfSection": line.is_beginning_of_section,
-                "variants": [
-                    {
-                        "intertext": OneOfNoteLinePartSchema().dump(
-                            variant.intertext, many=True
-                        ),
-                        "reconstruction": OneOfTokenSchema().dump(
-                            variant.reconstruction, many=True
-                        ),
-                        "note": variant.note and NoteLineSchema().dump(variant.note),
-                        "manuscripts": ManuscriptLineSchema().dump(
-                            variant.manuscripts, many=True
-                        ),
-                        "parallelLines": ParallelLineSchema().dump(
-                            variant.parallel_lines, many=True
-                        ),
-                    }
-                    for variant in line.variants
-                ],
+                "variants": variants_to_dict(line.variants, for_loading),
                 "translation": []
                 if missing_translation
                 else TranslationLineSchema().dump(line.translation, many=True),


### PR DESCRIPTION
Store the index of each variant in chapter.line.variants in a new `originalIndex` field for easier handling of partial ChapterDisplay in frontend corpus search results