### PR TITLE
Add Spurlock Museum and Spurlock External number

### DIFF
--- a/ebl/fragmentarium/application/fragment_fields_schemas.py
+++ b/ebl/fragmentarium/application/fragment_fields_schemas.py
@@ -62,6 +62,7 @@ class ExternalNumbersSchema(Schema):
     kelsey_number = fields.String(load_default="", data_key="kelseyNumber")
     harvard_ham_number = fields.String(load_default="", data_key="harvardHamNumber")
     sketchfab_number = fields.String(load_default="", data_key="sketchfabNumber")
+    spurlock_number = fields.String(load_default="", data_key="spurlockNumber")
     ark_number = fields.String(load_default="", data_key="arkNumber")
     dublin_tcd_number = fields.String(load_default="", data_key="dublinTcdNumber")
     cambridge_maa_number = fields.String(load_default="", data_key="cambridgeMaaNumber")

--- a/ebl/fragmentarium/domain/fragment_external_numbers.py
+++ b/ebl/fragmentarium/domain/fragment_external_numbers.py
@@ -20,6 +20,7 @@ class ExternalNumbers:
     kelsey_number: str = ""
     harvard_ham_number: str = ""
     sketchfab_number: str = ""
+    spurlock_number: str = ""
     ark_number: str = ""
     dublin_tcd_number: str = ""
     cambridge_maa_number: str = ""
@@ -148,6 +149,10 @@ class FragmentExternalNumbers:
     @property
     def philadelphia_number(self) -> str:
         return self._get_external_number("philadelphia")
+
+    @property
+    def spurlock_number(self) -> str:
+        return self._get_external_number("spurlock")
 
     @property
     def seal_numbers(self) -> str:

--- a/ebl/fragmentarium/domain/museum.py
+++ b/ebl/fragmentarium/domain/museum.py
@@ -271,6 +271,12 @@ class Museum(Enum):
         "IQ",
         "https://slemanimuseum.org/",
     )
+    SPURLOCK_MUSEUM = (
+        "Spurlock Museum, University of Illinois",
+        "Urbana",
+        "US",
+        "https://www.spurlock.illinois.edu/",
+    )
     THE_BRITISH_MUSEUM = (
         "The British Museum",
         "London",

--- a/ebl/tests/fragmentarium/test_fragment.py
+++ b/ebl/tests/fragmentarium/test_fragment.py
@@ -243,6 +243,7 @@ def test_scopes():
         "pierpont_morgan_number",
         "rsti_number",
         "sketchfab_number",
+        "spurlock_number",
         "yale_peabody_number",
     ],
 )


### PR DESCRIPTION
## Summary by Sourcery

Add support for the Spurlock Museum as a museum authority and introduce a corresponding Spurlock external number field for fragments.

New Features:
- Register Spurlock Museum as a supported museum with associated location and URL metadata.
- Add a Spurlock external number field to fragment external numbers and expose it through the serialization schema.