### PR TITLE
Make archaeology date start optional

### DIFF
--- a/ebl/fragmentarium/application/date_schemas.py
+++ b/ebl/fragmentarium/application/date_schemas.py
@@ -28,7 +28,7 @@ class PartialDateSchema(Schema):
 
 
 class DateRangeSchema(Schema):
-    start = fields.Nested(PartialDateSchema, required=True)
+    start = fields.Nested(PartialDateSchema, allow_none=True)
     end = fields.Nested(PartialDateSchema, allow_none=True)
     notes = fields.String(allow_none=True)
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Make the 'start' field in DateRangeSchema optional by allowing None values.