### PR TITLE
add donation to Genres

### DIFF
--- a/ebl/fragmentarium/domain/genres.py
+++ b/ebl/fragmentarium/domain/genres.py
@@ -30,6 +30,7 @@ genres = (
     ("ARCHIVAL", "Legal", "Suretyship"),
     ("ARCHIVAL", "Legal", "Transfer of Properties, Other"),
     ("ARCHIVAL", "Legal", "Transfer of Properties, Other", "Adoption"),
+    ("ARCHIVAL", "Legal", "Transfer of Properties, Other", "Donation"),
     ("ARCHIVAL", "Legal", "Transfer of Properties, Other", "Dowry"),
     ("ARCHIVAL", "Legal", "Transfer of Properties, Other", "Exchange"),
     ("ARCHIVAL", "Legal", "Transfer of Properties, Other", "Inheritance"),


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Include 'Donation' as a valid genre under ARCHIVAL > Legal > Transfer of Properties, Other