### PR TITLE
Add Rust to Docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,16 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
 
       - name: Install
         id: install
         run: |
+          pip install --upgrade pip
           pip install poetry
           poetry install --no-root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM pypy:3.9-7.3.10
 
+RUN pip install --upgrade pip
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN pip install poetry
 
 EXPOSE 8000
@@ -16,3 +19,4 @@ COPY ./docs ./docs
 RUN chmod -R a-wx ./docs
 
 CMD ["poetry", "run", "waitress-serve", "--port=8000", "--connection-limit=500", "--call", "ebl.app:get_app"]
+


### PR DESCRIPTION
## Summary by Sourcery

Integrate Rust into the Docker environment and CI workflow by adding Rust installation steps to both the Dockerfile and the CI configuration.

Build:
- Update Dockerfile to include Rust installation and set the PATH environment variable to include Cargo binaries.

CI:
- Add Rust installation step to the CI workflow to ensure Rust is available during the build process.