### PR TITLE
Add no longer visible (°) to ATF Grammar

### DIFF
--- a/docs/ebl-atf.md
+++ b/docs/ebl-atf.md
@@ -155,7 +155,7 @@ ruling = ('single' | 'double' | 'triple'), ' ', 'ruling',
 
 image = '(image ' number, [ lower-case-letter ], ' = ', free-text, ')';
 
-dollar-status = '*' | '?' | '!' | '!?';
+dollar-status = '*' | '?' | '!' | '!?' | '°';
 ```
 
 See: [ATF Structure Tutorial](http://oracc.museum.upenn.edu/doc/help/editinginatf/primer/structuretutorial/index.html)
@@ -537,11 +537,12 @@ invalue-broken-away: open-broken-away | close-broken-away;
 
 variant-separator = '/';
 
-flag = { damage | uncertain | correction | collation };
+flag = { damage | uncertain | correction | collation | no-longer-visible };
 damage = '#';
 uncertain = '?';
 correction = '!';
 collation = '*';
+no-longer-visible = '°';
 
 modifier = { '@', ( 'c' | 'f' | 'g' | 's' | 't' | 'n'
                   | 'z' | 'k' | 'r' | 'h' | 'v' | { decimal-digit }- ) };

--- a/ebl/tests/transliteration/test_parse_ruling_dollar_line.py
+++ b/ebl/tests/transliteration/test_parse_ruling_dollar_line.py
@@ -23,6 +23,7 @@ from ebl.transliteration.domain.text import Text
         ("?", atf.DollarStatus.UNCERTAIN),
         ("!", atf.DollarStatus.EMENDED_NOT_COLLATED),
         ("!?", atf.DollarStatus.NEEDS_COLLATION),
+        ("°", atf.DollarStatus.NO_LONGER_VISIBLE),
     ],
 )
 @pytest.mark.parametrize("status_space", [True, False])

--- a/ebl/tests/transliteration/test_parse_state_dollar_line.py
+++ b/ebl/tests/transliteration/test_parse_state_dollar_line.py
@@ -129,6 +129,16 @@ from ebl.transliteration.domain.transliteration_error import TransliterationErro
             ),
         ),
         (
+            "several tablet blank °",
+            StateDollarLine(
+                None,
+                atf.Extent.SEVERAL,
+                ScopeContainer(atf.Object.TABLET),
+                atf.State.BLANK,
+                atf.DollarStatus.NO_LONGER_VISIBLE,
+            ),
+        ),
+        (
             "several tablet blank !?",
             StateDollarLine(
                 None,

--- a/ebl/tests/transliteration/test_parse_state_dollar_line_exhaustive.py
+++ b/ebl/tests/transliteration/test_parse_state_dollar_line_exhaustive.py
@@ -76,6 +76,7 @@ STATUSES = [
     ("!", atf.DollarStatus.EMENDED_NOT_COLLATED),
     ("?", atf.DollarStatus.UNCERTAIN),
     ("!?", atf.DollarStatus.NEEDS_COLLATION),
+    ("°", atf.DollarStatus.NO_LONGER_VISIBLE),
 ]
 
 

--- a/ebl/transliteration/domain/atf.py
+++ b/ebl/transliteration/domain/atf.py
@@ -65,6 +65,7 @@ class DollarStatus(Enum):
     UNCERTAIN = "?"
     EMENDED_NOT_COLLATED = "!"
     NEEDS_COLLATION = "!?"
+    NO_LONGER_VISIBLE = "°"
 
     CORRECTION = "!"
     COLLATION = "*"

--- a/ebl/transliteration/domain/ebl_atf_dollar_line.lark
+++ b/ebl/transliteration/domain/ebl_atf_dollar_line.lark
@@ -30,7 +30,7 @@ SCOPE: "columns" | "column" | "lines" | "line" | "cases" | "case" | "surface" | 
 STATE: "blank" | "broken" | "effaced" | "illegible" | "missing" | "traces"
      | "omitted" | "continues"
 
-DOLLAR_STATUS: "!?" | "*" | "?" | "!"
+DOLLAR_STATUS: "!?" | "*" | "?" | "!" | "°"
 
 ruling : RULING_NUMBER " ruling" [" "? DOLLAR_STATUS]
 RULING_NUMBER : "single" | "double" | "triple"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add the 'no longer visible' status to the ATF grammar and update related documentation and tests to support this new status.

New Features:
- Introduce a new 'no longer visible' status represented by the symbol '°' in the ATF grammar.

Documentation:
- Update the ATF grammar documentation to include the 'no longer visible' status.

Tests:
- Add test cases for the new 'no longer visible' status in the transliteration parsing tests.

<!-- Generated by sourcery-ai[bot]: end summary -->