### PR TITLE
Add multiple genre option and Non defined

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-REACT_APP_AUTH0_DOMAIN=auth.ebl.lmu.de
-REACT_APP_AUTH0_CLIENT_ID=X_GcKmRe_G8F-zM4NeE3rWJTdcCgFko7
-REACT_APP_AUTH0_AUDIENCE=dictionary-api
-#REACT_APP_DICTIONARY_API_URL=http://localhost:8000
-#REACT_APP_DICTIONARY_API_URL=https://www.ebl.lmu.de/api
-#REACT_APP_DICTIONARY_API_URL=https://www.ebl.lmu.de/test/api
-REACT_APP_SENTRY_DSN=https://b750722239fe4dac861fd3004b1e45e9@o548559.ingest.sentry.io/1225495

--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+REACT_APP_AUTH0_DOMAIN=auth.ebl.lmu.de
+REACT_APP_AUTH0_CLIENT_ID=X_GcKmRe_G8F-zM4NeE3rWJTdcCgFko7
+REACT_APP_AUTH0_AUDIENCE=dictionary-api
+#REACT_APP_DICTIONARY_API_URL=http://localhost:8000
+#REACT_APP_DICTIONARY_API_URL=https://www.ebl.lmu.de/api
+#REACT_APP_DICTIONARY_API_URL=https://www.ebl.lmu.de/test/api
+REACT_APP_SENTRY_DSN=https://b750722239fe4dac861fd3004b1e45e9@o548559.ingest.sentry.io/1225495

--- a/ebl/common/query/parameter_parser.py
+++ b/ebl/common/query/parameter_parser.py
@@ -89,6 +89,13 @@ def parse_pages(parameters: Dict) -> Dict:
 
 
 def parse_genre(parameters: Dict) -> Dict:
-    genre = parameters.get("genre", "").split(":")
-
-    return {**parameters, "genre": genre} if any(genre) else parameters
+    genre_param = parameters.get("genre", "")
+    
+    if isinstance(genre_param, list):
+        genre = genre_param
+    elif isinstance(genre_param, str) and genre_param:
+        genre = genre_param.split(":")
+    else:
+        return parameters
+    
+    return {**parameters, "genre": genre} if genre else parameters

--- a/ebl/common/query/parameter_parser.py
+++ b/ebl/common/query/parameter_parser.py
@@ -90,12 +90,12 @@ def parse_pages(parameters: Dict) -> Dict:
 
 def parse_genre(parameters: Dict) -> Dict:
     genre_param = parameters.get("genre", "")
-    
+
     if isinstance(genre_param, list):
         genre = genre_param
     elif isinstance(genre_param, str) and genre_param:
         genre = genre_param.split(":")
     else:
         return parameters
-    
+
     return {**parameters, "genre": genre} if genre else parameters

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -70,10 +70,10 @@ class PatternMatcher:
     def _filter_by_genre(self) -> Dict:
         if not (genre := self._query.get("genre")):
             return {}
-        
+
         criteria = []
         regular_genres = [g for g in genre if g != "Non defined"]
-        
+
         if "Non defined" in genre:
             criteria.append({
                 "$or": [
@@ -81,16 +81,16 @@ class PatternMatcher:
                     {"genres": {"$size": 0}}
                 ]
             })
-        
+
         if regular_genres:
             criteria.append({"genres.category": {"$in": regular_genres}})
-        
+
         if not criteria:
             return {}
-        
+
         if len(criteria) == 1:
             return criteria[0]
-        
+
         return {"$or": criteria}
 
     def _filter_by_museum(self) -> Dict:

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -68,9 +68,30 @@ class PatternMatcher:
         }
 
     def _filter_by_genre(self) -> Dict:
-        if genre := self._query.get("genre"):
-            return {"genres.category": {"$all": genre}}
-        return {}
+        if not (genre := self._query.get("genre")):
+            return {}
+        
+        criteria = []
+        regular_genres = [g for g in genre if g != "Non defined"]
+        
+        if "Non defined" in genre:
+            criteria.append({
+                "$or": [
+                    {"genres": {"$exists": False}},
+                    {"genres": {"$size": 0}}
+                ]
+            })
+        
+        if regular_genres:
+            criteria.append({"genres.category": {"$in": regular_genres}})
+        
+        if not criteria:
+            return {}
+        
+        if len(criteria) == 1:
+            return criteria[0]
+        
+        return {"$or": criteria}
 
     def _filter_by_museum(self) -> Dict:
         return {"museum": museum} if (museum := self._query.get("museum")) else {}

--- a/ebl/tests/common/test_parameter_parser.py
+++ b/ebl/tests/common/test_parameter_parser.py
@@ -6,6 +6,7 @@ from ebl.common.query.parameter_parser import (
     parse_lemmas,
     parse_lines,
     parse_transliteration,
+    parse_genre,
 )
 from ebl.common.query.query_result import LemmaQueryType
 from ebl.errors import DataError
@@ -113,3 +114,27 @@ def test_pipeline(sign_repository):
             for line in PARAMS["transliteration"].splitlines()
         ],
     }
+
+
+@pytest.mark.parametrize(
+    "genre_input,expected_genre",
+    [
+        (["CANONICAL"], ["CANONICAL"]),
+        (["CANONICAL", "Technical"], ["CANONICAL", "Technical"]),
+        (["Non defined"], ["Non defined"]),
+        (["CANONICAL", "Non defined"], ["CANONICAL", "Non defined"]),
+        ("CANONICAL:Technical", ["CANONICAL", "Technical"]),
+        ("CANONICAL", ["CANONICAL"]),
+        ([], None),
+        ("", None),
+    ],
+)
+def test_parse_genre(genre_input, expected_genre):
+    if expected_genre is None:
+        assert parse_genre({"genre": genre_input}) == {"genre": genre_input}
+    else:
+        assert parse_genre({"genre": genre_input}) == {"genre": expected_genre}
+
+
+def test_parse_genre_missing():
+    assert parse_genre({}) == {}

--- a/ebl/tests/fragmentarium/test_fragment_repository.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository.py
@@ -1046,10 +1046,13 @@ def test_query_script(fragment_repository, query, expected):
         (["MONUMENTAL"], [0]),
         (["ARCHIVAL"], [2]),
         (["CANONICAL"], [1, 2]),
-        (["CANONICAL", "Technical"], [1]),
-        (["CANONICAL", "Divination"], [2]),
-        (["CANONICAL", "Divination", "Celestial"], [2]),
-        (["MONUMENTAL", "Narrative"], []),
+        (["CANONICAL", "Technical"], [1, 2]),
+        (["CANONICAL", "Divination"], [1, 2]),
+        (["CANONICAL", "Divination", "Celestial"], [1, 2]),
+        (["MONUMENTAL", "Narrative"], [0]),
+        (["Non defined"], [3]),
+        (["CANONICAL", "Non defined"], [1, 2, 3]),
+        (["Hymns"], []),
     ],
 )
 def test_query_genres(fragment_repository, query, expected):
@@ -1061,6 +1064,7 @@ def test_query_genres(fragment_repository, query, expected):
             Genre(["CANONICAL", "Divination", "Celestial"], False),
             Genre(["ARCHIVAL", "Letter"], False),
         ),
+        (),
     ]
     fragments = [
         FragmentFactory.build(


### PR DESCRIPTION
## Summary by Sourcery

Support querying fragments by multiple genres including a special 'Non defined' genre and update parsing and tests accordingly.

New Features:
- Allow genre query parameters to be provided as either colon-separated strings or lists to support multiple genre selection.
- Enable querying fragments that either have matching genres or no genres defined via a special 'Non defined' genre option.

Enhancements:
- Adjust fragment genre filtering to use inclusive matching across multiple genres rather than requiring all genres to be present.

Tests:
- Expand parameter parser and fragment repository tests to cover multiple-genre inputs, the 'Non defined' genre behavior, and missing/empty genre parameters.