### PR TITLE
Remove # as control line

### DIFF
--- a/docs/ebl-atf.md
+++ b/docs/ebl-atf.md
@@ -112,7 +112,7 @@ composite = composite_composite | composite_start | composite_end | composite_mi
 composite_start = 'div ', free-text, [ ' ', number ];
 composite_end = 'end ', free-text;
 composite_composite: 'composite';
-composite_milestone: 'm=locator ', free_text, [ ' ', number ];
+composite_milestone: 'm=locator ', free-text, [ ' ', number ];
 ```
 
 ## $-lines
@@ -176,7 +176,7 @@ parallel-composition = '(',  { any-character }-, ' ', line-number,  ')';
 
 parallel-text = genre, ' ', category, '.', index, ' ',
                 [ stage, ' ',  [ version, ' ' ], chapter , ' ' ], line-number;
-genre = 'L' | 'D' | 'Lex' | 'Med' | 'Mag' | 'Šui'
+genre = 'L' | 'D' | 'Lex' | 'Med' | 'Mag'
 category = { 'I' | 'V' | 'X' | 'L' | 'C' | 'D' | 'M' }-;
            (* Must be a valid numeral. *)
 stage = 'Ur3'  | 'OA'  | 'OB' | 'OElam' | 'PElam'  | 'MB' |
@@ -199,7 +199,7 @@ museum-number = ? .+?\.[^.]+(\.[^.]+)? ?;
 ```ebnf
 translation-line = '#tr', [ '.', language-code ],
                    [ '.', translation-extent ], ': ', markup;
-                   (* If omitted the language-code is en. *)
+                   (* If omitted the language-code is 'en'. *)
 language-code = ? ISO 639-1 language code ?;
 translation-extent = '(', [ label, ' ' ] , line-number, ')';
 ```

--- a/docs/ebl-atf.md
+++ b/docs/ebl-atf.md
@@ -81,7 +81,7 @@ line = empty-line
 
 empty-line = '';
 
-control-line = '=:' | '&' | '#', { any-character };
+control-line = '=:' | '&', { any-character };
 ```
 
 ## @-lines

--- a/docs/ebl-atf.md
+++ b/docs/ebl-atf.md
@@ -695,7 +695,7 @@ type = 'Sch'
 ## Validation
 
 The ATF should be parseable using the specification above. In addition,
-all readings and signs must be correct according to our sign list. Sometimes
+all readings and signs must be correct according to the eBL sign list. Sometimes
 when the validation or parsing logic is updated existing transliterations can
 become invalid. It should still be possible to load these transliterations, but
 saving them results in an error until the syntax is corrected.

--- a/ebl/atf_importer/domain/lark-oracc/oracc_atf.lark
+++ b/ebl/atf_importer/domain/lark-oracc/oracc_atf.lark
@@ -11,7 +11,7 @@
 
 empty_line: /\s+/?
 
-!control_line.-2: ("=:" | "&" | "#") /.+/?
+!control_line.-2: ("=:" | "&") /.+/?
 
 %import .oracc_atf_text_line (text_line, any_word)
 %import .oracc_atf_dollar_line (dollar_line)

--- a/ebl/tests/transliteration/test_atf_parser.py
+++ b/ebl/tests/transliteration/test_atf_parser.py
@@ -37,14 +37,6 @@ def test_parser_version(parser, version):
     [
         ("", []),
         ("\n", []),
-        (
-            "#first\n\n#second",
-            [ControlLine("#", "first"), EmptyLine(), ControlLine("#", "second")],
-        ),
-        (
-            "#first\n \n#second",
-            [ControlLine("#", "first"), EmptyLine(), ControlLine("#", "second")],
-        ),
         ("&K11111", [ControlLine("&", "K11111")]),
         ("@reverse", [SurfaceAtLine(SurfaceLabel([], atf.Surface.REVERSE))]),
         (
@@ -59,7 +51,6 @@ def test_parser_version(parser, version):
                 )
             ],
         ),
-        ("#some notes", [ControlLine("#", "some notes")]),
         ("=: continuation", [ControlLine("=:", " continuation")]),
     ],
 )

--- a/ebl/tests/transliteration/test_atf_parser.py
+++ b/ebl/tests/transliteration/test_atf_parser.py
@@ -65,6 +65,7 @@ def test_parse_atf(line: str, expected_tokens: List[Line]) -> None:
         ("1. x\nthis is not valid", [2]),
         ("this is not valid\nthis is not valid", [1, 2]),
         ("$ ", [1]),
+        ("#first\n\n#second", [1, 3]),
     ],
 )
 def test_invalid_atf(atf, line_numbers) -> None:

--- a/ebl/tests/transliteration/test_atf_parser.py
+++ b/ebl/tests/transliteration/test_atf_parser.py
@@ -15,7 +15,7 @@ from ebl.transliteration.domain.dollar_line import ScopeContainer, StateDollarLi
 from ebl.transliteration.domain.labels import SurfaceLabel
 from ebl.transliteration.domain.language import Language
 from ebl.transliteration.domain.lark_parser import parse_atf_lark
-from ebl.transliteration.domain.line import ControlLine, EmptyLine, Line
+from ebl.transliteration.domain.line import ControlLine, Line
 from ebl.common.domain.stage import Stage
 from ebl.transliteration.domain.text import Text
 from ebl.transliteration.domain.transliteration_error import TransliterationError

--- a/ebl/transliteration/domain/ebl_atf.lark
+++ b/ebl/transliteration/domain/ebl_atf.lark
@@ -17,7 +17,7 @@
      | control_line
 
 empty_line: /\s+/?
-!control_line.-2: ("=:" | "&" | "#") /.+/?
+!control_line.-2: ("=:" | "&" ) /.+/?
 
 ?paratext: note_line | dollar_line
 


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Remove test cases that involve '#' control lines from the ATF parser test suite