### PR TITLE
fix: fix flaky test to guarantee unique values deterministically

### DIFF
--- a/ebl/tests/factories/afo_register.py
+++ b/ebl/tests/factories/afo_register.py
@@ -52,7 +52,7 @@ class AfoRegisterRecordFactory(factory.Factory):
     afo_number = factory.LazyAttribute(lambda obj: get_afo_number())
     page = factory.LazyAttribute(lambda obj: get_page())
     text = factory.LazyAttribute(lambda obj: get_text())
-    text_number = factory.LazyAttribute(lambda obj: get_text_number())
+    text_number = factory.Sequence(lambda n: f"Nr. {n}")
     lines_discussed = factory.LazyAttribute(lambda obj: get_lines_discussed())
     discussed_by = factory.LazyAttribute(lambda obj: get_discussed_by())
     discussed_by_notes = factory.Faker("sentence")


### PR DESCRIPTION
Replaced `text_number = factory.LazyAttribute(lambda obj: get_text_number())` with `text_number = factory.Sequence(lambda n: f"Nr. {n}")` to guarantee unique values deterministically.

## Summary by Sourcery

Ensure afo_register test factory generates deterministic, unique text numbers to avoid flakiness.

Bug Fixes:
- Resolve flaky tests caused by non-deterministic text number generation in the afo_register factory.

Tests:
- Update the afo_register factory to generate sequential text_number values for stable, repeatable tests.