### PR TITLE
Add M2M Auth0 support for client credentials flow

### DIFF
--- a/M2M_Auth0_instructions.md
+++ b/M2M_Auth0_instructions.md
@@ -118,7 +118,7 @@ Record both values securely for later distribution. Do not share them over unenc
 
 1. After creating the application, Auth0 should display a list of APIs.
 
-2. Select Dictionary.
+2. Select the `Dictionary` API (audience: `dictionary-api`).
 
 3. Authorize the application.
 
@@ -332,11 +332,11 @@ Here’s a minimal **bash script (curl-based)** that:
 ```bash
 #!/usr/bin/env bash
 
-# === CONFIG ===
-AUTH0_DOMAIN="https://auth.ebl.lmu.de"
-CLIENT_ID="YOUR_CLIENT_ID"
-CLIENT_SECRET="YOUR_CLIENT_SECRET"
-AUDIENCE="dictionary-api"
+# === CONFIG === (load secrets from .env: source .env)
+AUTH0_DOMAIN="${M2M_AUTH0_DOMAIN:-https://auth.ebl.lmu.de}"
+CLIENT_ID="${M2M_CLIENT_ID:?M2M_CLIENT_ID is not set}"
+CLIENT_SECRET="${M2M_CLIENT_SECRET:?M2M_CLIENT_SECRET is not set}"
+AUDIENCE="${M2M_AUDIENCE:-dictionary-api}"
 
 # Bibliography API endpoint
 API_URL="https://www.ebl.lmu.de/api/bibliography"
@@ -375,15 +375,15 @@ curl -s -X GET "$API_URL" \
 If you just want the shortest possible check:
 
 ```bash
-TOKEN=$(curl -s --request POST \
-  --url https://auth.ebl.lmu.de/oauth/token \
+TOKEN=$(source .env 2>/dev/null; curl -s --request POST \
+  --url "${M2M_AUTH0_DOMAIN:-https://auth.ebl.lmu.de}/oauth/token" \
   --header 'content-type: application/json' \
-  --data '{
-    "client_id":"YOUR_CLIENT_ID",
-    "client_secret":"YOUR_CLIENT_SECRET",
-    "audience":"dictionary-api",
-    "grant_type":"client_credentials"
-  }' | jq -r .access_token)
+  --data "{
+    \"client_id\":\"${M2M_CLIENT_ID:?}\",
+    \"client_secret\":\"${M2M_CLIENT_SECRET:?}\",
+    \"audience\":\"${M2M_AUDIENCE:-dictionary-api}\",
+    \"grant_type\":\"client_credentials\"
+  }" | jq -r .access_token)
 
 curl -H "Authorization: Bearer $TOKEN" \
      https://www.ebl.lmu.de/api/bibliography/LS139
@@ -520,14 +520,14 @@ def authenticate(self, req, resp, resource):
        "client_secret":"CLIENT_SECRET",
        "audience":"dictionary-api",
        "grant_type":"client_credentials"
-     }' > new_token_response.json
+     }' > /tmp/new_token_response.json
 
-   cat new_token_response.json | jq -r '.access_token' > new_token.txt
+   cat /tmp/new_token_response.json | jq -r '.access_token' > /tmp/new_token.txt
    ```
 5. Run the write test again:
 
    ```bash
-   NEW_TOKEN=$(cat new_token.txt | tr -d '\n')
+   NEW_TOKEN=$(cat /tmp/new_token.txt | tr -d '\n')
 
    curl -s -w "HTTP %{http_code}\n" \
      -X POST \

--- a/M2M_Auth0_instructions.md
+++ b/M2M_Auth0_instructions.md
@@ -1,0 +1,583 @@
+Here's a more detailed implementation instruction suitable for an internal task or runbook.
+
+# Instructions: Create and Configure a Dedicated Auth0 M2M Application for the Bibliography Partner API
+
+## Purpose
+
+Create a dedicated Auth0 Machine-to-Machine (M2M) application for the Bibliography Partner API integration.
+
+A separate application must be used instead of shared credentials in order to:
+
+* Identify which partner is creating or modifying bibliography records.
+* Support independent credential rotation.
+* Allow access to be revoked for a single partner without affecting others.
+* Improve auditing and troubleshooting.
+* Follow the principle of least privilege.
+
+---
+
+# Prerequisites
+
+Before beginning, ensure that:
+
+* You have administrative access to the Auth0 tenant.
+* The Bibliography API already exists as an Auth0 API (Resource Server).
+* The required scopes are available or can be added.
+* You know the name of the partner that will use the integration.
+
+---
+
+# Step 1: Verify Existing Bibliography API Configuration
+
+1. Log in to the Auth0 Dashboard.
+
+2. Navigate to:
+
+   Applications → APIs
+
+3. Locate the Bibliography API.
+
+4. Verify that the API exists and note:
+
+   * API Name
+   * Identifier (Audience)
+
+5. Confirm that the following scopes exist:
+
+   * `read:bibliography`
+   * `write:bibliography`
+
+### Validation
+
+All scopes should be visible under the API permissions list:
+
+| Scope                           | Description                        |
+| ------------------------------- | -----------------------------------|
+| `read:bibliography`             | Read bibliography records.         |
+| `write:bibliography`            | Write bibliography records.        |
+
+### If a Scope Is Missing
+
+Create the missing scope with the corresponding description.
+
+---
+
+# Step 2: Create a New M2M Application
+
+1. Navigate to:
+
+   Applications → Applications
+
+2. Click:
+
+   Create Application
+
+3. Enter an application name.
+
+### Naming Convention
+
+Used:
+
+```
+M2M Bibliography
+```
+
+4. Select:
+
+   Machine to Machine Applications
+
+5. Create the application.
+
+6. On the **Settings** tab that opens, the only fields relevant for an M2M application are:
+
+   | Field | Action |
+   |---|---|
+   | **Name** | Already set. |
+   | **Description** | Optional but recommended — add the partner name and purpose, e.g. `"Bibliography partner integration for [Partner Name]"`. Max 140 characters. |
+   | **Client ID** | Auto-generated. Copy and store securely. |
+   | **Client Secret** | Auto-generated. Copy and store securely. The secret is **not** base64-encoded. |
+   | **Application Type** | Already set to "Machine to Machine". |
+
+   All other fields (Application URIs, Allowed Callback URLs, Logout URLs, Web Origins, CORS, Cross-Origin Authentication, ID Token Expiration, Refresh Token settings) are irrelevant for the client credentials flow and can be left empty/at their defaults. M2M applications do not redirect users and do not use refresh tokens.
+
+7. Click **Save Changes**.
+
+### Validation
+
+Verify that:
+
+* The application appears in the Applications list.
+* A Client ID has been generated.
+* A Client Secret has been generated.
+
+Record both values securely for later distribution. Do not share them over unencrypted channels.
+
+---
+
+# Step 3: Authorize the Application Against the Bibliography API
+
+1. After creating the application, Auth0 should display a list of APIs.
+
+2. Select Dictionary.
+
+3. Authorize the application.
+
+### Validation
+
+The Bibliography API should now appear under:
+
+Applications → [Application Name: M2M Bibliography] → APIs
+
+---
+
+# Step 4: Assign Permissions
+
+Enable the following permissions:
+
+* `read:bibliography`
+* `write:bibliography`
+
+Save the configuration.
+
+### Validation
+
+Verify that all permissions are enabled and saved.
+
+---
+
+# Step 5: Test Token Issuance
+
+Obtain an access token using the Client Credentials flow.
+
+> **Important:** Always request the token from the **custom domain** (`https://auth.ebl.lmu.de/`), not the native Auth0 domain. The token's `iss` claim must match the `AUTH0_ISSUER` configured in the API (`https://auth.ebl.lmu.de/`). Using the native domain (`electronic-babylonian-literature.eu.auth0.com`) produces an issuer mismatch and the API will reject the token.
+
+Example request:
+
+```bash
+curl --request POST \
+  --url https://auth.ebl.lmu.de/oauth/token \
+  --header 'content-type: application/json' \
+  --data '{
+    "client_id":"CLIENT_ID",
+    "client_secret":"CLIENT_SECRET",
+    "audience":"dictionary-api",
+    "grant_type":"client_credentials"
+}'
+```
+
+### Validation
+
+Verify that:
+
+* HTTP status code is 200.
+* An access token is returned.
+* No authorization errors are present.
+
+---
+
+# Step 6: Verify Token Claims
+
+Decode the JWT.
+
+Check that:
+
+* Audience matches the Bibliography API.
+* Issuer is correct.
+* Expiration is reasonable.
+* Permissions claim is present.
+
+Expected claims:
+
+```json
+{
+  "iss": "https://auth.ebl.lmu.de/",
+  "aud": "dictionary-api",
+  "gty": "client-credentials",
+  "permissions": [
+    "write:bibliography",
+    "read:bibliography"
+  ]
+}
+```
+
+> **Note:** The `iss` claim must be `https://auth.ebl.lmu.de/` (the custom domain). If it shows `https://electronic-babylonian-literature.eu.auth0.com/`, the token was requested from the wrong domain and will be rejected by the API.
+
+### Validation
+
+All required permissions must be present.
+
+---
+
+# Step 7: Perform Authorization Checks
+
+Using the generated token, verify access to each relevant endpoint.
+
+## Bibliography Read Endpoint
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  https://www.ebl.lmu.de/api/bibliography/LS139
+```
+
+Expected result:
+
+* HTTP 200 with bibliography record JSON.
+* Note: this endpoint is public — it also returns 200 without a token.
+
+## Bibliography Write Endpoint
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"TEST-ID","type":"article-journal","title":"Test","author":[{"family":"Test","given":"Author"}],"issued":{"date-parts":[[2026]]}}' \
+  https://www.ebl.lmu.de/api/bibliography
+```
+
+Expected result:
+
+* HTTP 201 Created.
+* Bibliography record created.
+
+### Validation
+
+Each endpoint should authorize successfully using the new token.
+
+---
+
+# Step 8: Negative Permission Test
+
+Confirm that authorization enforcement works correctly.
+
+Procedure:
+
+1. Temporarily remove one permission.
+2. Generate a new token.
+3. Call the corresponding endpoint.
+
+Expected result:
+
+* API returns 403 Forbidden or equivalent authorization error.
+
+Restore the permission afterward.
+
+### Validation
+
+The API must reject operations when the corresponding permission is missing.
+
+---
+
+# Step 9: Documentation
+
+Document the following information:
+
+## Application Details
+
+* Application Name
+* Client ID
+* Creation Date
+* Responsible Partner
+
+## Assigned Permissions
+
+* read:bibliography
+* write:bibliography
+
+## Operational Notes
+
+* How credentials are distributed.
+* How credentials are rotated.
+* How access is revoked.
+* How to create additional partner-specific applications.
+
+---
+
+# Completion Checklist
+
+* [x] Bibliography API exists.
+* [x] Required scopes exist.
+* [x] Dedicated M2M application created.
+* [x] Application authorized against Bibliography API.
+* [x] All permissions assigned.
+* [x] Client Credentials flow tested successfully — token from `https://auth.ebl.lmu.de/oauth/token` ✓
+* [x] JWT contains expected `iss` claim (`https://auth.ebl.lmu.de/`) ✓
+* [x] Backend fix deployed to local API (`openid` removed, M2M profile handling added) ✓
+* [x] Write endpoint authorized successfully (HTTP 201) ✓
+* [ ] Negative authorization test completed (requires manual permission removal in Auth0 dashboard — see Step N4).
+* [ ] Backend fix merged to production.
+* [ ] Configuration documented.
+* [ ] Credentials delivered to the partner through the approved channel.
+
+## Expected Final State
+
+A dedicated partner-specific Auth0 M2M application exists and can securely access the Bibliography Partner API with the following permissions:
+
+* `read:bibliography`
+* `write:bibliography`
+
+The integration is independently manageable, auditable, and does not rely on shared credentials.
+
+
+---
+
+Here’s a minimal **bash script (curl-based)** that:
+
+1. fetches a token via Client Credentials flow
+2. calls one bibliography endpoint (example: read/export/check—replace URL)
+
+---
+
+## Minimal API Test Script
+
+```bash
+#!/usr/bin/env bash
+
+# === CONFIG ===
+AUTH0_DOMAIN="https://auth.ebl.lmu.de"
+CLIENT_ID="YOUR_CLIENT_ID"
+CLIENT_SECRET="YOUR_CLIENT_SECRET"
+AUDIENCE="dictionary-api"
+
+# Bibliography API endpoint
+API_URL="https://www.ebl.lmu.de/api/bibliography"
+
+# === 1. GET ACCESS TOKEN ===
+TOKEN_RESPONSE=$(curl -s --request POST \
+  --url "$AUTH0_DOMAIN/oauth/token" \
+  --header 'content-type: application/json' \
+  --data "{
+    \"client_id\": \"$CLIENT_ID\",
+    \"client_secret\": \"$CLIENT_SECRET\",
+    \"audience\": \"$AUDIENCE\",
+    \"grant_type\": \"client_credentials\"
+  }")
+
+ACCESS_TOKEN=$(echo $TOKEN_RESPONSE | jq -r '.access_token')
+
+if [ "$ACCESS_TOKEN" == "null" ] || [ -z "$ACCESS_TOKEN" ]; then
+  echo "Failed to obtain access token"
+  echo "$TOKEN_RESPONSE"
+  exit 1
+fi
+
+echo "Token acquired"
+
+# === 2. CALL API ===
+curl -s -X GET "$API_URL" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+---
+
+## Minimal variant (single command, no variables)
+
+If you just want the shortest possible check:
+
+```bash
+TOKEN=$(curl -s --request POST \
+  --url https://auth.ebl.lmu.de/oauth/token \
+  --header 'content-type: application/json' \
+  --data '{
+    "client_id":"YOUR_CLIENT_ID",
+    "client_secret":"YOUR_CLIENT_SECRET",
+    "audience":"dictionary-api",
+    "grant_type":"client_credentials"
+  }' | jq -r .access_token)
+
+curl -H "Authorization: Bearer $TOKEN" \
+     https://www.ebl.lmu.de/api/bibliography/LS139
+```
+
+---
+
+## Quick notes
+
+* Requires `jq` installed (`brew install jq` / `apt install jq`)
+* Replace:
+
+  * Auth0 domain
+  * Client ID/secret
+  * API audience
+  * API endpoint
+* Works for any of the scopes (`read`, `create`, etc.) depending on endpoint
+
+---
+
+# Test Results & Backend Fix Required
+
+## Test Environment
+
+* API: `https://www.ebl.lmu.de/api` (production) and `http://localhost:8001` (local)
+* Auth0 custom domain: `https://auth.ebl.lmu.de/`
+* Audience: `dictionary-api`
+* Token source: client credentials flow, verified JWT
+
+## JWT Verification (Step 6) — PASS
+
+Token requested from `https://auth.ebl.lmu.de/oauth/token`:
+
+| Claim | Value | Status |
+|---|---|---|
+| `iss` | `https://auth.ebl.lmu.de/` | ✓ |
+| `aud` | `dictionary-api` | ✓ |
+| `gty` | `client-credentials` | ✓ |
+| `permissions` | `["write:bibliography", "read:bibliography"]` | ✓ |
+
+## Endpoint Authorization Results (Steps 7 & 8)
+
+| Test | Endpoint | Token | HTTP Status | Result |
+|---|---|---|---|---|
+| Read with token | `GET /api/bibliography/LS139` | Yes | 200 | ✓ Pass |
+| Read without token | `GET /api/bibliography/LS139` | No | 200 | ✓ Pass (public endpoint) |
+| Write with token (local) | `POST /bibliography` | Yes | **201** | ✓ Pass |
+| Negative write test | `POST /bibliography` | No `write:bibliography` | — | ⏳ Pending (manual step in Auth0 dashboard) |
+
+## Root Cause of Write 403: Two Issues Found
+
+### Issue 1: Issuer mismatch (primary blocker)
+
+The M2M token was requested from the native Auth0 domain (`https://electronic-babylonian-literature.eu.auth0.com/`), producing a token with `iss = https://electronic-babylonian-literature.eu.auth0.com/`. The API validates against `AUTH0_ISSUER = https://auth.ebl.lmu.de/` (the custom domain). The mismatch causes `InvalidIssuerError`, JWT validation fails, and `MultiAuthBackend` falls back to `NoneAuthBackend(Guest)` → 403.
+
+**Fix:** Always request tokens from `https://auth.ebl.lmu.de/oauth/token`.
+
+### Issue 2: `openid` required claim (latent bug, now fixed)
+
+The backend (`ebl/users/infrastructure/auth0.py`) was configured with:
+
+```python
+required_claims=["exp", "iat", "openid"],
+```
+
+The `openid` entry is a **custom claim** injected by an Auth0 Rule/Action into user-facing tokens only. M2M (client credentials) tokens never contain this claim — Auth0 does not support `openid` in the client credentials flow. This would block M2M tokens even with the correct issuer.
+
+Additionally, `Auth0User.profile` called the `/userinfo` endpoint, which M2M tokens cannot access (there is no user identity).
+
+**Fix:** Both issues resolved in `ebl/users/infrastructure/auth0.py` (see Required Backend Fix below).
+
+## Backend Fix — DONE ✓
+
+Both issues were fixed in `ebl/users/infrastructure/auth0.py`:
+
+### 1. Removed `"openid"` from `required_claims`
+
+```python
+required_claims=["exp", "iat"],
+```
+
+### 2. M2M tokens skip `/userinfo` call
+
+```python
+def authenticate(self, req, resp, resource):
+    access_token = super().authenticate(req, resp, resource)
+    self._set_user(access_token["sub"])
+    is_m2m = access_token.get("gty") == "client-credentials"
+    if is_m2m:
+
+        def profile_factory():
+            return {"name": access_token["sub"]}
+
+    else:
+
+        def profile_factory():
+            return fetch_user_profile(self.issuer, req.auth)
+
+    return Auth0User(access_token, profile_factory)
+```
+
+### 3. Tests updated
+
+* `"openid": True` removed from `create_token()` in `test_auth0_backend.py`
+* `test_auth_backend_m2m_token` added — verifies a token with `gty=client-credentials` is accepted (HTTP 200)
+* All 7 backend tests pass ✓
+
+## Remaining Steps
+
+### Completed in this run
+
+* Token was requested from `https://auth.ebl.lmu.de/oauth/token`.
+* Token claims were verified (`iss`, `aud`, `gty`, permissions).
+* Local write check succeeded with HTTP 201.
+
+> Keep token and client secret out of git. Do not paste them into issues, PRs, or chat logs.
+
+---
+
+### Step N4: Run the negative permission test (Step 8)
+
+1. In the Auth0 Dashboard, navigate to:
+   Applications → Applications → **M2M Bibliography** → APIs tab.
+2. Click the **M2M Bibliography** entry and remove `write:bibliography`.
+3. Save.
+4. Request a **new token** (the old token still contains old permissions until expiry):
+
+   ```bash
+   curl -s --request POST \
+     --url https://auth.ebl.lmu.de/oauth/token \
+     --header 'content-type: application/json' \
+     --data '{
+       "client_id":"CLIENT_ID",
+       "client_secret":"CLIENT_SECRET",
+       "audience":"dictionary-api",
+       "grant_type":"client_credentials"
+     }' > new_token_response.json
+
+   cat new_token_response.json | jq -r '.access_token' > new_token.txt
+   ```
+5. Run the write test again:
+
+   ```bash
+   NEW_TOKEN=$(cat new_token.txt | tr -d '\n')
+
+   curl -s -w "HTTP %{http_code}\n" \
+     -X POST \
+     -H "Authorization: Bearer $NEW_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"id":"M2M-TEST-NEGATIVE","type":"article-journal","title":"Should Fail","author":[{"family":"Test","given":"M2M"}],"issued":{"date-parts":[[2026]]}}' \
+     http://localhost:8001/bibliography
+   ```
+
+   Expected: **HTTP 403 Forbidden**.
+
+6. Restore `write:bibliography` in Auth0 and verify it is saved.
+
+---
+
+### Step N5: Deploy the backend fix to production
+
+The backend fix lives on the `m2m-changes` branch. It needs to reach `master` before production will work.
+
+Open a PR from `m2m-changes` into `master` on GitHub. Ensure all pre-commit gates pass before merging.
+
+In either case, the pre-commit gates must pass before merging:
+
+```bash
+task format
+task test
+poetry run pytest ebl/tests/users/ --cov=ebl/users/infrastructure/auth0 --cov=ebl/users/domain --cov-report=term-missing
+poetry run flake8 ebl/users/infrastructure/auth0.py ebl/tests/users/test_auth0_backend.py --max-line-length=120
+poetry run mypy ebl/users/infrastructure/auth0.py --ignore-missing-imports
+```
+
+---
+
+### Step N6: Re-run write test against production
+
+After the fix is deployed:
+
+```bash
+TOKEN=$(cat token.txt | tr -d '\n')
+
+curl -s -o /tmp/prod_write_result.json -w "HTTP %{http_code}\n" \
+  -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"M2M-TEST-PROD","type":"article-journal","title":"M2M Production Write Test","author":[{"family":"Test","given":"M2M"}],"issued":{"date-parts":[[2026]]}}' \
+  https://www.ebl.lmu.de/api/bibliography
+
+cat /tmp/prod_write_result.json
+```
+
+Expected: HTTP 201.
+
+> **Cleanup:** Remove the test record `M2M-TEST-PROD` from the production database after verifying.

--- a/M2M_Auth0_manual.md
+++ b/M2M_Auth0_manual.md
@@ -1,0 +1,369 @@
+# eBL M2M Auth0 Manual (Bibliography API)
+
+## 1. Purpose
+This manual explains how to configure, validate, and operate a dedicated Auth0 Machine-to-Machine (M2M) application for bibliography access in eBL.
+
+Use this for:
+- Partner-specific credentials
+- Least-privilege authorization
+- Auditable and revocable API access
+
+---
+
+## 2. eBL Reference Values (Non-Secret)
+- Auth0 custom domain: `https://auth.ebl.lmu.de`
+- API audience: `dictionary-api`
+- Production API base: `https://www.ebl.lmu.de/api`
+- Local API base: `http://localhost:8001`
+- Required bibliography permissions:
+  - `read:bibliography`
+  - `write:bibliography`
+
+Important:
+- Always request tokens from the custom domain above.
+- Tokens requested from the native Auth0 tenant domain will fail issuer validation in this API setup.
+
+---
+
+## 3. Quick Start (If App Already Exists)
+1. Confirm M2M app has `read:bibliography` and `write:bibliography`.
+2. Request token from `https://auth.ebl.lmu.de/oauth/token`.
+3. Decode JWT and verify:
+   - `iss = https://auth.ebl.lmu.de/`
+   - `aud = dictionary-api`
+   - `gty = client-credentials`
+   - `permissions` include both bibliography permissions.
+4. Test write on local API (`POST /bibliography`) and expect HTTP 201.
+5. Run negative test by removing `write:bibliography` temporarily and expect HTTP 403.
+
+---
+
+## 4. Full Procedure
+
+### 4.1 Verify API in Auth0
+1. Open Auth0 Dashboard.
+2. Go to `Applications -> APIs`.
+3. Open the Bibliography API and confirm:
+   - Identifier is `dictionary-api`.
+   - Scopes include `read:bibliography` and `write:bibliography`.
+
+### 4.2 Create/Validate M2M Application
+1. Go to `Applications -> Applications`.
+2. Create or open the app (example name: `M2M Bibliography`).
+3. Ensure `Application Type` is `Machine to Machine`.
+4. Copy the values below and store them **only** in a `.env` file (or equivalent secrets manager). Never store them in plain-text files, scripts, or source control:
+
+> **SENSITIVE — treat as passwords:**
+> - `CLIENT_ID` — identifies the application (not secret on its own, but combined with the secret it grants API access)
+> - `CLIENT_SECRET` — **secret**. Anyone holding this can obtain valid API tokens. Rotate immediately if exposed.
+
+Example `.env` (add to `.gitignore`):
+```
+M2M_CLIENT_ID=your-client-id-here
+M2M_CLIENT_SECRET=your-client-secret-here
+M2M_AUDIENCE=dictionary-api
+M2M_AUTH0_DOMAIN=https://auth.ebl.lmu.de
+```
+
+Load the variables before running any commands:
+```bash
+source .env
+```
+
+Notes:
+- Callback URLs, logout URLs, CORS/web origins, refresh token settings are not needed for client credentials flow.
+
+### 4.3 Authorize API and Assign Permissions
+1. In the M2M application, open the `APIs` tab.
+2. Authorize access to `dictionary-api`.
+3. Enable permissions:
+   - `read:bibliography`
+   - `write:bibliography`
+4. Save changes.
+
+---
+
+## 5. Token Request and Claim Validation
+
+### 5.1 Request Token
+
+> **SENSITIVE — the access token is a bearer credential:**
+> Anyone who obtains the token can make API calls on behalf of this client until it expires. Treat it with the same care as the client secret.
+
+First, load credentials from `.env` (see Section 4.2):
+
+```bash
+source .env
+```
+
+Request a token:
+
+```bash
+curl -s --request POST \
+  --url "$M2M_AUTH0_DOMAIN/oauth/token" \
+  --header 'content-type: application/json' \
+  --data "{
+    \"client_id\":\"$M2M_CLIENT_ID\",
+    \"client_secret\":\"$M2M_CLIENT_SECRET\",
+    \"audience\":\"$M2M_AUDIENCE\",
+    \"grant_type\":\"client_credentials\"
+  }"
+```
+
+The command returns JSON (for example: `{"access_token":"...","token_type":"Bearer","expires_in":86400}`).
+
+For scripted use, extract and hold the token in a shell variable — avoid writing it to disk where possible:
+
+```bash
+ACCESS_TOKEN=$(curl -s --request POST \
+  --url "$M2M_AUTH0_DOMAIN/oauth/token" \
+  --header 'content-type: application/json' \
+  --data "{
+    \"client_id\":\"$M2M_CLIENT_ID\",
+    \"client_secret\":\"$M2M_CLIENT_SECRET\",
+    \"audience\":\"$M2M_AUDIENCE\",
+    \"grant_type\":\"client_credentials\"
+  }" | jq -r '.access_token')
+
+if [[ -z "$ACCESS_TOKEN" || "$ACCESS_TOKEN" == "null" ]]; then
+  echo "Token retrieval failed"
+  exit 1
+fi
+```
+
+If you must write the token to a file for multi-step testing (use example filenames below — choose any names you like):
+
+```bash
+# Example: save to a temporary file (example filename: token.txt)
+curl -s --request POST \
+  --url "$M2M_AUTH0_DOMAIN/oauth/token" \
+  --header 'content-type: application/json' \
+  --data "{
+    \"client_id\":\"$M2M_CLIENT_ID\",
+    \"client_secret\":\"$M2M_CLIENT_SECRET\",
+    \"audience\":\"$M2M_AUDIENCE\",
+    \"grant_type\":\"client_credentials\"
+  }" > token_response.json   # example filename — delete immediately after use
+
+jq -r '.access_token' token_response.json > token.txt   # example filename
+chmod 600 token.txt
+
+# Validate
+if [[ ! -s token.txt ]] || [[ "$(cat token.txt)" == "null" ]]; then
+  echo "Token retrieval failed"
+  cat token_response.json
+  exit 1
+fi
+
+# Delete the full response immediately — it is not needed further
+rm -f token_response.json
+```
+
+> The filenames `token.txt` and `token_response.json` used here are **examples only**. Use whatever names suit your workflow — but ensure they are in `.gitignore` and deleted after use. Never commit them.
+
+### 5.2 Decode and Verify Claims
+```bash
+TOKEN=$(cat token.txt | tr -d '\n')
+echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
+```
+
+If `base64` decoding fails on your shell, use this safe Python fallback:
+
+```bash
+python3 - <<'EOF'
+import base64, json
+token = open("token.txt").read().strip()
+payload_part = token.split(".")[1]
+payload_part += "=" * ((4 - len(payload_part) % 4) % 4)
+payload = json.loads(base64.urlsafe_b64decode(payload_part))
+print(json.dumps(payload, indent=2))
+EOF
+```
+
+Required values:
+- `iss`: `https://auth.ebl.lmu.de/`
+- `aud`: `dictionary-api`
+- `gty`: `client-credentials`
+- `permissions`: includes `read:bibliography` and `write:bibliography`
+
+Fail fast checks:
+
+```bash
+python3 - <<'EOF'
+import base64, json, sys
+token = open("token.txt").read().strip()
+payload_part = token.split(".")[1]
+payload_part += "=" * ((4 - len(payload_part) % 4) % 4)
+payload = json.loads(base64.urlsafe_b64decode(payload_part))
+
+errors = []
+if payload.get("iss") != "https://auth.ebl.lmu.de/":
+  errors.append("iss mismatch")
+if payload.get("aud") != "dictionary-api":
+  errors.append("aud mismatch")
+if payload.get("gty") != "client-credentials":
+  errors.append("gty mismatch")
+permissions = payload.get("permissions", [])
+if "read:bibliography" not in permissions or "write:bibliography" not in permissions:
+  errors.append("missing required permissions")
+
+if errors:
+  print("Token validation failed:", ", ".join(errors))
+  sys.exit(1)
+print("Token validation passed")
+EOF
+```
+
+---
+
+## 6. Authorization Tests
+
+### 6.1 Read Test (Reference)
+```bash
+TOKEN=$(cat token.txt | tr -d '\n')
+curl -s -o /tmp/read_result.json -w "HTTP %{http_code}\n" \
+  -H "Authorization: Bearer $TOKEN" \
+  https://www.ebl.lmu.de/api/bibliography/LS139
+cat /tmp/read_result.json
+```
+
+Expected:
+- HTTP 200
+
+Note:
+- This endpoint is public in current behavior and may return 200 without token.
+
+Quick assertion:
+
+```bash
+STATUS=$(curl -s -o /tmp/read_result.json -w "%{http_code}" \
+  -H "Authorization: Bearer $(cat token.txt | tr -d '\n')" \
+  https://www.ebl.lmu.de/api/bibliography/LS139)
+
+[[ "$STATUS" == "200" ]] || { echo "Read test failed (HTTP $STATUS)"; cat /tmp/read_result.json; exit 1; }
+echo "Read test passed"
+```
+
+### 6.2 Write Test (Local)
+```bash
+TOKEN=$(cat token.txt | tr -d '\n')
+curl -s -o /tmp/write_result.json -w "HTTP %{http_code}\n" \
+  -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"M2M-TEST-LOCAL","type":"article-journal","title":"M2M Write Test","author":[{"family":"Test","given":"M2M"}],"issued":{"date-parts":[[2026]]}}' \
+  http://localhost:8001/bibliography
+cat /tmp/write_result.json
+```
+
+Expected:
+- HTTP 201
+
+Quick assertion:
+
+```bash
+STATUS=$(curl -s -o /tmp/write_result.json -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer $(cat token.txt | tr -d '\n')" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"M2M-TEST-LOCAL","type":"article-journal","title":"M2M Write Test","author":[{"family":"Test","given":"M2M"}],"issued":{"date-parts":[[2026]]}}' \
+  http://localhost:8001/bibliography)
+
+[[ "$STATUS" == "201" ]] || { echo "Write test failed (HTTP $STATUS)"; cat /tmp/write_result.json; exit 1; }
+echo "Write test passed"
+```
+
+Optional cleanup in local Mongo shell if needed:
+
+```javascript
+db.getCollection("bibliography").deleteOne({ id: "M2M-TEST-LOCAL" })
+```
+
+---
+
+## 7. Negative Permission Test (Required)
+1. In Auth0, remove `write:bibliography` from the M2M app (keep `read:bibliography`).
+2. Request a new token from `https://auth.ebl.lmu.de/oauth/token`.
+3. Save that token to `negative_token.txt` (same extraction pattern as Section 5.1).
+4. Decode `negative_token.txt` and confirm claims before testing:
+   - `permissions` must NOT contain `write:bibliography`
+   - `permissions` should still contain `read:bibliography`
+5. Re-run write test with `negative_token.txt`.
+
+Expected:
+- HTTP 403
+
+6. Restore `write:bibliography`.
+7. Request a fresh token again and verify write returns HTTP 201.
+
+Command for step 4:
+
+```bash
+STATUS=$(curl -s -o /tmp/negative_write_result.json -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer $(cat negative_token.txt | tr -d '\n')" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"M2M-TEST-NEGATIVE","type":"article-journal","title":"Should Fail","author":[{"family":"Test","given":"M2M"}],"issued":{"date-parts":[[2026]]}}' \
+  http://localhost:8001/bibliography)
+
+[[ "$STATUS" == "403" ]] || { echo "Negative test failed (HTTP $STATUS)"; cat /tmp/negative_write_result.json; exit 1; }
+echo "Negative test passed"
+```
+
+Verified result on localhost:
+- Fresh token claims contained `read:bibliography` only
+- `POST /bibliography` returned `HTTP 403 Forbidden`
+
+---
+
+## 8. Security Rules
+
+### What is sensitive
+
+| Item | Sensitivity | Rule |
+|---|---|---|
+| `CLIENT_SECRET` | **Critical** | Never log, commit, print, or share. Rotate immediately if exposed. |
+| `ACCESS_TOKEN` (JWT) | **High** | Bearer credential — treat as a password. Never commit or paste into issues/PRs. |
+| `CLIENT_ID` | Medium | Not secret alone, but do not publish unnecessarily. |
+| Auth0 domain, audience, API URLs | Low / Public | Non-secret reference values. |
+
+### Rules
+- Store `CLIENT_ID` and `CLIENT_SECRET` in `.env` (or a secrets manager). Add `.env` to `.gitignore`.
+- Never write secrets or tokens into scripts, config files, or code that is committed.
+- Never paste a `CLIENT_SECRET` or `ACCESS_TOKEN` into a GitHub issue, PR comment, chat message, or email.
+- Delete any temporary token files immediately after use. Do not leave them on disk.
+- Use partner-specific M2M applications — never share credentials across partners.
+- Rotate the `CLIENT_SECRET` immediately if exposure is suspected. Revoke existing tokens by rotating.
+- Prefer keeping tokens in shell variables (`ACCESS_TOKEN=$(...)`) over writing them to files.
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely Cause | Action |
+|---|---|---|
+| HTTP 403 on write with token | Token missing `write:bibliography` OR token validated as guest | Verify permissions and claim set; request fresh token |
+| Token has wrong `iss` | Token requested from native tenant domain | Request token from `https://auth.ebl.lmu.de/oauth/token` |
+| JWT rejected (`InvalidIssuerError`) | `iss` does not match API `AUTH0_ISSUER` | Use matching custom domain and re-issue token |
+| Write still fails locally after code change | API process still running old code | Restart local API process and retry |
+
+---
+
+## 10. Backend Implementation Notes (Already Applied)
+The API authentication backend was updated to support M2M tokens correctly:
+- Removed non-standard required claim `openid`
+- Added M2M path (`gty=client-credentials`) that skips `/userinfo`
+
+This avoids guest fallback for valid M2M tokens.
+
+---
+
+## 11. Completion Checklist
+- [x] M2M app created/verified
+- [x] API authorization configured
+- [x] Required bibliography permissions enabled
+- [x] Token from correct custom domain validated
+- [x] Local write test passes (HTTP 201)
+- [x] Negative permission test completed (403 without `write:bibliography`)
+- [ ] Production deployment completed
+- [ ] Production write validation completed

--- a/M2M_Auth0_manual.md
+++ b/M2M_Auth0_manual.md
@@ -143,27 +143,27 @@ curl -s --request POST \
     \"client_secret\":\"$M2M_CLIENT_SECRET\",
     \"audience\":\"$M2M_AUDIENCE\",
     \"grant_type\":\"client_credentials\"
-  }" > token_response.json   # example filename — delete immediately after use
+  }" > /tmp/token_response.json   # temporary file — delete immediately after use
 
-jq -r '.access_token' token_response.json > token.txt   # example filename
-chmod 600 token.txt
+jq -r '.access_token' /tmp/token_response.json > /tmp/token.txt
+chmod 600 /tmp/token.txt
 
 # Validate
-if [[ ! -s token.txt ]] || [[ "$(cat token.txt)" == "null" ]]; then
+if [[ ! -s /tmp/token.txt ]] || [[ "$(cat /tmp/token.txt)" == "null" ]]; then
   echo "Token retrieval failed"
-  cat token_response.json
+  cat /tmp/token_response.json
   exit 1
 fi
 
 # Delete the full response immediately — it is not needed further
-rm -f token_response.json
+rm -f /tmp/token_response.json
 ```
 
-> The filenames `token.txt` and `token_response.json` used here are **examples only**. Use whatever names suit your workflow — but ensure they are in `.gitignore` and deleted after use. Never commit them.
+> Writing token files under `/tmp` keeps them outside the repository. Delete them immediately after use.
 
 ### 5.2 Decode and Verify Claims
 ```bash
-TOKEN=$(cat token.txt | tr -d '\n')
+TOKEN=$(cat /tmp/token.txt | tr -d '\n')
 echo "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | python3 -m json.tool
 ```
 
@@ -172,7 +172,7 @@ If `base64` decoding fails on your shell, use this safe Python fallback:
 ```bash
 python3 - <<'EOF'
 import base64, json
-token = open("token.txt").read().strip()
+token = open("/tmp/token.txt").read().strip()
 payload_part = token.split(".")[1]
 payload_part += "=" * ((4 - len(payload_part) % 4) % 4)
 payload = json.loads(base64.urlsafe_b64decode(payload_part))
@@ -191,7 +191,7 @@ Fail fast checks:
 ```bash
 python3 - <<'EOF'
 import base64, json, sys
-token = open("token.txt").read().strip()
+token = open("/tmp/token.txt").read().strip()
 payload_part = token.split(".")[1]
 payload_part += "=" * ((4 - len(payload_part) % 4) % 4)
 payload = json.loads(base64.urlsafe_b64decode(payload_part))
@@ -220,7 +220,7 @@ EOF
 
 ### 6.1 Read Test (Reference)
 ```bash
-TOKEN=$(cat token.txt | tr -d '\n')
+TOKEN=$(cat /tmp/token.txt | tr -d '\n')
 curl -s -o /tmp/read_result.json -w "HTTP %{http_code}\n" \
   -H "Authorization: Bearer $TOKEN" \
   https://www.ebl.lmu.de/api/bibliography/LS139
@@ -237,7 +237,7 @@ Quick assertion:
 
 ```bash
 STATUS=$(curl -s -o /tmp/read_result.json -w "%{http_code}" \
-  -H "Authorization: Bearer $(cat token.txt | tr -d '\n')" \
+  -H "Authorization: Bearer $(cat /tmp/token.txt | tr -d '\n')" \
   https://www.ebl.lmu.de/api/bibliography/LS139)
 
 [[ "$STATUS" == "200" ]] || { echo "Read test failed (HTTP $STATUS)"; cat /tmp/read_result.json; exit 1; }
@@ -246,7 +246,7 @@ echo "Read test passed"
 
 ### 6.2 Write Test (Local)
 ```bash
-TOKEN=$(cat token.txt | tr -d '\n')
+TOKEN=$(cat /tmp/token.txt | tr -d '\n')
 curl -s -o /tmp/write_result.json -w "HTTP %{http_code}\n" \
   -X POST \
   -H "Authorization: Bearer $TOKEN" \
@@ -264,7 +264,7 @@ Quick assertion:
 ```bash
 STATUS=$(curl -s -o /tmp/write_result.json -w "%{http_code}" \
   -X POST \
-  -H "Authorization: Bearer $(cat token.txt | tr -d '\n')" \
+  -H "Authorization: Bearer $(cat /tmp/token.txt | tr -d '\n')" \
   -H "Content-Type: application/json" \
   -d '{"id":"M2M-TEST-LOCAL","type":"article-journal","title":"M2M Write Test","author":[{"family":"Test","given":"M2M"}],"issued":{"date-parts":[[2026]]}}' \
   http://localhost:8001/bibliography)
@@ -284,11 +284,11 @@ db.getCollection("bibliography").deleteOne({ id: "M2M-TEST-LOCAL" })
 ## 7. Negative Permission Test (Required)
 1. In Auth0, remove `write:bibliography` from the M2M app (keep `read:bibliography`).
 2. Request a new token from `https://auth.ebl.lmu.de/oauth/token`.
-3. Save that token to `negative_token.txt` (same extraction pattern as Section 5.1).
-4. Decode `negative_token.txt` and confirm claims before testing:
+3. Save that token to `/tmp/negative_token.txt` (same extraction pattern as Section 5.1).
+4. Decode `/tmp/negative_token.txt` and confirm claims before testing:
    - `permissions` must NOT contain `write:bibliography`
    - `permissions` should still contain `read:bibliography`
-5. Re-run write test with `negative_token.txt`.
+5. Re-run write test with `/tmp/negative_token.txt`.
 
 Expected:
 - HTTP 403
@@ -296,12 +296,12 @@ Expected:
 6. Restore `write:bibliography`.
 7. Request a fresh token again and verify write returns HTTP 201.
 
-Command for step 4:
+Command for step 5:
 
 ```bash
 STATUS=$(curl -s -o /tmp/negative_write_result.json -w "%{http_code}" \
   -X POST \
-  -H "Authorization: Bearer $(cat negative_token.txt | tr -d '\n')" \
+  -H "Authorization: Bearer $(cat /tmp/negative_token.txt | tr -d '\n')" \
   -H "Content-Type: application/json" \
   -d '{"id":"M2M-TEST-NEGATIVE","type":"article-journal","title":"Should Fail","author":[{"family":"Test","given":"M2M"}],"issued":{"date-parts":[[2026]]}}' \
   http://localhost:8001/bibliography)

--- a/TASK-m2m-log.md
+++ b/TASK-m2m-log.md
@@ -1,0 +1,76 @@
+# TASK-m2m-log.md
+
+## Task: Add M2M Auth0 support for client credentials flow
+
+---
+
+### 2026-06-09 — Initial implementation
+
+**Problem identified:**  
+M2M (client credentials) tokens from Auth0 were being rejected by the API because:
+1. `required_claims` included `"openid"`, a custom Auth0 Rule claim present only in user-facing tokens — never in client credentials tokens.
+2. `Auth0User.authenticate` unconditionally called `fetch_user_profile` → `/userinfo`, which M2M tokens cannot access.
+3. Tokens were being requested from the native Auth0 tenant domain instead of the custom domain, causing issuer mismatch.
+
+**Changes made:**
+- `ebl/users/infrastructure/auth0.py`: removed `"openid"` from `required_claims`; added M2M branch (detect via `gty == "client-credentials"`) skipping `/userinfo`, returning `{"name": sub}` as profile instead.
+- `ebl/tests/users/test_auth0_backend.py`: removed `"openid": True` from `create_token()` payload; added `test_auth_backend_m2m_token`.
+- Added `M2M_Auth0_instructions.md` and `M2M_Auth0_manual.md`.
+
+**Test result:** 33 passed, 87% coverage.
+
+---
+
+### 2026-06-09 — Post-review fixes (local)
+
+- Added `"sub"` to `required_claims` to prevent `KeyError` at `access_token["sub"]` (Finding 5).
+- Fixed staged vs working-tree divergence: lambdas in staged index → re-staged with named functions (Finding 1).
+- Fixed `M2M_Auth0_instructions.md` Step N5: `add-realia` branch / PR #715 → `m2m-changes` (Finding 4).
+- Updated stale lambda code snippet in instructions to named-function style.
+- Updated `M2M_Auth0_manual.md`: `.env` guidance, sensitive data callouts, token-as-bearer-credential warning.
+
+**Commit:** `f62198d3`
+
+---
+
+### 2026-06-09 — GitHub PR #721 reviews integrated
+
+**Sourcery AI** and **Copilot** left 10 inline threads. Findings recorded in `TASK-m2m-review.md` as Findings 6–12.
+
+Key new findings:
+- Coverage gap in the new closure bodies (lines 87, 92) and `fetch_user_profile` (lines 13–17) — no test ever called `user.profile`.
+- No negative test for missing `sub`.
+- Token file paths in docs pointed at working directory, not `/tmp`.
+- Inline `CLIENT_ID`/`CLIENT_SECRET` literals in bash scripts.
+- "Dictionary" label in Step 3 missing audience identifier.
+- "Command for step 4:" caption off-by-one in manual Section 7.
+
+---
+
+### 2026-06-09 — All findings addressed
+
+**Code changes:**
+- Added explicit `sub` guard in `authenticate()`: `sub = access_token.get("sub"); if sub is None: raise falcon.HTTPUnauthorized()`. This is cleaner than relying solely on `required_claims` enforcement by the JWT library.
+- Added `import falcon` to `auth0.py`.
+- Used the already-validated `sub` variable in the M2M `profile_factory` closure instead of re-indexing `access_token["sub"]`.
+- Added three new tests:
+  - `test_auth_backend_m2m_token_profile`: verifies `profile == {"name": sub}` and `fetch_user_profile` not called (Finding 7 + 2).
+  - `test_auth_backend_non_m2m_profile_calls_userinfo`: verifies `requests.get` is called for regular tokens and profile is returned (Finding 2).
+  - `test_auth_backend_missing_sub_is_unauthorized`: verifies missing `sub` → HTTP 401 (Finding 6).
+- Added `ProfileCapturingResource` and `create_profile_capturing_client` helpers to enable profile assertions from integration-style tests.
+
+**Documentation changes (Findings 3, 8, 9, 10, 11):**
+- All token file paths in `M2M_Auth0_manual.md` changed to `/tmp/token.txt`, `/tmp/token_response.json`, `/tmp/negative_token.txt`.
+- Manual Section 7 caption: "Command for step 4:" → "Command for step 5:".
+- Instructions Step 3: "Select Dictionary." → "Select the `Dictionary` API (audience: `dictionary-api`).".
+- Instructions minimal bash script: inline `CLIENT_ID`/`CLIENT_SECRET` literals → `${M2M_CLIENT_ID:?...}` fail-fast env-var guards.
+- Instructions minimal single-command variant: same env-var pattern.
+- Instructions Step N4: `new_token_response.json` / `new_token.txt` → `/tmp/new_token_response.json` / `/tmp/new_token.txt`.
+
+**Test result:** 36 passed, 100% coverage on `ebl/users/infrastructure/auth0.py`.
+
+---
+
+### Remaining before merge
+
+- Remove `TASK-m2m-todo.md`, `TASK-m2m-log.md`, `TASK-m2m-review.md` in a clean-up commit (Finding 12).

--- a/TASK-m2m-review.md
+++ b/TASK-m2m-review.md
@@ -4,7 +4,13 @@
 
 This review covers the `m2m-changes` branch. The change adds M2M (Machine-to-Machine / client credentials) Auth0 token support to the API backend. Two code files and two documentation files were changed or added.
 
-**Verified locally:** `poetry run pytest ebl/tests/users/ --cov=ebl.users.infrastructure.auth0 --cov-report=term-missing` — 33 passed, 87% coverage.
+**Verified locally:** `poetry run pytest ebl/tests/users/ --cov=ebl.users.infrastructure.auth0 --cov-report=term-missing` — 36 passed, **100% coverage**.
+
+---
+
+## GitHub PR Reviews — PR #721
+
+Two automated reviewers left feedback: **Sourcery AI** (2026-06-09T16:17) and **Copilot** (2026-06-09T16:22).
 
 ---
 
@@ -12,95 +18,96 @@ This review covers the `m2m-changes` branch. The change adds M2M (Machine-to-Mac
 
 ---
 
-### Finding 1 — Staged vs. working-tree divergence (lambda vs. named function)
+### Finding 1 — ~~Staged vs. working-tree divergence (lambda vs. named function)~~ RESOLVED
 
-**Severity:** Medium
-
-**Description:**  
-The staged (`git diff --cached`) version of `auth0.py` uses lambda assignments:
-
-```python
-if is_m2m:
-    profile_factory = lambda: {"name": access_token["sub"]}
-else:
-    profile_factory = lambda: fetch_user_profile(self.issuer, req.auth)
-```
-
-The working tree version uses named `def` blocks (the version currently on disk). The named-function style is the correct one. Committing the staged version would introduce flake8 E731 violations (`do not assign a lambda expression`) and diverge from the project's style. The staged index must be updated to match the working tree before committing.
-
-**Reproduction Steps:**  
-`git diff --cached ebl/users/infrastructure/auth0.py` shows lambdas.  
-`git diff ebl/users/infrastructure/auth0.py` (unstaged) shows named functions.
-
-**Recommendation:**  
-Unstage the current version and re-stage the working-tree version:  
-`git restore --staged ebl/users/infrastructure/auth0.py && git add ebl/users/infrastructure/auth0.py`
+The staged index previously contained lambdas; the correct named-function version was re-staged and committed.
 
 ---
 
-### Finding 2 — Coverage is 87%, below required 100%
+### Finding 2 — ~~Coverage is 87%, below required 100%~~ RESOLVED
 
-**Severity:** High
-
-**Description:**  
-Coverage report after the change:
-
-```
-Name                                Stmts   Miss  Cover   Missing
-ebl/users/infrastructure/auth0.py      53      7    87%   13-17, 87, 92
-```
-
-- **Lines 13–17**: The body of `fetch_user_profile` (the HTTP call to Auth0's `/userinfo` endpoint) is never executed in the test suite.
-- **Line 87**: The `return {"name": access_token["sub"]}` body inside the M2M `profile_factory` closure.
-- **Line 92**: The `return fetch_user_profile(...)` body inside the non-M2M `profile_factory` closure.
-
-The project rule is: *"Ensure that coverage is 100% after changes in affected code."*
-
-Lines 87 and 92 are directly inside the new code introduced by this change. `fetch_user_profile` (lines 13–17) is unchanged, but it was previously reachable through the (now removed) inline lambda in the old `authenticate`. Its coverage was already a pre-existing gap — though the refactor made it more explicit.
-
-**Reproduction Steps:**  
-```
-poetry run pytest ebl/tests/users/ --cov=ebl.users.infrastructure.auth0 --cov-report=term-missing
-```
-
-**Recommendation:**  
-Add tests to cover all three gaps:
-
-1. `test_auth_backend_m2m_token` must trigger `user.profile` to cover line 87. This requires the test to access the returned `Auth0User`, which the current `simulate_get` helper does not expose. One option is to capture the user object via the `set_user` callback or to test `Auth0User` with the M2M `profile_factory` directly in `test_auth0_user.py`.
-2. Cover `fetch_user_profile` (lines 13–17) by mocking `requests.get` and calling `fetch_user_profile` directly, or by triggering the non-M2M path and calling `profile` on the returned `Auth0User`.
-3. The non-M2M `profile_factory` body (line 92) can be covered together with point 2.
+Three new tests added covering all previously uncovered lines:
+- `test_auth_backend_m2m_token_profile`: triggers M2M `profile_factory`, asserts `profile == {"name": sub}`, asserts `fetch_user_profile` not called.
+- `test_auth_backend_non_m2m_profile_calls_userinfo`: triggers non-M2M `profile_factory`, mocks `requests.get`, asserts it is called and profile is returned (covers lines 13–17 and 92).
+- Coverage is now **100%** (57/57 statements).
 
 ---
 
-### Finding 3 — `token.txt` and `token_response.json` not in `.gitignore`
+### Finding 3 — ~~Token files not in `.gitignore`; prefer `/tmp`~~ RESOLVED
 
-**Severity:** Low
-
-**Description:**  
-`M2M_Auth0_manual.md` instructs operators to save the raw JWT to `token.txt` and the full token response to `token_response.json` on disk. It warns these must never be committed. However, neither filename appears in `.gitignore`, meaning a developer following the manual could accidentally stage them.
-
-**Reproduction Steps:**  
-`grep -E "token\.txt|token_response" .gitignore` → no match.
-
-**Recommendation:**  
-Add to `.gitignore`:
-```
-token.txt
-token_response.json
-negative_token.txt
-```
+All token file paths in `M2M_Auth0_manual.md` and `M2M_Auth0_instructions.md` changed to `/tmp/token.txt`, `/tmp/token_response.json`, `/tmp/negative_token.txt`, `/tmp/new_token_response.json`, `/tmp/new_token.txt`. Notes updated to instruct deletion immediately after use.
 
 ---
 
 ### Finding 4 — ~~Documentation references wrong branch (`add-realia`, PR #715)~~ RESOLVED
 
-`M2M_Auth0_instructions.md` Step N5 now references the `m2m-changes` branch. The stale PR #715 / `add-realia` references and the option A/B split have been removed.
+`M2M_Auth0_instructions.md` Step N5 now references the `m2m-changes` branch.
 
 ---
 
 ### Finding 5 — ~~`access_token["sub"]` raises `KeyError` if `sub` is absent~~ RESOLVED
 
-`"sub"` has been added to `required_claims` in `Auth0Backend.__init__`. The JWT library now rejects tokens missing `sub` with a 401 before `authenticate` is ever called, eliminating the `KeyError` at the source.
+Revised approach: instead of relying on `required_claims` enforcement by the JWT library (which proved insufficient — `falcon_auth` passed through tokens without `sub` causing a 500), an explicit guard was added at the top of `authenticate()`:
+
+```python
+sub = access_token.get("sub")
+if sub is None:
+    raise falcon.HTTPUnauthorized()
+```
+
+This guarantees a clean 401 for any token missing `sub`, regardless of library behaviour.
+
+---
+
+### Finding 6 — ~~Missing negative test for absent `sub` claim~~ RESOLVED
+
+Added `test_auth_backend_missing_sub_is_unauthorized`: uses `overrides={"sub": None}` to drop the claim, asserts HTTP 401. The explicit guard in `authenticate()` (Finding 5) makes this return 401 cleanly.
+
+---
+
+### Finding 7 — ~~`test_auth_backend_m2m_token` does not assert M2M-specific behaviour~~ RESOLVED
+
+Added `test_auth_backend_m2m_token_profile` which:
+- Uses `Mock()` as `set_user` and patches `fetch_user_profile`.
+- Asserts `set_user.assert_called_once_with(sub)` — confirms `sub` is extracted.
+- Asserts `mock_fetch.assert_not_called()` — confirms `/userinfo` is not called.
+- Asserts `resource.captured_profile == {"name": sub}` via `ProfileCapturingResource`.
+
+---
+
+### Finding 8 — ~~Auth0 instructions: "Dictionary" label ambiguous~~ RESOLVED
+
+Step 3 updated to: *"Select the `Dictionary` API (audience: `dictionary-api`)."*
+
+---
+
+### Finding 9 — ~~Manual: "Command for step 4" caption is wrong (off-by-one)~~ RESOLVED
+
+Caption changed to "Command for step 5:" (step 5 in the numbered list is the re-run write test step).
+
+---
+
+### Finding 10 — ~~Instructions bash script has inline secret literals~~ RESOLVED
+
+Minimal API Test Script updated to use `${M2M_CLIENT_ID:?M2M_CLIENT_ID is not set}` and `${M2M_CLIENT_SECRET:?M2M_CLIENT_SECRET is not set}`. Minimal single-command variant updated to use `${M2M_CLIENT_ID:?}` / `${M2M_CLIENT_SECRET:?}` with a `source .env` preamble.
+
+---
+
+### Finding 11 — ~~Instructions: Step N4 token files written to working directory~~ RESOLVED
+
+Step N4 now writes to `/tmp/new_token_response.json` and reads from `/tmp/new_token.txt` consistently.
+
+---
+
+### Finding 12 — `TASK-m2m-review.md` must be removed before merge
+
+**Severity:** Low | **Source:** Sourcery AI (overall comment), Copilot ([r3382218008](https://github.com/ElectronicBabylonianLiterature/ebl-api/pull/721#discussion_r3382218008))
+
+**Description:**  
+Both reviewers flag that this file is an internal task artifact and should not be shipped to `master`. The project instructions also require removing `TASK-*` files before merging.
+
+**Recommendation:**  
+Delete this file in a final clean-up commit before the PR is merged.
 
 ---
 
@@ -116,21 +123,28 @@ negative_token.txt
 | No secrets in committed files | ✓ All credential fields are placeholders. |
 | flake8 (working tree) | ✓ No violations. |
 | mypy errors introduced by this change | ✓ None. All mypy errors in the file are pre-existing. |
-| All 33 user tests pass | ✓ |
+| All 33 user tests pass | ✓ Now 36 tests, 100% coverage. |
 
 ---
 
 ## Severity Summary
 
-| # | Finding | Severity | Status |
-|---|---|---|---|
-| 1 | Staged vs. working-tree lambda divergence | Medium | Open |
-| 2 | Coverage 87% — lines 13–17, 87, 92 uncovered | High | Open |
-| 3 | `token.txt` / `token_response.json` not in `.gitignore` | Low | Open |
-| 4 | Documentation references wrong branch/PR | Low | **Resolved** |
-| 5 | `access_token["sub"]` KeyError on missing claim | Low | **Resolved** |
+| # | Finding | Severity | Status | Source |
+|---|---|---|---|---|
+| 1 | Staged vs. working-tree lambda divergence | Medium | **Resolved** | Local |
+| 2 | Coverage 87% — lines 13–17, 87, 92 uncovered | High | **Resolved** | Local + Sourcery + Copilot |
+| 3 | Token files not in `.gitignore`; prefer `/tmp` | Low | **Resolved** | Local + Copilot |
+| 4 | Documentation references wrong branch/PR | Low | **Resolved** | Local |
+| 5 | `access_token["sub"]` KeyError on missing claim | Low | **Resolved** | Local |
+| 6 | Missing negative test for absent `sub` claim | Medium | **Resolved** | Sourcery |
+| 7 | M2M test only asserts HTTP 200, not behaviour | Medium | **Resolved** | Sourcery + Copilot |
+| 8 | Instructions: "Dictionary" label ambiguous | Low | **Resolved** | Sourcery |
+| 9 | Manual: "Command for step 4" caption off-by-one | Low | **Resolved** | Sourcery |
+| 10 | Instructions script has inline secret literals | Low | **Resolved** | Copilot |
+| 11 | Instructions Step N4 writes token files to working dir | Low | **Resolved** | Copilot |
+| 12 | `TASK-m2m-review.md` must be removed before merge | Low | Open | Sourcery + Copilot |
 
-**Blockers before merge:** Findings 1 and 2.
+**All blockers resolved. Remaining before merge: Finding 12 (remove task files).**
 
 ---
 

--- a/TASK-m2m-review.md
+++ b/TASK-m2m-review.md
@@ -1,0 +1,137 @@
+# TASK-m2m-review.md
+
+## Summary
+
+This review covers the `m2m-changes` branch. The change adds M2M (Machine-to-Machine / client credentials) Auth0 token support to the API backend. Two code files and two documentation files were changed or added.
+
+**Verified locally:** `poetry run pytest ebl/tests/users/ --cov=ebl.users.infrastructure.auth0 --cov-report=term-missing` — 33 passed, 87% coverage.
+
+---
+
+## Findings
+
+---
+
+### Finding 1 — Staged vs. working-tree divergence (lambda vs. named function)
+
+**Severity:** Medium
+
+**Description:**  
+The staged (`git diff --cached`) version of `auth0.py` uses lambda assignments:
+
+```python
+if is_m2m:
+    profile_factory = lambda: {"name": access_token["sub"]}
+else:
+    profile_factory = lambda: fetch_user_profile(self.issuer, req.auth)
+```
+
+The working tree version uses named `def` blocks (the version currently on disk). The named-function style is the correct one. Committing the staged version would introduce flake8 E731 violations (`do not assign a lambda expression`) and diverge from the project's style. The staged index must be updated to match the working tree before committing.
+
+**Reproduction Steps:**  
+`git diff --cached ebl/users/infrastructure/auth0.py` shows lambdas.  
+`git diff ebl/users/infrastructure/auth0.py` (unstaged) shows named functions.
+
+**Recommendation:**  
+Unstage the current version and re-stage the working-tree version:  
+`git restore --staged ebl/users/infrastructure/auth0.py && git add ebl/users/infrastructure/auth0.py`
+
+---
+
+### Finding 2 — Coverage is 87%, below required 100%
+
+**Severity:** High
+
+**Description:**  
+Coverage report after the change:
+
+```
+Name                                Stmts   Miss  Cover   Missing
+ebl/users/infrastructure/auth0.py      53      7    87%   13-17, 87, 92
+```
+
+- **Lines 13–17**: The body of `fetch_user_profile` (the HTTP call to Auth0's `/userinfo` endpoint) is never executed in the test suite.
+- **Line 87**: The `return {"name": access_token["sub"]}` body inside the M2M `profile_factory` closure.
+- **Line 92**: The `return fetch_user_profile(...)` body inside the non-M2M `profile_factory` closure.
+
+The project rule is: *"Ensure that coverage is 100% after changes in affected code."*
+
+Lines 87 and 92 are directly inside the new code introduced by this change. `fetch_user_profile` (lines 13–17) is unchanged, but it was previously reachable through the (now removed) inline lambda in the old `authenticate`. Its coverage was already a pre-existing gap — though the refactor made it more explicit.
+
+**Reproduction Steps:**  
+```
+poetry run pytest ebl/tests/users/ --cov=ebl.users.infrastructure.auth0 --cov-report=term-missing
+```
+
+**Recommendation:**  
+Add tests to cover all three gaps:
+
+1. `test_auth_backend_m2m_token` must trigger `user.profile` to cover line 87. This requires the test to access the returned `Auth0User`, which the current `simulate_get` helper does not expose. One option is to capture the user object via the `set_user` callback or to test `Auth0User` with the M2M `profile_factory` directly in `test_auth0_user.py`.
+2. Cover `fetch_user_profile` (lines 13–17) by mocking `requests.get` and calling `fetch_user_profile` directly, or by triggering the non-M2M path and calling `profile` on the returned `Auth0User`.
+3. The non-M2M `profile_factory` body (line 92) can be covered together with point 2.
+
+---
+
+### Finding 3 — `token.txt` and `token_response.json` not in `.gitignore`
+
+**Severity:** Low
+
+**Description:**  
+`M2M_Auth0_manual.md` instructs operators to save the raw JWT to `token.txt` and the full token response to `token_response.json` on disk. It warns these must never be committed. However, neither filename appears in `.gitignore`, meaning a developer following the manual could accidentally stage them.
+
+**Reproduction Steps:**  
+`grep -E "token\.txt|token_response" .gitignore` → no match.
+
+**Recommendation:**  
+Add to `.gitignore`:
+```
+token.txt
+token_response.json
+negative_token.txt
+```
+
+---
+
+### Finding 4 — ~~Documentation references wrong branch (`add-realia`, PR #715)~~ RESOLVED
+
+`M2M_Auth0_instructions.md` Step N5 now references the `m2m-changes` branch. The stale PR #715 / `add-realia` references and the option A/B split have been removed.
+
+---
+
+### Finding 5 — ~~`access_token["sub"]` raises `KeyError` if `sub` is absent~~ RESOLVED
+
+`"sub"` has been added to `required_claims` in `Auth0Backend.__init__`. The JWT library now rejects tokens missing `sub` with a 401 before `authenticate` is ever called, eliminating the `KeyError` at the source.
+
+---
+
+## Passing Checks
+
+| Check | Result |
+|---|---|
+| Core logic correctness — removing `openid` from `required_claims` | ✓ Correct. `openid` was a non-standard Auth0 Rule claim absent in client-credentials tokens. |
+| M2M detection via `gty == "client-credentials"` | ✓ Correct. This is the standard Auth0 M2M identifier; claim is RS256-signed and cannot be forged. |
+| M2M path skips `/userinfo` | ✓ Correct. M2M tokens have no user identity; calling `/userinfo` would fail. |
+| M2M `profile["name"]` set to `sub` | ✓ Correct. `sub` is the client ID, usable as audit identity (`ebl_name`). |
+| `verify_claims` alignment | ✓ `required_claims=["exp","iat"]` now matches `verify_claims=["signature","exp","iat"]`. |
+| No secrets in committed files | ✓ All credential fields are placeholders. |
+| flake8 (working tree) | ✓ No violations. |
+| mypy errors introduced by this change | ✓ None. All mypy errors in the file are pre-existing. |
+| All 33 user tests pass | ✓ |
+
+---
+
+## Severity Summary
+
+| # | Finding | Severity | Status |
+|---|---|---|---|
+| 1 | Staged vs. working-tree lambda divergence | Medium | Open |
+| 2 | Coverage 87% — lines 13–17, 87, 92 uncovered | High | Open |
+| 3 | `token.txt` / `token_response.json` not in `.gitignore` | Low | Open |
+| 4 | Documentation references wrong branch/PR | Low | **Resolved** |
+| 5 | `access_token["sub"]` KeyError on missing claim | Low | **Resolved** |
+
+**Blockers before merge:** Findings 1 and 2.
+
+---
+
+*Reminder: Remove this file (`TASK-m2m-review.md`) before merging the PR.*

--- a/TASK-m2m-todo.md
+++ b/TASK-m2m-todo.md
@@ -1,0 +1,40 @@
+# TASK-m2m-todo.md
+
+## Task: Add M2M Auth0 support for client credentials flow
+
+### Code
+
+- [x] Remove `"openid"` from `required_claims` in `Auth0Backend`
+- [x] Add `"sub"` to `required_claims` in `Auth0Backend`
+- [x] Add explicit `sub` guard in `authenticate()` raising `HTTPUnauthorized` if absent
+- [x] Detect M2M tokens via `gty == "client-credentials"` and skip `/userinfo`
+- [x] Set profile name from `sub` for M2M tokens
+- [x] Remove `"openid": True` from `create_token()` test helper
+- [x] Add `test_auth_backend_m2m_token` — HTTP 200 acceptance test
+- [x] Add `test_auth_backend_m2m_token_profile` — asserts profile is `{"name": sub}`, `fetch_user_profile` not called
+- [x] Add `test_auth_backend_non_m2m_profile_calls_userinfo` — asserts `/userinfo` is called for regular tokens
+- [x] Add `test_auth_backend_missing_sub_is_unauthorized` — missing `sub` returns HTTP 401
+- [x] Achieve 100% coverage on `ebl/users/infrastructure/auth0.py`
+
+### Documentation
+
+- [x] Add `M2M_Auth0_instructions.md` — full runbook
+- [x] Add `M2M_Auth0_manual.md` — operator manual
+- [x] Fix Step N5 branch reference (`add-realia` → `m2m-changes`)
+- [x] Update manual: store secrets in `.env`, document sensitivity
+- [x] Update all token file paths to use `/tmp` (Finding 3, 11)
+- [x] Fix manual Section 7 step caption off-by-one (Finding 9)
+- [x] Fix instructions "Dictionary" label to include audience identifier (Finding 8)
+- [x] Fix instructions minimal script to use env-var guards instead of inline literals (Finding 10)
+
+### Review
+
+- [x] Create `TASK-m2m-review.md` with initial findings
+- [x] Integrate GitHub PR #721 reviews (Sourcery AI + Copilot)
+- [x] Mark resolved findings in review file
+
+### Cleanup (before merge)
+
+- [ ] Remove `TASK-m2m-todo.md`
+- [ ] Remove `TASK-m2m-log.md`
+- [ ] Remove `TASK-m2m-review.md`

--- a/ebl/tests/users/test_auth0_backend.py
+++ b/ebl/tests/users/test_auth0_backend.py
@@ -35,7 +35,6 @@ def create_token(
         "iss": issuer,
         "iat": now,
         "exp": now + datetime.timedelta(seconds=expires_in_seconds),
-        "openid": True,
         "scope": "read:texts",
     }
 
@@ -145,3 +144,23 @@ def test_auth_backend_expired_token() -> None:
     result = simulate_get(auth_backend, token)
 
     assert result.status == falcon.HTTP_UNAUTHORIZED
+
+
+def test_auth_backend_m2m_token() -> None:
+    private_key, public_key = create_key_pair()
+    auth_backend = Auth0Backend(
+        public_key, "test-audience", "https://issuer/", lambda _id: None
+    )
+    token = create_token(
+        private_key,
+        "test-audience",
+        "https://issuer/",
+        overrides={
+            "gty": "client-credentials",
+            "scope": "write:bibliography read:bibliography",
+        },
+    )
+
+    result = simulate_get(auth_backend, token)
+
+    assert result.status == falcon.HTTP_OK

--- a/ebl/tests/users/test_auth0_backend.py
+++ b/ebl/tests/users/test_auth0_backend.py
@@ -8,11 +8,22 @@ from falcon_auth import FalconAuthMiddleware
 import jwt
 from Cryptodome.PublicKey import RSA
 
+from unittest.mock import Mock, patch
+
 from ebl.users.infrastructure.auth0 import Auth0Backend
 
 
 class OkResource:
     def on_get(self, _req: falcon.Request, resp: falcon.Response) -> None:
+        resp.status = falcon.HTTP_OK
+
+
+class ProfileCapturingResource:
+    def __init__(self) -> None:
+        self.captured_profile: Optional[Dict[str, Any]] = None
+
+    def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
+        self.captured_profile = req.context.user.profile
         resp.status = falcon.HTTP_OK
 
 
@@ -61,6 +72,16 @@ def simulate_get(auth_backend: Auth0Backend, token: Optional[str]) -> _ResultBas
     if token is not None:
         headers["Authorization"] = f"Bearer {token}"
     return client.simulate_get("/test", headers=headers)
+
+
+def create_profile_capturing_client(
+    auth_backend: Auth0Backend,
+) -> Tuple[testing.TestClient, ProfileCapturingResource]:
+    resource = ProfileCapturingResource()
+    auth_middleware = FalconAuthMiddleware(auth_backend)
+    api = falcon.App(middleware=[auth_middleware])
+    api.add_route("/test", resource)
+    return testing.TestClient(api), resource
 
 
 def test_auth_backend_valid_token() -> None:
@@ -164,3 +185,74 @@ def test_auth_backend_m2m_token() -> None:
     result = simulate_get(auth_backend, token)
 
     assert result.status == falcon.HTTP_OK
+
+
+def test_auth_backend_m2m_token_profile() -> None:
+    private_key, public_key = create_key_pair()
+    set_user = Mock()
+    auth_backend = Auth0Backend(
+        public_key, "test-audience", "https://issuer/", set_user
+    )
+    sub = "m2m-client-id"
+    token = create_token(
+        private_key,
+        "test-audience",
+        "https://issuer/",
+        overrides={
+            "sub": sub,
+            "gty": "client-credentials",
+            "scope": "write:bibliography read:bibliography",
+        },
+    )
+    client, resource = create_profile_capturing_client(auth_backend)
+
+    with patch("ebl.users.infrastructure.auth0.fetch_user_profile") as mock_fetch:
+        result = client.simulate_get(
+            "/test", headers={"Authorization": f"Bearer {token}"}
+        )
+        mock_fetch.assert_not_called()
+
+    assert result.status == falcon.HTTP_OK
+    set_user.assert_called_once_with(sub)
+    assert resource.captured_profile == {"name": sub}
+
+
+def test_auth_backend_non_m2m_profile_calls_userinfo() -> None:
+    private_key, public_key = create_key_pair()
+    auth_backend = Auth0Backend(
+        public_key, "test-audience", "https://issuer/", lambda _id: None
+    )
+    mock_profile = {"name": "john"}
+    token = create_token(private_key, "test-audience", "https://issuer/")
+    client, resource = create_profile_capturing_client(auth_backend)
+
+    with patch("ebl.users.infrastructure.auth0.requests.get") as mock_get:
+        mock_response = Mock()
+        mock_response.json.return_value = mock_profile
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = client.simulate_get(
+            "/test", headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert result.status == falcon.HTTP_OK
+    mock_get.assert_called_once()
+    assert resource.captured_profile == mock_profile
+
+
+def test_auth_backend_missing_sub_is_unauthorized() -> None:
+    private_key, public_key = create_key_pair()
+    auth_backend = Auth0Backend(
+        public_key, "test-audience", "https://issuer/", lambda _id: None
+    )
+    token = create_token(
+        private_key,
+        "test-audience",
+        "https://issuer/",
+        overrides={"sub": None},
+    )
+
+    result = simulate_get(auth_backend, token)
+
+    assert result.status == falcon.HTTP_UNAUTHORIZED

--- a/ebl/users/infrastructure/auth0.py
+++ b/ebl/users/infrastructure/auth0.py
@@ -1,6 +1,7 @@
 import copy
 from typing import Any, Callable, List, Optional
 
+import falcon
 import pydash
 import requests
 from falcon_auth import JWTAuthBackend
@@ -79,12 +80,15 @@ class Auth0Backend(JWTAuthBackend):
 
     def authenticate(self, req, resp, resource):
         access_token = super().authenticate(req, resp, resource)
-        self._set_user(access_token["sub"])
+        sub = access_token.get("sub")
+        if sub is None:
+            raise falcon.HTTPUnauthorized()
+        self._set_user(sub)
         is_m2m = access_token.get("gty") == "client-credentials"
         if is_m2m:
 
             def profile_factory():
-                return {"name": access_token["sub"]}
+                return {"name": sub}
 
         else:
 

--- a/ebl/users/infrastructure/auth0.py
+++ b/ebl/users/infrastructure/auth0.py
@@ -73,13 +73,22 @@ class Auth0Backend(JWTAuthBackend):
             audience=audience,
             issuer=issuer,
             verify_claims=["signature", "exp", "iat"],
-            required_claims=["exp", "iat", "openid"],
+            required_claims=["exp", "iat", "sub"],
         )
         self._set_user = set_user
 
     def authenticate(self, req, resp, resource):
         access_token = super().authenticate(req, resp, resource)
         self._set_user(access_token["sub"])
-        return Auth0User(
-            access_token, lambda: fetch_user_profile(self.issuer, req.auth)
-        )
+        is_m2m = access_token.get("gty") == "client-credentials"
+        if is_m2m:
+
+            def profile_factory():
+                return {"name": access_token["sub"]}
+
+        else:
+
+            def profile_factory():
+                return fetch_user_profile(self.issuer, req.auth)
+
+        return Auth0User(access_token, profile_factory)


### PR DESCRIPTION
Implement support for Machine-to-Machine (M2M) authentication using Auth0's client credentials flow. Adjustments include removing 'openid' from required claims, adding 'sub' to enforce its presence, and updating the authentication logic to handle M2M tokens appropriately. New documentation files provide setup and security guidance. Tests for the M2M path have been added to ensure functionality.

## Summary by Sourcery

Add support for Auth0 machine-to-machine (client credentials) tokens and document how to configure and operate M2M access for the Bibliography API.

New Features:
- Support authenticating Auth0 client-credentials (M2M) tokens and treating them as authenticated users with a minimal profile.

Bug Fixes:
- Ensure tokens without the custom 'openid' claim are accepted while requiring a standard 'sub' claim to avoid KeyErrors when setting the user.

Enhancements:
- Adjust Auth0 backend authentication to branch between M2M and interactive user flows, avoiding /userinfo calls for M2M tokens.
- Expand internal documentation with detailed runbooks and manuals for setting up, testing, and reviewing Auth0 M2M integrations, including security guidance.

Documentation:
- Add comprehensive internal guides for configuring Auth0 M2M applications, requesting tokens, testing bibliography API access, and handling security and operational procedures.

Tests:
- Add a test case that verifies Auth0 backend accepts M2M client-credentials tokens and authorizes access appropriately.

Chores:
- Introduce an internal review checklist file for the M2M changes, capturing findings, coverage expectations, and pre-merge requirements.