### PR TITLE
Update Scope format

### DIFF
--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get_extended.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get_extended.py
@@ -158,8 +158,7 @@ class MongoFragmentRepositoryGetExtended(MongoFragmentRepositoryBase):
             {},
         )
         return [
-            Scope.from_string(f"read:{value}-fragments")
-            for value in fragment.get("authorizedScopes", [])
+            Scope.from_string(value) for value in fragment.get("authorizedScopes", [])
         ]
 
     def fetch_names(self, name_query: str) -> List[str]:

--- a/ebl/fragmentarium/infrastructure/queries.py
+++ b/ebl/fragmentarium/infrastructure/queries.py
@@ -46,9 +46,7 @@ def match_user_scopes(user_scopes: Sequence[Scope] = tuple()) -> dict:
     ]
 
     if user_scopes:
-        allowed_scopes.extend(
-            {"authorizedScopes": scope.scope_name} for scope in user_scopes
-        )
+        allowed_scopes.extend({"authorizedScopes": str(scope)} for scope in user_scopes)
 
     return {"$or": allowed_scopes}
 

--- a/ebl/schemas.py
+++ b/ebl/schemas.py
@@ -70,10 +70,10 @@ class ScopeField(EnumField):
         super().__init__(Scope, **kwargs)
 
     def _serialize_enum(self, value: Scope) -> str:
-        return value.scope_name
+        return str(value)
 
     def _deserialize_enum(self, value: str) -> Enum:
-        return Scope.from_string(f"read:{value}-fragments")
+        return Scope.from_string(value)
 
 
 class ResearchProjectField(EnumField):

--- a/ebl/tests/fragmentarium/test_fragment_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_schema.py
@@ -10,8 +10,8 @@ SCOPES = [
     Scope.READ_SIPPARLIBRARY_FRAGMENTS,
 ]
 SERIALIZED_SCOPES = [
-    "ITALIANNINEVEH",
-    "SIPPARLIBRARY",
+    "read:ITALIANNINEVEH-fragments",
+    "read:SIPPARLIBRARY-fragments",
 ]
 
 


### PR DESCRIPTION
Store full scope names in `authorizedScopes` (e.g., `["read:CAIC-fragments"]` instead of `["CAIC"]`.