### PR TITLE
Add aš as MODIFIER_CHARACTER

### DIFF
--- a/docs/ebl-atf.md
+++ b/docs/ebl-atf.md
@@ -544,7 +544,7 @@ correction = '!';
 collation = '*';
 no-longer-visible = '°';
 
-modifier = { '@', ( 'c' | 'f' | 'g' | 's' | 't' | 'n'
+modifier = { '@', ( 'aš' | 'c' | 'f' | 'g' | 's' | 't' | 'n'
                   | 'z' | 'k' | 'r' | 'h' | 'v' | { decimal-digit }- ) };
 
 sub-index-character = '₀' | '₁' | '₂' | '₃' | '₄' | '₅'

--- a/ebl/transliteration/domain/ebl_atf_text_line.lark
+++ b/ebl/transliteration/domain/ebl_atf_text_line.lark
@@ -276,7 +276,7 @@ DAMAGE: "#"
 
 modifiers: MODIFIER*
 MODIFIER: ("@" (MODIFIER_CHARACTER | ("0".."9")+))
-MODIFIER_CHARACTER: "c" | "f" | "g" | "s" | "t" | "n" | "z" | "k" | "r" | "h" | "v"
+MODIFIER_CHARACTER: "c" | "f" | "g" | "s" | "t" | "n" | "z" | "k" | "r" | "h" | "v" | "aš"
 
 in_word_newline: IN_WORD_NEWLINE
 IN_WORD_NEWLINE: ";"


### PR DESCRIPTION
## Summary by Sourcery

Adds "aš" as a valid modifier character in EBL ATF.