### PR TITLE
Replace --no-dev by --only main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/src/ebl
 
 COPY pyproject.toml ./
 COPY poetry.* ./
-RUN poetry install --no-root --no-dev
+RUN poetry install --no-root --only main
 
 COPY ./ebl ./ebl
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Install only the `main` dependencies instead of all dependencies except dev dependencies.