### PR TITLE
add RSTI number

### DIFF
--- a/ebl/fragmentarium/application/fragment_fields_schemas.py
+++ b/ebl/fragmentarium/application/fragment_fields_schemas.py
@@ -43,6 +43,7 @@ class ExternalNumbersSchema(Schema):
     bm_id_number = fields.String(load_default="", data_key="bmIdNumber")
     archibab_number = fields.String(load_default="", data_key="archibabNumber")
     bdtns_number = fields.String(load_default="", data_key="bdtnsNumber")
+    rsti_number = fields.String(load_default="", data_key="rstiNumber")
     chicago_isac_number = fields.String(load_default="", data_key="chicagoIsacNumber")
     ur_online_number = fields.String(load_default="", data_key="urOnlineNumber")
     hilprecht_jena_number = fields.String(

--- a/ebl/fragmentarium/domain/fragment_external_numbers.py
+++ b/ebl/fragmentarium/domain/fragment_external_numbers.py
@@ -8,6 +8,7 @@ class ExternalNumbers:
     bm_id_number: str = ""
     archibab_number: str = ""
     bdtns_number: str = ""
+    rsti_number: str = ""
     chicago_isac_number: str = ""
     ur_online_number: str = ""
     hilprecht_jena_number: str = ""
@@ -50,6 +51,10 @@ class FragmentExternalNumbers:
     @property
     def bdtns_number(self) -> str:
         return self._get_external_number("bdtns")
+
+    @property
+    def rsti_number(self) -> str:
+        return self._get_external_number("rsti")
 
     @property
     def chicago_isac_number(self) -> str:

--- a/ebl/tests/factories/fragment.py
+++ b/ebl/tests/factories/fragment.py
@@ -183,6 +183,7 @@ class ExternalNumbersFactory(factory.Factory):
     bm_id_number = factory.Sequence(lambda n: f"bmId-{n}")
     archibab_number = factory.Sequence(lambda n: f"archibab-{n}")
     bdtns_number = factory.Sequence(lambda n: f"bdtns-{n}")
+    rsti_number = factory.Sequence(lambda n: f"rsti-{n}")
     chicago_isac_number = factory.Sequence(lambda n: f"chicago-isac-number-{n}")
     ur_online_number = factory.Sequence(lambda n: f"ur-online-{n}")
     hilprecht_jena_number = factory.Sequence(lambda n: f"hilprecht-jena-{n}")


### PR DESCRIPTION
## Summary by Sourcery

Add support for the RSTI external number by updating the domain model, schema, and test factories

New Features:
- Introduce rsti_number as a new external identifier for fragments

Enhancements:
- Expose rsti_number through the ExternalNumbers domain model and its property

Tests:
- Add rsti_number to the fragment factory to generate test data