### PR TITLE
Fix Diff Coverage CI and Speed Up Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: coverage.xml
+          add-prefix: ebl/
 
   docker:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,13 +71,13 @@ jobs:
         if: ${{ startsWith(matrix.python-version, 'pypy') }}
         env:
           MONGODB_URI: mongodb://localhost:27017
-        run: poetry run pytest
+        run: poetry run pytest -n auto
 
       - name: Unit Tests with Coverage
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         env:
           MONGODB_URI: mongodb://localhost:27017
-        run: poetry run pytest --cov=ebl --cov-report term --cov-report xml -x
+        run: poetry run pytest --cov=ebl --cov-report term --cov-report xml -x -n auto
 
       - uses: qltysh/qlty-action/coverage@v1
         with:


### PR DESCRIPTION
## Summary by Sourcery

Parallelize pytest runs in the GitHub Actions CI and correct coverage report paths for diff coverage analysis

Enhancements:
- Run pytest with xdist (-n auto) for both PyPy and standard Python jobs to speed up testing
- Prefix coverage report files with 'ebl/' in the qlty-action coverage step to ensure correct path mapping