### PR TITLE
Fix 500 errors on rapid saving

### DIFF
--- a/ebl/fragmentarium/web/bootstrap.py
+++ b/ebl/fragmentarium/web/bootstrap.py
@@ -7,6 +7,7 @@ from ebl.fragmentarium.application.fragment_finder import FragmentFinder
 from ebl.fragmentarium.application.fragment_matcher import FragmentMatcher
 from ebl.fragmentarium.application.fragmentarium import Fragmentarium
 from ebl.fragmentarium.web.annotations import AnnotationResource
+from ebl.fragmentarium.web.edition import EditionResource
 from ebl.fragmentarium.web.findspots import FindspotResource
 from ebl.fragmentarium.web.folio_pager import FolioPagerResource
 from ebl.fragmentarium.web.folios import FoliosResource
@@ -120,6 +121,7 @@ def create_fragmentarium_routes(api: falcon.App, context: Context):
     archaeology = ArchaeologyResource(updater)
     colophon = ColophonResource(updater)
     notes = NotesResource(updater)
+    edition = EditionResource(transliteration, notes, introduction)
     annotations = AnnotationResource(annotations_service)
     fragment_pager = make_fragment_pager_resource(finder, context.cache)
     folio_pager = FolioPagerResource(finder)
@@ -148,6 +150,7 @@ def create_fragmentarium_routes(api: falcon.App, context: Context):
         ("/fragments/{number}/references", references),
         ("/fragments/{number}/transliteration", transliteration),
         ("/fragments/{number}/introduction", introduction),
+        ("/fragments/{number}/edition", edition),
         ("/fragments/{number}/archaeology", archaeology),
         ("/fragments/{number}/colophon", colophon),
         ("/fragments/{number}/notes", notes),

--- a/ebl/fragmentarium/web/edition.py
+++ b/ebl/fragmentarium/web/edition.py
@@ -1,0 +1,24 @@
+from falcon import Request, Response
+
+from ebl.fragmentarium.web.introductions import IntroductionResource
+from ebl.fragmentarium.web.notes import NotesResource
+from ebl.fragmentarium.web.transliterations import TransliterationResource
+
+
+class EditionResource:
+    def __init__(
+        self,
+        transliteration_resource: TransliterationResource,
+        notes_resource: NotesResource,
+        introduction_resource: IntroductionResource,
+    ):
+        self._update_resources = {
+            "transliteration": transliteration_resource,
+            "notes": notes_resource,
+            "introduction": introduction_resource,
+        }
+
+    def on_post(self, req: Request, resp: Response, number: str) -> None:
+        for field, resource in self._update_resources.items():
+            if field in req.media:
+                resource.on_post(req, resp, number)

--- a/ebl/fragmentarium/web/transliterations.py
+++ b/ebl/fragmentarium/web/transliterations.py
@@ -16,7 +16,11 @@ from ebl.fragmentarium.domain.fragment import NotLowestJoinError
 
 TRANSLITERATION_DTO_SCHEMA = {
     "type": "object",
-    "properties": {"transliteration": {"type": "string"}},
+    "properties": {
+        "transliteration": {"type": "string"},
+        "notes": {"type": "string"},
+        "introduction": {"type": "string"},
+    },
     "required": ["transliteration"],
     "additionalProperties": False,
 }


### PR DESCRIPTION
Saving multiple times within a short period of time causes 500 errors due to rate limits of auth0. This is caused by the fact that saving editions performs 3 separate authentication calls to /userinfo, one for the notes, the introduction, and the transliteration, even if not changes were made. This PR adds a dedicated /edition endpoint to handle changes to these fields with a single API call, thus mitigating the rate limit issue.