### PR TITLE
add Ashmolean number

### DIFF
--- a/ebl/fragmentarium/application/fragment_fields_schemas.py
+++ b/ebl/fragmentarium/application/fragment_fields_schemas.py
@@ -63,6 +63,7 @@ class ExternalNumbersSchema(Schema):
     louvre_number = fields.String(load_default="", data_key="louvreNumber")
     dublin_tcd_number = fields.String(load_default="", data_key="dublinTcdNumber")
     cambridge_maa_number = fields.String(load_default="", data_key="cambridgeMaaNumber")
+    ashmolean_number = fields.String(load_default="", data_key="ashmoleanNumber")
     alalah_hpm_number = fields.String(load_default="", data_key="alalahHpmNumber")
     philadelphia_number = fields.String(load_default="", data_key="philadelphiaNumber")
     australianinstituteofarchaeology_number = fields.String(

--- a/ebl/fragmentarium/domain/fragment_external_numbers.py
+++ b/ebl/fragmentarium/domain/fragment_external_numbers.py
@@ -17,6 +17,7 @@ class ExternalNumbers:
     louvre_number: str = ""
     dublin_tcd_number: str = ""
     cambridge_maa_number: str = ""
+    ashmolean_number: str = ""
     alalah_hpm_number: str = ""
     australianinstituteofarchaeology_number: str = ""
     philadelphia_number: str = ""
@@ -89,6 +90,10 @@ class FragmentExternalNumbers:
     @property
     def cambridge_maa_number(self) -> str:
         return self._get_external_number("cambridge_maa_number")
+
+    @property
+    def ashmolean_number(self) -> str:
+        return self._get_external_number("ashmolean_number")
 
     @property
     def alalah_hpm_number(self) -> str:

--- a/ebl/tests/factories/fragment.py
+++ b/ebl/tests/factories/fragment.py
@@ -193,6 +193,7 @@ class ExternalNumbersFactory(factory.Factory):
     louvre_number = factory.Sequence(lambda n: f"louvre-number-{n}")
     dublin_tcd_number = factory.Sequence(lambda n: f"dublin-tcd-number-{n}")
     cambridge_maa_number = factory.Sequence(lambda n: f"cambridge-maa-number-{n}")
+    ashmolean_number = factory.Sequence(lambda n: f"ashmolean-number-{n}")
     alalah_hpm_number = factory.Sequence(lambda n: f"alalah-hpm-number-{n}")
     australianinstituteofarchaeology_number = factory.Sequence(
         lambda n: f"australianinstituteofarchaeology-number-{n}"


### PR DESCRIPTION
## Summary by Sourcery

Add support for Ashmolean museum number in fragment external numbers

New Features:
- Add Ashmolean museum number as a new external number type for fragments

Enhancements:
- Extend external numbers tracking to include Ashmolean museum number in domain model, schema, and test factories