### PR TITLE
Translation extents dots

### DIFF
--- a/ebl/atf_importer/domain/lark-oracc/oracc_atf_translation_line.lark
+++ b/ebl/atf_importer/domain/lark-oracc/oracc_atf_translation_line.lark
@@ -1,5 +1,10 @@
 
-translation_line: "#tr.en: " (emphasis_part | language_part | string_part)+
+translation_line: "#tr" ["." language_code] ["." translation_extent] ": " markup+
+language_code: /[a-z]{2}/
+translation_extent: "(" [label " "] line_number ")"
+label: /[a-z0-9]+/
+line_number: /[0-9]+/
+markup: emphasis_part | language_part | string_part
 language_part: "@" LANGUAGE "{" translation_text "}"
 emphasis_part: "@i{" translation_text "}"
 string_part: translation_text

--- a/ebl/atf_importer/domain/lark-oracc/oracc_atf_translation_line.lark
+++ b/ebl/atf_importer/domain/lark-oracc/oracc_atf_translation_line.lark
@@ -2,7 +2,7 @@
 translation_line: "#tr" ["." language_code] ["." translation_extent] ": " markup+
 language_code: /[a-z]{2}/
 translation_extent: "(" [label " "] line_number ")"
-label: /[a-z0-9]+/
+label: /[a-z0-9\.]+/
 line_number: /[0-9]+/
 markup: emphasis_part | language_part | string_part
 language_part: "@" LANGUAGE "{" translation_text "}"


### PR DESCRIPTION
Added "\." as valid character for translation line extents for the side tags ("b.e.","t.e."...).

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where translation extent tags could not contain dots.