### PR TITLE
fix: fixed uninitialized var

### DIFF
--- a/ebl/mongo_collection.py
+++ b/ebl/mongo_collection.py
@@ -86,13 +86,12 @@ class MongoCollection:
         for attempt in range(2):
             try:
                 result = self.__get_collection().update_one(query, update)
-                break
             except AutoReconnect:
                 if attempt == 1:
                     raise
-        if result.matched_count == 0:
-            raise self.__not_found_error(query)
-        else:
+                continue
+            if result.matched_count == 0:
+                raise self.__not_found_error(query)
             return result
 
     def update_many(self, query, update, **kwargs):

--- a/ebl/tests/test_mongo_collection.py
+++ b/ebl/tests/test_mongo_collection.py
@@ -228,3 +228,36 @@ def test_insert_one_duplicate_after_auto_reconnect_returns_document_id(
 
     assert collection.insert_one(document) == "fixed-id"
     assert mocked_collection.insert_one.call_count == 2
+
+
+def test_update_one_retries_once_on_auto_reconnect(collection) -> None:
+    update_result = Mock()
+    update_result.matched_count = 1
+
+    mocked_collection = Mock()
+    mocked_collection.update_one.side_effect = [
+        AutoReconnect("operation cancelled"),
+        update_result,
+    ]
+
+    collection._MongoCollection__get_collection = lambda: mocked_collection
+
+    assert (
+        collection.update_one({"_id": "id"}, {"$set": {"data": "x"}}) is update_result
+    )
+    assert mocked_collection.update_one.call_count == 2
+
+
+def test_update_one_reraises_auto_reconnect_after_last_attempt(collection) -> None:
+    mocked_collection = Mock()
+    mocked_collection.update_one.side_effect = [
+        AutoReconnect("operation cancelled"),
+        AutoReconnect("operation cancelled"),
+    ]
+
+    collection._MongoCollection__get_collection = lambda: mocked_collection
+
+    with pytest.raises(AutoReconnect):
+        collection.update_one({"_id": "id"}, {"$set": {"data": "x"}})
+
+    assert mocked_collection.update_one.call_count == 2


### PR DESCRIPTION
Eliminates CodeQL warning of no use of `result` outside the `try` scope path that defines it. Created tests to cover behavior.

## Summary by Sourcery

Ensure MongoDB update_one retries on AutoReconnect and either returns the update result or raises consistently.

Bug Fixes:
- Guard update_one against using an uninitialized result when AutoReconnect is raised on all retry attempts.

Tests:
- Add tests verifying update_one retries once on AutoReconnect and returns the successful result.
- Add tests verifying update_one re-raises AutoReconnect after the final retry and does not continue retrying.