### PR TITLE
Search optimization

### DIFF
--- a/ebl/common/query/parameter_parser.py
+++ b/ebl/common/query/parameter_parser.py
@@ -5,6 +5,8 @@ from ebl.transliteration.application.transliteration_query_factory import (
     TransliterationQueryFactory,
 )
 
+COUNT_MODES = ("exact", "none", "page")
+
 
 def parse_integer_field(field: str) -> Callable[[Dict], Dict]:
     def parse_integer(parameters: Dict) -> Dict:
@@ -21,6 +23,18 @@ def parse_integer_field(field: str) -> Callable[[Dict], Dict]:
             ) from error
 
     return parse_integer
+
+
+def parse_non_negative_integer_field(field: str) -> Callable[[Dict], Dict]:
+    parse_integer = parse_integer_field(field)
+
+    def parse_non_negative_integer(parameters: Dict) -> Dict:
+        parameters = parse_integer(parameters)
+        if parameters.get(field, 0) < 0:
+            raise DataError(f"{field} must be non-negative")
+        return parameters
+
+    return parse_non_negative_integer
 
 
 def parse_lines(lines: Sequence[str]) -> Sequence[int]:
@@ -92,3 +106,13 @@ def parse_genre(parameters: Dict) -> Dict:
     genre = parameters.get("genre", "").split(":")
 
     return {**parameters, "genre": genre} if any(genre) else parameters
+
+
+def parse_count(parameters: Dict) -> Dict:
+    if "count" not in parameters:
+        return parameters
+
+    count = parameters["count"]
+    if count not in COUNT_MODES:
+        raise DataError(f"unexpected count {count!r}")
+    return parameters

--- a/ebl/common/query/query_result.py
+++ b/ebl/common/query/query_result.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 import attr
 from enum import Enum
 from ebl.transliteration.domain.museum_number import MuseumNumber
@@ -20,14 +20,41 @@ class QueryItem:
     match_count: int
 
 
-@attr.s(auto_attribs=True, frozen=True)
+@attr.s(auto_attribs=True, frozen=True, eq=False)
 class QueryResult:
     items: Sequence[QueryItem]
-    match_count_total: int
+    match_count_total: Optional[int]
+    is_match_count_total_exact: bool = True
+    has_next_page: Optional[bool] = None
+    show_count_metadata: bool = False
 
     @staticmethod
     def create_empty() -> "QueryResult":
         return QueryResult([], 0)
+
+    def __eq__(self, other):
+        if isinstance(other, QueryResult):
+            return (
+                tuple(self.items) == tuple(other.items)
+                and self.match_count_total == other.match_count_total
+                and self.is_match_count_total_exact
+                == other.is_match_count_total_exact
+                and self.has_next_page == other.has_next_page
+            )
+
+        try:
+            other_items = other.items
+            other_match_count_total = other.match_count_total
+        except AttributeError:
+            return NotImplemented
+
+        return (
+            tuple(self.items) == tuple(other_items)
+            and self.match_count_total == other_match_count_total
+            and self.is_match_count_total_exact
+            == getattr(other, "is_match_count_total_exact", True)
+            and self.has_next_page == getattr(other, "has_next_page", None)
+        )
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -49,7 +76,10 @@ class AfORegisterToFragmentQueryItem:
 @attr.s(auto_attribs=True, frozen=True)
 class CorpusQueryResult:
     items: Sequence[CorpusQueryItem]
-    match_count_total: int
+    match_count_total: Optional[int]
+    is_match_count_total_exact: bool = True
+    has_next_page: Optional[bool] = None
+    show_count_metadata: bool = False
 
     @staticmethod
     def create_empty() -> "CorpusQueryResult":

--- a/ebl/common/query/query_result.py
+++ b/ebl/common/query/query_result.py
@@ -6,6 +6,29 @@ from ebl.common.domain.stage import Stage
 from ebl.transliteration.domain.text_id import TextId
 
 
+def _query_result_equality_values(result):
+    return (
+        tuple(result.items),
+        result.match_count_total,
+        result.is_match_count_total_exact,
+        result.has_next_page,
+    )
+
+
+def compare_query_results(left, right):
+    try:
+        right_values = (
+            tuple(right.items),
+            right.match_count_total,
+            getattr(right, "is_match_count_total_exact", True),
+            getattr(right, "has_next_page", None),
+        )
+    except AttributeError:
+        return NotImplemented
+
+    return _query_result_equality_values(left) == right_values
+
+
 class LemmaQueryType(Enum):
     AND = "and"
     OR = "or"
@@ -33,28 +56,7 @@ class QueryResult:
         return QueryResult([], 0)
 
     def __eq__(self, other):
-        if isinstance(other, QueryResult):
-            return (
-                tuple(self.items) == tuple(other.items)
-                and self.match_count_total == other.match_count_total
-                and self.is_match_count_total_exact
-                == other.is_match_count_total_exact
-                and self.has_next_page == other.has_next_page
-            )
-
-        try:
-            other_items = other.items
-            other_match_count_total = other.match_count_total
-        except AttributeError:
-            return NotImplemented
-
-        return (
-            tuple(self.items) == tuple(other_items)
-            and self.match_count_total == other_match_count_total
-            and self.is_match_count_total_exact
-            == getattr(other, "is_match_count_total_exact", True)
-            and self.has_next_page == getattr(other, "has_next_page", None)
-        )
+        return compare_query_results(self, other)
 
 
 @attr.s(auto_attribs=True, frozen=True)

--- a/ebl/common/query/query_result.py
+++ b/ebl/common/query/query_result.py
@@ -49,7 +49,6 @@ class QueryResult:
     match_count_total: Optional[int]
     is_match_count_total_exact: bool = True
     has_next_page: Optional[bool] = None
-    show_count_metadata: bool = False
 
     @staticmethod
     def create_empty() -> "QueryResult":
@@ -81,7 +80,6 @@ class CorpusQueryResult:
     match_count_total: Optional[int]
     is_match_count_total_exact: bool = True
     has_next_page: Optional[bool] = None
-    show_count_metadata: bool = False
 
     @staticmethod
     def create_empty() -> "CorpusQueryResult":

--- a/ebl/common/query/query_schemas.py
+++ b/ebl/common/query/query_schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, post_load, validate
+from marshmallow import Schema, fields, post_dump, post_load, validate
 from ebl.common.query.query_result import (
     CorpusQueryItem,
     CorpusQueryResult,
@@ -58,8 +58,27 @@ class AfORegisterToFragmentQueryItemSchema(Schema):
 
 
 class QueryResultSchema(Schema):
-    match_count_total = fields.Integer(data_key="matchCountTotal", required=True)
+    match_count_total = fields.Integer(
+        data_key="matchCountTotal", required=True, allow_none=True
+    )
+    is_match_count_total_exact = fields.Boolean(
+        data_key="isMatchCountTotalExact", load_default=True, dump_default=True
+    )
+    has_next_page = fields.Boolean(
+        data_key="hasNextPage", load_default=None, dump_default=None, allow_none=True
+    )
+    show_count_metadata = fields.Boolean(
+        data_key="_showCountMetadata", load_default=False, dump_default=False
+    )
     items = fields.Nested(QueryItemSchema, many=True, required=True)
+
+    @post_dump
+    def filter_count_metadata(self, data, **kwargs):
+        show_count_metadata = data.pop("_showCountMetadata", False)
+        if not show_count_metadata:
+            data.pop("isMatchCountTotalExact", None)
+            data.pop("hasNextPage", None)
+        return data
 
     @post_load
     def make_query_result(self, data, **kwargs) -> QueryResult:

--- a/ebl/common/query/query_schemas.py
+++ b/ebl/common/query/query_schemas.py
@@ -58,6 +58,10 @@ class AfORegisterToFragmentQueryItemSchema(Schema):
 
 
 class QueryResultSchema(Schema):
+    def __init__(self, *args, include_count_metadata=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._include_count_metadata = include_count_metadata
+
     match_count_total = fields.Integer(
         data_key="matchCountTotal", required=True, allow_none=True
     )
@@ -67,15 +71,11 @@ class QueryResultSchema(Schema):
     has_next_page = fields.Boolean(
         data_key="hasNextPage", load_default=None, dump_default=None, allow_none=True
     )
-    show_count_metadata = fields.Boolean(
-        data_key="_showCountMetadata", load_default=False, dump_default=False
-    )
     items = fields.Nested(QueryItemSchema, many=True, required=True)
 
     @post_dump
     def filter_count_metadata(self, data, **kwargs):
-        show_count_metadata = data.pop("_showCountMetadata", False)
-        if not show_count_metadata:
+        if not self._include_count_metadata:
             data.pop("isMatchCountTotalExact", None)
             data.pop("hasNextPage", None)
         return data

--- a/ebl/fragmentarium/application/fragment_query_summary_schema.py
+++ b/ebl/fragmentarium/application/fragment_query_summary_schema.py
@@ -1,18 +1,88 @@
 from marshmallow import EXCLUDE, Schema, fields, post_dump, post_load
 import pydash
 
+from ebl.bibliography.application.reference_schema import ReferenceSchema
 from ebl.common.application.schemas import AccessionSchema
-from ebl.fragmentarium.application.fragment_fields_schemas import ScriptSchema
+from ebl.common.domain.period import Period, PeriodModifier
+from ebl.fragmentarium.application.fragment_fields_schemas import (
+    DossierReferenceSchema,
+)
 from ebl.fragmentarium.application.genre_schema import GenreSchema
 from ebl.fragmentarium.domain.date import DateSchema
+from ebl.fragmentarium.domain.fragment import Script
 from ebl.fragmentarium.domain.fragment_query_summary import (
+    FragmentQueryArchaeology,
     FragmentQueryResult,
     FragmentQuerySummary,
 )
+from ebl.schemas import ResearchProjectField, ValueEnumField
 from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
+from ebl.transliteration.application.text_schema import TextSchema
+from ebl.transliteration.domain.text import Text
 
 
 DEFAULT_THUMBNAIL_RESOLUTION = "small"
+
+
+def deserialize_script_period(value):
+    try:
+        return Period.from_abbreviation(value)
+    except ValueError:
+        return Period.from_name(value)
+
+
+class FragmentQueryScriptSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    period = fields.Function(
+        lambda script: script.period.abbreviation,
+        deserialize_script_period,
+        required=True,
+    )
+    period_modifier = ValueEnumField(
+        PeriodModifier, required=True, data_key="periodModifier"
+    )
+    uncertain = fields.Boolean(load_default=None)
+
+    @post_load
+    def make_script(self, data, **kwargs) -> Script:
+        return Script(**data)
+
+
+class FragmentQueryArchaeologySchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    excavation_number = fields.Nested(
+        MuseumNumberSchema,
+        allow_none=True,
+        load_default=None,
+        dump_default=None,
+        data_key="excavationNumber",
+    )
+    site = fields.Method("serialize_site", "deserialize_site", allow_none=True)
+
+    @staticmethod
+    def serialize_site(obj):
+        return {"name": obj.site} if obj.site else None
+
+    @staticmethod
+    def deserialize_site(value):
+        if not value:
+            return None
+        if isinstance(value, dict):
+            return value.get("name")
+        return value
+
+    @post_load
+    def make_archaeology(self, data, **kwargs) -> FragmentQueryArchaeology:
+        return FragmentQueryArchaeology(**data)
+
+    @post_dump
+    def filter_none(self, data, **kwargs):
+        data = pydash.omit_by(data, pydash.is_none)
+        return data or None
 
 
 class FragmentQuerySummarySchema(Schema):
@@ -26,13 +96,29 @@ class FragmentQuerySummarySchema(Schema):
         AccessionSchema, allow_none=True, load_default=None, dump_default=None
     )
     description = fields.String(required=True)
-    script = fields.Nested(ScriptSchema, required=True)
+    script = fields.Nested(FragmentQueryScriptSchema, required=True)
     date = fields.Nested(
         DateSchema, allow_none=True, load_default=None, dump_default=None
     )
     genres = fields.Nested(GenreSchema, many=True, load_default=())
+    archaeology = fields.Nested(
+        FragmentQueryArchaeologySchema,
+        allow_none=True,
+        load_default=None,
+        dump_default=None,
+    )
+    references = fields.Nested(ReferenceSchema, many=True, load_default=())
+    projects = fields.List(ResearchProjectField(), load_default=())
+    dossiers = fields.Nested(DossierReferenceSchema, many=True, load_default=())
     matching_lines = fields.List(
         fields.Integer(), required=True, data_key="matchingLines"
+    )
+    matching_line_preview = fields.Nested(
+        TextSchema,
+        allow_none=True,
+        load_default=None,
+        dump_default=None,
+        data_key="matchingLinePreview",
     )
     match_count = fields.Integer(required=True, data_key="matchCount")
     has_photo = fields.Boolean(required=True, data_key="hasPhoto")
@@ -46,6 +132,11 @@ class FragmentQuerySummarySchema(Schema):
     def make_query_item(self, data, **kwargs) -> FragmentQuerySummary:
         data["matching_lines"] = tuple(data["matching_lines"])
         data["genres"] = tuple(data["genres"])
+        data["references"] = tuple(data["references"])
+        data["projects"] = tuple(data["projects"])
+        data["dossiers"] = tuple(data["dossiers"])
+        if data.get("matching_line_preview") is None:
+            data["matching_line_preview"] = Text()
         return FragmentQuerySummary(**data)
 
     @post_dump(pass_many=True)

--- a/ebl/fragmentarium/application/fragment_query_summary_schema.py
+++ b/ebl/fragmentarium/application/fragment_query_summary_schema.py
@@ -123,7 +123,9 @@ class FragmentQuerySummarySchema(Schema):
     match_count = fields.Integer(required=True, data_key="matchCount")
     has_photo = fields.Boolean(required=True, data_key="hasPhoto")
     thumbnail_path = fields.Function(
-        lambda summary: f"/fragments/{summary.museum_number}/thumbnail/{DEFAULT_THUMBNAIL_RESOLUTION}",
+        lambda summary: (
+            f"/fragments/{summary.museum_number}/thumbnail/{DEFAULT_THUMBNAIL_RESOLUTION}"
+        ),
         dump_only=True,
         data_key="thumbnailPath",
     )

--- a/ebl/fragmentarium/application/fragment_query_summary_schema.py
+++ b/ebl/fragmentarium/application/fragment_query_summary_schema.py
@@ -1,0 +1,68 @@
+from marshmallow import EXCLUDE, Schema, fields, post_dump, post_load
+import pydash
+
+from ebl.common.application.schemas import AccessionSchema
+from ebl.fragmentarium.application.fragment_fields_schemas import ScriptSchema
+from ebl.fragmentarium.application.genre_schema import GenreSchema
+from ebl.fragmentarium.domain.date import DateSchema
+from ebl.fragmentarium.domain.fragment_query_summary import (
+    FragmentQueryResult,
+    FragmentQuerySummary,
+)
+from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
+
+
+DEFAULT_THUMBNAIL_RESOLUTION = "small"
+
+
+class FragmentQuerySummarySchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    museum_number = fields.Nested(
+        MuseumNumberSchema, required=True, data_key="museumNumber"
+    )
+    accession = fields.Nested(
+        AccessionSchema, allow_none=True, load_default=None, dump_default=None
+    )
+    description = fields.String(required=True)
+    script = fields.Nested(ScriptSchema, required=True)
+    date = fields.Nested(
+        DateSchema, allow_none=True, load_default=None, dump_default=None
+    )
+    genres = fields.Nested(GenreSchema, many=True, load_default=())
+    matching_lines = fields.List(
+        fields.Integer(), required=True, data_key="matchingLines"
+    )
+    match_count = fields.Integer(required=True, data_key="matchCount")
+    has_photo = fields.Boolean(required=True, data_key="hasPhoto")
+    thumbnail_path = fields.Function(
+        lambda summary: f"/fragments/{summary.museum_number}/thumbnail/{DEFAULT_THUMBNAIL_RESOLUTION}",
+        dump_only=True,
+        data_key="thumbnailPath",
+    )
+
+    @post_load
+    def make_query_item(self, data, **kwargs) -> FragmentQuerySummary:
+        data["matching_lines"] = tuple(data["matching_lines"])
+        data["genres"] = tuple(data["genres"])
+        return FragmentQuerySummary(**data)
+
+    @post_dump(pass_many=True)
+    def filter_none(self, data, many, **kwargs):
+        if many:
+            return [pydash.omit_by(item, pydash.is_none) for item in data]
+        return pydash.omit_by(data, pydash.is_none)
+
+
+class FragmentQueryResultSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    items = fields.Nested(FragmentQuerySummarySchema, many=True, required=True)
+    match_count_total = fields.Integer(required=True, data_key="matchCountTotal")
+
+    @post_load
+    def make_query_result(self, data, **kwargs) -> FragmentQueryResult:
+        data["items"] = tuple(data["items"])
+        return FragmentQueryResult(**data)

--- a/ebl/fragmentarium/application/fragment_query_summary_schema.py
+++ b/ebl/fragmentarium/application/fragment_query_summary_schema.py
@@ -4,6 +4,7 @@ import pydash
 from ebl.bibliography.application.reference_schema import ReferenceSchema
 from ebl.common.application.schemas import AccessionSchema
 from ebl.common.domain.period import Period, PeriodModifier
+from ebl.common.query.query_schemas import QueryResultSchema
 from ebl.fragmentarium.application.fragment_fields_schemas import (
     DossierReferenceSchema,
 )
@@ -18,7 +19,6 @@ from ebl.fragmentarium.domain.fragment_query_summary import (
 )
 from ebl.schemas import ResearchProjectField, ValueEnumField
 from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
-
 
 DEFAULT_THUMBNAIL_RESOLUTION = "small"
 
@@ -175,31 +175,11 @@ class FragmentQuerySummarySchema(Schema):
         return pydash.omit_by(data, pydash.is_none)
 
 
-class FragmentQueryResultSchema(Schema):
+class FragmentQueryResultSchema(QueryResultSchema):
     class Meta:
         unknown = EXCLUDE
 
     items = fields.Nested(FragmentQuerySummarySchema, many=True, required=True)
-    match_count_total = fields.Integer(
-        required=True, data_key="matchCountTotal", allow_none=True
-    )
-    is_match_count_total_exact = fields.Boolean(
-        data_key="isMatchCountTotalExact", load_default=True, dump_default=True
-    )
-    has_next_page = fields.Boolean(
-        data_key="hasNextPage", load_default=None, dump_default=None, allow_none=True
-    )
-    show_count_metadata = fields.Boolean(
-        data_key="_showCountMetadata", load_default=False, dump_default=False
-    )
-
-    @post_dump
-    def filter_count_metadata(self, data, **kwargs):
-        show_count_metadata = data.pop("_showCountMetadata", False)
-        if not show_count_metadata:
-            data.pop("isMatchCountTotalExact", None)
-            data.pop("hasNextPage", None)
-        return data
 
     @post_load
     def make_query_result(self, data, **kwargs) -> FragmentQueryResult:

--- a/ebl/fragmentarium/application/fragment_query_summary_schema.py
+++ b/ebl/fragmentarium/application/fragment_query_summary_schema.py
@@ -109,7 +109,7 @@ class FragmentQueryMatchingLinePreviewSchema(Schema):
         unknown = EXCLUDE
 
     lines = fields.Nested(FragmentQueryPreviewLineSchema, many=True, required=True)
-    parser_version = fields.String(required=True)
+    parser_version = fields.String(required=True, data_key="parserVersion")
 
 
 class FragmentQuerySummarySchema(Schema):

--- a/ebl/fragmentarium/application/fragment_query_summary_schema.py
+++ b/ebl/fragmentarium/application/fragment_query_summary_schema.py
@@ -14,11 +14,10 @@ from ebl.fragmentarium.domain.fragment_query_summary import (
     FragmentQueryArchaeology,
     FragmentQueryResult,
     FragmentQuerySummary,
+    empty_matching_line_preview,
 )
 from ebl.schemas import ResearchProjectField, ValueEnumField
 from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
-from ebl.transliteration.application.text_schema import TextSchema
-from ebl.transliteration.domain.text import Text
 
 
 DEFAULT_THUMBNAIL_RESOLUTION = "small"
@@ -85,6 +84,34 @@ class FragmentQueryArchaeologySchema(Schema):
         return data or None
 
 
+class FragmentQueryPreviewTokenSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    value = fields.String(required=True)
+    cleanValue = fields.String(allow_none=True)
+    uniqueLemma = fields.List(fields.String())
+    type = fields.String()
+
+
+class FragmentQueryPreviewLineSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    number = fields.String(required=True)
+    prefix = fields.String(required=True)
+    text = fields.String(required=True)
+    tokens = fields.Nested(FragmentQueryPreviewTokenSchema, many=True, required=True)
+
+
+class FragmentQueryMatchingLinePreviewSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    lines = fields.Nested(FragmentQueryPreviewLineSchema, many=True, required=True)
+    parser_version = fields.String(required=True)
+
+
 class FragmentQuerySummarySchema(Schema):
     class Meta:
         unknown = EXCLUDE
@@ -114,7 +141,7 @@ class FragmentQuerySummarySchema(Schema):
         fields.Integer(), required=True, data_key="matchingLines"
     )
     matching_line_preview = fields.Nested(
-        TextSchema,
+        FragmentQueryMatchingLinePreviewSchema,
         allow_none=True,
         load_default=None,
         dump_default=None,
@@ -138,7 +165,7 @@ class FragmentQuerySummarySchema(Schema):
         data["projects"] = tuple(data["projects"])
         data["dossiers"] = tuple(data["dossiers"])
         if data.get("matching_line_preview") is None:
-            data["matching_line_preview"] = Text()
+            data["matching_line_preview"] = empty_matching_line_preview()
         return FragmentQuerySummary(**data)
 
     @post_dump(pass_many=True)
@@ -153,7 +180,26 @@ class FragmentQueryResultSchema(Schema):
         unknown = EXCLUDE
 
     items = fields.Nested(FragmentQuerySummarySchema, many=True, required=True)
-    match_count_total = fields.Integer(required=True, data_key="matchCountTotal")
+    match_count_total = fields.Integer(
+        required=True, data_key="matchCountTotal", allow_none=True
+    )
+    is_match_count_total_exact = fields.Boolean(
+        data_key="isMatchCountTotalExact", load_default=True, dump_default=True
+    )
+    has_next_page = fields.Boolean(
+        data_key="hasNextPage", load_default=None, dump_default=None, allow_none=True
+    )
+    show_count_metadata = fields.Boolean(
+        data_key="_showCountMetadata", load_default=False, dump_default=False
+    )
+
+    @post_dump
+    def filter_count_metadata(self, data, **kwargs):
+        show_count_metadata = data.pop("_showCountMetadata", False)
+        if not show_count_metadata:
+            data.pop("isMatchCountTotalExact", None)
+            data.pop("hasNextPage", None)
+        return data
 
     @post_load
     def make_query_result(self, data, **kwargs) -> FragmentQueryResult:

--- a/ebl/fragmentarium/application/fragment_repository.py
+++ b/ebl/fragmentarium/application/fragment_repository.py
@@ -102,7 +102,7 @@ class FragmentRepository(ABC):
     @abstractmethod
     def query(
         self, query: dict, user_scopes: Sequence[Scope] = ()
-    ) -> FragmentQueryResult:
+    ) -> Union[QueryResult, FragmentQueryResult]:
         raise NotImplementedError
 
     @abstractmethod

--- a/ebl/fragmentarium/application/fragment_repository.py
+++ b/ebl/fragmentarium/application/fragment_repository.py
@@ -6,6 +6,7 @@ from ebl.common.query.query_result import QueryResult, AfORegisterToFragmentQuer
 from ebl.fragmentarium.application.line_to_vec import LineToVecEntry
 from ebl.fragmentarium.domain.archaeology import ExcavationNumber
 from ebl.fragmentarium.domain.fragment import Fragment
+from ebl.fragmentarium.domain.fragment_query_summary import FragmentQueryResult
 from ebl.fragmentarium.domain.fragment_info import FragmentInfo
 from ebl.fragmentarium.domain.fragment_pager_info import FragmentPagerInfo
 from ebl.transliteration.domain.museum_number import MuseumNumber
@@ -99,7 +100,9 @@ class FragmentRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def query(self, query: dict, user_scopes: Sequence[Scope] = ()) -> QueryResult:
+    def query(
+        self, query: dict, user_scopes: Sequence[Scope] = ()
+    ) -> FragmentQueryResult:
         raise NotImplementedError
 
     @abstractmethod

--- a/ebl/fragmentarium/domain/fragment_query_summary.py
+++ b/ebl/fragmentarium/domain/fragment_query_summary.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import attr
 
@@ -7,6 +7,7 @@ from ebl.common.domain.accession import Accession
 from ebl.common.domain.project import ResearchProject
 from ebl.fragmentarium.domain.date import Date
 from ebl.fragmentarium.domain.fragment import DossierReference, Genre, Script
+from ebl.transliteration.domain.atf import DEFAULT_ATF_PARSER_VERSION
 from ebl.transliteration.domain.museum_number import MuseumNumber
 from ebl.transliteration.domain.text import Text
 
@@ -17,13 +18,44 @@ class FragmentQueryArchaeology:
     site: Optional[str] = None
 
 
+def empty_matching_line_preview() -> Dict[str, Any]:
+    return {"lines": (), "parser_version": DEFAULT_ATF_PARSER_VERSION}
+
+
+def lightweight_token_of(token) -> Dict[str, Any]:
+    data = {
+        "value": token.value,
+        "cleanValue": getattr(token, "clean_value", None),
+        "uniqueLemma": [
+            str(lemma) for lemma in getattr(token, "unique_lemma", ())
+        ],
+        "type": token.__class__.__name__,
+    }
+    return {
+        key: value
+        for key, value in data.items()
+        if value is not None and (key != "uniqueLemma" or value)
+    }
+
+
+def lightweight_line_preview_of(line) -> Dict[str, Any]:
+    content = getattr(line, "content", ())
+    prefix = getattr(getattr(line, "line_number", None), "atf", "")
+    return {
+        "number": prefix,
+        "prefix": prefix,
+        "text": " ".join(token.value for token in content),
+        "tokens": [lightweight_token_of(token) for token in content],
+    }
+
+
 @attr.s(auto_attribs=True, frozen=True, eq=False)
 class FragmentQuerySummary:
     museum_number: MuseumNumber
     description: str
     script: Script
     matching_lines: Sequence[int] = ()
-    matching_line_preview: Text = attr.Factory(Text)
+    matching_line_preview: Dict[str, Any] = attr.Factory(empty_matching_line_preview)
     match_count: int = 0
     has_photo: bool = False
     accession: Optional[Accession] = None
@@ -70,17 +102,22 @@ class FragmentQuerySummary:
         )
 
 
-def matching_line_preview_of(text: Text, matching_lines: Sequence[int]) -> Text:
-    return Text.of_iterable(
-        (text.lines[index] for index in matching_lines),
-        text.parser_version,
-    )
+def matching_line_preview_of(text: Text, matching_lines: Sequence[int]) -> Dict[str, Any]:
+    return {
+        "lines": [
+            lightweight_line_preview_of(text.lines[index]) for index in matching_lines
+        ],
+        "parser_version": text.parser_version or DEFAULT_ATF_PARSER_VERSION,
+    }
 
 
 @attr.s(auto_attribs=True, frozen=True, eq=False)
 class FragmentQueryResult:
     items: Sequence[FragmentQuerySummary]
-    match_count_total: int
+    match_count_total: Optional[int]
+    is_match_count_total_exact: bool = True
+    has_next_page: Optional[bool] = None
+    show_count_metadata: bool = False
 
     @staticmethod
     def create_empty() -> "FragmentQueryResult":
@@ -91,6 +128,9 @@ class FragmentQueryResult:
             return (
                 tuple(self.items) == tuple(other.items)
                 and self.match_count_total == other.match_count_total
+                and self.is_match_count_total_exact
+                == other.is_match_count_total_exact
+                and self.has_next_page == other.has_next_page
             )
 
         try:
@@ -102,4 +142,7 @@ class FragmentQueryResult:
         return (
             tuple(self.items) == tuple(other_items)
             and self.match_count_total == other_match_count_total
+            and self.is_match_count_total_exact
+            == getattr(other, "is_match_count_total_exact", True)
+            and self.has_next_page == getattr(other, "has_next_page", None)
         )

--- a/ebl/fragmentarium/domain/fragment_query_summary.py
+++ b/ebl/fragmentarium/domain/fragment_query_summary.py
@@ -27,9 +27,7 @@ def lightweight_token_of(token) -> Dict[str, Any]:
     data = {
         "value": token.value,
         "cleanValue": getattr(token, "clean_value", None),
-        "uniqueLemma": [
-            str(lemma) for lemma in getattr(token, "unique_lemma", ())
-        ],
+        "uniqueLemma": [str(lemma) for lemma in getattr(token, "unique_lemma", ())],
         "type": token.__class__.__name__,
     }
     return {
@@ -103,7 +101,9 @@ class FragmentQuerySummary:
         )
 
 
-def matching_line_preview_of(text: Text, matching_lines: Sequence[int]) -> Dict[str, Any]:
+def matching_line_preview_of(
+    text: Text, matching_lines: Sequence[int]
+) -> Dict[str, Any]:
     return {
         "lines": [
             lightweight_line_preview_of(text.lines[index]) for index in matching_lines

--- a/ebl/fragmentarium/domain/fragment_query_summary.py
+++ b/ebl/fragmentarium/domain/fragment_query_summary.py
@@ -5,6 +5,7 @@ import attr
 from ebl.bibliography.domain.reference import Reference
 from ebl.common.domain.accession import Accession
 from ebl.common.domain.project import ResearchProject
+from ebl.common.query.query_result import compare_query_results
 from ebl.fragmentarium.domain.date import Date
 from ebl.fragmentarium.domain.fragment import DossierReference, Genre, Script
 from ebl.transliteration.domain.atf import DEFAULT_ATF_PARSER_VERSION
@@ -124,25 +125,4 @@ class FragmentQueryResult:
         return FragmentQueryResult([], 0)
 
     def __eq__(self, other):
-        if isinstance(other, FragmentQueryResult):
-            return (
-                tuple(self.items) == tuple(other.items)
-                and self.match_count_total == other.match_count_total
-                and self.is_match_count_total_exact
-                == other.is_match_count_total_exact
-                and self.has_next_page == other.has_next_page
-            )
-
-        try:
-            other_items = other.items
-            other_match_count_total = other.match_count_total
-        except AttributeError:
-            return NotImplemented
-
-        return (
-            tuple(self.items) == tuple(other_items)
-            and self.match_count_total == other_match_count_total
-            and self.is_match_count_total_exact
-            == getattr(other, "is_match_count_total_exact", True)
-            and self.has_next_page == getattr(other, "has_next_page", None)
-        )
+        return compare_query_results(self, other)

--- a/ebl/fragmentarium/domain/fragment_query_summary.py
+++ b/ebl/fragmentarium/domain/fragment_query_summary.py
@@ -2,10 +2,19 @@ from typing import Optional, Sequence
 
 import attr
 
+from ebl.bibliography.domain.reference import Reference
 from ebl.common.domain.accession import Accession
+from ebl.common.domain.project import ResearchProject
 from ebl.fragmentarium.domain.date import Date
-from ebl.fragmentarium.domain.fragment import Genre, Script
+from ebl.fragmentarium.domain.fragment import DossierReference, Genre, Script
 from ebl.transliteration.domain.museum_number import MuseumNumber
+from ebl.transliteration.domain.text import Text
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class FragmentQueryArchaeology:
+    excavation_number: Optional[MuseumNumber] = None
+    site: Optional[str] = None
 
 
 @attr.s(auto_attribs=True, frozen=True, eq=False)
@@ -14,11 +23,16 @@ class FragmentQuerySummary:
     description: str
     script: Script
     matching_lines: Sequence[int] = ()
+    matching_line_preview: Text = attr.Factory(Text)
     match_count: int = 0
     has_photo: bool = False
     accession: Optional[Accession] = None
     date: Optional[Date] = None
     genres: Sequence[Genre] = ()
+    archaeology: Optional[FragmentQueryArchaeology] = None
+    references: Sequence[Reference] = ()
+    projects: Sequence[ResearchProject] = ()
+    dossiers: Sequence[DossierReference] = ()
 
     def __eq__(self, other):
         if isinstance(other, FragmentQuerySummary):
@@ -27,11 +41,16 @@ class FragmentQuerySummary:
                 and self.description == other.description
                 and self.script == other.script
                 and tuple(self.matching_lines) == tuple(other.matching_lines)
+                and self.matching_line_preview == other.matching_line_preview
                 and self.match_count == other.match_count
                 and self.has_photo == other.has_photo
                 and self.accession == other.accession
                 and self.date == other.date
                 and tuple(self.genres) == tuple(other.genres)
+                and self.archaeology == other.archaeology
+                and tuple(self.references) == tuple(other.references)
+                and tuple(self.projects) == tuple(other.projects)
+                and tuple(self.dossiers) == tuple(other.dossiers)
             )
 
         try:

--- a/ebl/fragmentarium/domain/fragment_query_summary.py
+++ b/ebl/fragmentarium/domain/fragment_query_summary.py
@@ -34,24 +34,27 @@ class FragmentQuerySummary:
     projects: Sequence[ResearchProject] = ()
     dossiers: Sequence[DossierReference] = ()
 
+    def _comparison_values(self):
+        return (
+            self.museum_number,
+            self.description,
+            self.script,
+            tuple(self.matching_lines),
+            self.matching_line_preview,
+            self.match_count,
+            self.has_photo,
+            self.accession,
+            self.date,
+            tuple(self.genres),
+            self.archaeology,
+            tuple(self.references),
+            tuple(self.projects),
+            tuple(self.dossiers),
+        )
+
     def __eq__(self, other):
         if isinstance(other, FragmentQuerySummary):
-            return (
-                self.museum_number == other.museum_number
-                and self.description == other.description
-                and self.script == other.script
-                and tuple(self.matching_lines) == tuple(other.matching_lines)
-                and self.matching_line_preview == other.matching_line_preview
-                and self.match_count == other.match_count
-                and self.has_photo == other.has_photo
-                and self.accession == other.accession
-                and self.date == other.date
-                and tuple(self.genres) == tuple(other.genres)
-                and self.archaeology == other.archaeology
-                and tuple(self.references) == tuple(other.references)
-                and tuple(self.projects) == tuple(other.projects)
-                and tuple(self.dossiers) == tuple(other.dossiers)
-            )
+            return self._comparison_values() == other._comparison_values()
 
         try:
             other_museum_number = other.museum_number
@@ -65,6 +68,13 @@ class FragmentQuerySummary:
             and tuple(self.matching_lines) == tuple(other_matching_lines)
             and self.match_count == other_match_count
         )
+
+
+def matching_line_preview_of(text: Text, matching_lines: Sequence[int]) -> Text:
+    return Text.of_iterable(
+        (text.lines[index] for index in matching_lines),
+        text.parser_version,
+    )
 
 
 @attr.s(auto_attribs=True, frozen=True, eq=False)

--- a/ebl/fragmentarium/domain/fragment_query_summary.py
+++ b/ebl/fragmentarium/domain/fragment_query_summary.py
@@ -106,7 +106,9 @@ def matching_line_preview_of(
 ) -> Dict[str, Any]:
     return {
         "lines": [
-            lightweight_line_preview_of(text.lines[index]) for index in matching_lines
+            lightweight_line_preview_of(text.lines[index])
+            for index in matching_lines
+            if 0 <= index < len(text.lines)
         ],
         "parser_version": text.parser_version or DEFAULT_ATF_PARSER_VERSION,
     }
@@ -118,7 +120,6 @@ class FragmentQueryResult:
     match_count_total: Optional[int]
     is_match_count_total_exact: bool = True
     has_next_page: Optional[bool] = None
-    show_count_metadata: bool = False
 
     @staticmethod
     def create_empty() -> "FragmentQueryResult":

--- a/ebl/fragmentarium/domain/fragment_query_summary.py
+++ b/ebl/fragmentarium/domain/fragment_query_summary.py
@@ -1,0 +1,76 @@
+from typing import Optional, Sequence
+
+import attr
+
+from ebl.common.domain.accession import Accession
+from ebl.fragmentarium.domain.date import Date
+from ebl.fragmentarium.domain.fragment import Genre, Script
+from ebl.transliteration.domain.museum_number import MuseumNumber
+
+
+@attr.s(auto_attribs=True, frozen=True, eq=False)
+class FragmentQuerySummary:
+    museum_number: MuseumNumber
+    description: str
+    script: Script
+    matching_lines: Sequence[int] = ()
+    match_count: int = 0
+    has_photo: bool = False
+    accession: Optional[Accession] = None
+    date: Optional[Date] = None
+    genres: Sequence[Genre] = ()
+
+    def __eq__(self, other):
+        if isinstance(other, FragmentQuerySummary):
+            return (
+                self.museum_number == other.museum_number
+                and self.description == other.description
+                and self.script == other.script
+                and tuple(self.matching_lines) == tuple(other.matching_lines)
+                and self.match_count == other.match_count
+                and self.has_photo == other.has_photo
+                and self.accession == other.accession
+                and self.date == other.date
+                and tuple(self.genres) == tuple(other.genres)
+            )
+
+        try:
+            other_museum_number = other.museum_number
+            other_matching_lines = other.matching_lines
+            other_match_count = other.match_count
+        except AttributeError:
+            return NotImplemented
+
+        return (
+            self.museum_number == other_museum_number
+            and tuple(self.matching_lines) == tuple(other_matching_lines)
+            and self.match_count == other_match_count
+        )
+
+
+@attr.s(auto_attribs=True, frozen=True, eq=False)
+class FragmentQueryResult:
+    items: Sequence[FragmentQuerySummary]
+    match_count_total: int
+
+    @staticmethod
+    def create_empty() -> "FragmentQueryResult":
+        return FragmentQueryResult([], 0)
+
+    def __eq__(self, other):
+        if isinstance(other, FragmentQueryResult):
+            return (
+                tuple(self.items) == tuple(other.items)
+                and self.match_count_total == other.match_count_total
+            )
+
+        try:
+            other_items = other.items
+            other_match_count_total = other.match_count_total
+        except AttributeError:
+            return NotImplemented
+
+        return (
+            tuple(self.items) == tuple(other_items)
+            and self.match_count_total == other_match_count_total
+        )

--- a/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
@@ -24,6 +24,17 @@ class LemmaMatcher:
         self.pattern = pattern
         self.query_type = query_type
 
+    @staticmethod
+    def _summary_projection() -> Dict:
+        return {
+            "accession": 1,
+            "date": 1,
+            "description": 1,
+            "genres": 1,
+            "museumNumber": 1,
+            "script": 1,
+        }
+
     def build_pipeline(self, count_matches_per_item=True) -> List[Dict]:
         pipelines = {
             LemmaQueryType.AND: self._and,
@@ -48,10 +59,9 @@ class LemmaMatcher:
         return [
             {
                 "$project": {
-                    "museumNumber": 1,
+                    **self._summary_projection(),
                     "_sortKey": 1,
                     self.flat_path: f"${self.unique_lemma_path}",
-                    "script": 1,
                 }
             },
             {
@@ -70,6 +80,10 @@ class LemmaMatcher:
                     "matchingLines": {"$push": "$lineIndex"},
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
+                    "accession": {"$first": "$accession"},
+                    "date": {"$first": "$date"},
+                    "description": {"$first": "$description"},
+                    "genres": {"$first": "$genres"},
                     "script": {"$first": "$script"},
                     **({"matchCount": {"$sum": 1}} if count_matches_per_item else {}),
                 }
@@ -117,9 +131,8 @@ class LemmaMatcher:
                 "$project": {
                     "ngram": ngrams(f"${self.flat_path}", n=len(self.pattern)),
                     "lineIndex": True,
-                    "museumNumber": True,
+                    **self._summary_projection(),
                     "_sortKey": True,
-                    "script": True,
                 }
             },
             {"$addFields": {"ngram": {"$setUnion": ["$ngram", []]}}},

--- a/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
@@ -1,5 +1,6 @@
 from ebl.common.query.query_result import LemmaQueryType
 from ebl.common.query.util import flatten_field, drop_duplicates, ngrams
+from ebl.fragmentarium.infrastructure.queries import fragment_summary_projection
 from typing import List, Dict
 
 
@@ -23,26 +24,6 @@ class LemmaMatcher:
     ):
         self.pattern = pattern
         self.query_type = query_type
-
-    @staticmethod
-    def _summary_projection() -> Dict:
-        return {
-            "accession": 1,
-            "archaeology": {
-                "excavationNumber": "$archaeology.excavationNumber",
-                "site": "$archaeology.site",
-            },
-            "date": 1,
-            "description": 1,
-            "dossiers": 1,
-            "genres": 1,
-            "museumNumber": 1,
-            "projects": 1,
-            "references": 1,
-            "script": 1,
-            "textLines": "$text.lines",
-            "textParserVersion": "$text.parser_version",
-        }
 
     def build_pipeline(self, count_matches_per_item=True) -> List[Dict]:
         pipelines = {
@@ -68,7 +49,7 @@ class LemmaMatcher:
         return [
             {
                 "$project": {
-                    **self._summary_projection(),
+                    **fragment_summary_projection(),
                     "_sortKey": 1,
                     self.flat_path: f"${self.unique_lemma_path}",
                 }

--- a/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
@@ -28,11 +28,20 @@ class LemmaMatcher:
     def _summary_projection() -> Dict:
         return {
             "accession": 1,
+            "archaeology": {
+                "excavationNumber": "$archaeology.excavationNumber",
+                "site": "$archaeology.site",
+            },
             "date": 1,
             "description": 1,
+            "dossiers": 1,
             "genres": 1,
             "museumNumber": 1,
+            "projects": 1,
+            "references": 1,
             "script": 1,
+            "textLines": "$text.lines",
+            "textParserVersion": "$text.parser_version",
         }
 
     def build_pipeline(self, count_matches_per_item=True) -> List[Dict]:
@@ -81,10 +90,16 @@ class LemmaMatcher:
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
                     "accession": {"$first": "$accession"},
+                    "archaeology": {"$first": "$archaeology"},
                     "date": {"$first": "$date"},
                     "description": {"$first": "$description"},
+                    "dossiers": {"$first": "$dossiers"},
                     "genres": {"$first": "$genres"},
+                    "projects": {"$first": "$projects"},
+                    "references": {"$first": "$references"},
                     "script": {"$first": "$script"},
+                    "textLines": {"$first": "$textLines"},
+                    "textParserVersion": {"$first": "$textParserVersion"},
                     **({"matchCount": {"$sum": 1}} if count_matches_per_item else {}),
                 }
             },
@@ -131,7 +146,18 @@ class LemmaMatcher:
                 "$project": {
                     "ngram": ngrams(f"${self.flat_path}", n=len(self.pattern)),
                     "lineIndex": True,
-                    **self._summary_projection(),
+                    "accession": True,
+                    "archaeology": True,
+                    "date": True,
+                    "description": True,
+                    "dossiers": True,
+                    "genres": True,
+                    "museumNumber": True,
+                    "projects": True,
+                    "references": True,
+                    "script": True,
+                    "textLines": True,
+                    "textParserVersion": True,
                     "_sortKey": True,
                 }
             },

--- a/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
@@ -1,6 +1,8 @@
 from ebl.common.query.query_result import LemmaQueryType
 from ebl.common.query.util import flatten_field, drop_duplicates, ngrams
-from ebl.fragmentarium.infrastructure.queries import fragment_summary_projection
+from ebl.fragmentarium.infrastructure.queries import (
+    fragment_summary_projection_lightweight,
+)
 from typing import List, Dict
 
 
@@ -49,7 +51,7 @@ class LemmaMatcher:
         return [
             {
                 "$project": {
-                    **fragment_summary_projection(),
+                    **fragment_summary_projection_lightweight(),
                     "_sortKey": 1,
                     self.flat_path: f"${self.unique_lemma_path}",
                 }
@@ -79,8 +81,6 @@ class LemmaMatcher:
                     "projects": {"$first": "$projects"},
                     "references": {"$first": "$references"},
                     "script": {"$first": "$script"},
-                    "textLines": {"$first": "$textLines"},
-                    "textParserVersion": {"$first": "$textParserVersion"},
                     **({"matchCount": {"$sum": 1}} if count_matches_per_item else {}),
                 }
             },
@@ -137,8 +137,6 @@ class LemmaMatcher:
                     "projects": True,
                     "references": True,
                     "script": True,
-                    "textLines": True,
-                    "textParserVersion": True,
                     "_sortKey": True,
                 }
             },

--- a/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_lemma_matcher.py
@@ -1,8 +1,5 @@
 from ebl.common.query.query_result import LemmaQueryType
 from ebl.common.query.util import flatten_field, drop_duplicates, ngrams
-from ebl.fragmentarium.infrastructure.queries import (
-    fragment_summary_projection_lightweight,
-)
 from typing import List, Dict
 
 
@@ -51,8 +48,9 @@ class LemmaMatcher:
         return [
             {
                 "$project": {
-                    **fragment_summary_projection_lightweight(),
+                    "museumNumber": 1,
                     "_sortKey": 1,
+                    "_scriptSortKey": "$script.sortKey",
                     self.flat_path: f"${self.unique_lemma_path}",
                 }
             },
@@ -72,15 +70,7 @@ class LemmaMatcher:
                     "matchingLines": {"$push": "$lineIndex"},
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
-                    "accession": {"$first": "$accession"},
-                    "archaeology": {"$first": "$archaeology"},
-                    "date": {"$first": "$date"},
-                    "description": {"$first": "$description"},
-                    "dossiers": {"$first": "$dossiers"},
-                    "genres": {"$first": "$genres"},
-                    "projects": {"$first": "$projects"},
-                    "references": {"$first": "$references"},
-                    "script": {"$first": "$script"},
+                    "_scriptSortKey": {"$first": "$_scriptSortKey"},
                     **({"matchCount": {"$sum": 1}} if count_matches_per_item else {}),
                 }
             },
@@ -127,17 +117,9 @@ class LemmaMatcher:
                 "$project": {
                     "ngram": ngrams(f"${self.flat_path}", n=len(self.pattern)),
                     "lineIndex": True,
-                    "accession": True,
-                    "archaeology": True,
-                    "date": True,
-                    "description": True,
-                    "dossiers": True,
-                    "genres": True,
                     "museumNumber": True,
-                    "projects": True,
-                    "references": True,
-                    "script": True,
                     "_sortKey": True,
+                    "_scriptSortKey": True,
                 }
             },
             {"$addFields": {"ngram": {"$setUnion": ["$ngram", []]}}},

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -1,6 +1,10 @@
 from typing import List, Dict, Sequence, Optional
 from ebl.common.domain.scopes import Scope
-from ebl.fragmentarium.infrastructure.queries import number_is, match_user_scopes
+from ebl.fragmentarium.infrastructure.queries import (
+    fragment_photo_filename_expression,
+    match_user_scopes,
+    number_is,
+)
 from ebl.fragmentarium.infrastructure.fragment_lemma_matcher import (
     LemmaMatcher,
     EmptyMatcher,
@@ -45,28 +49,14 @@ class PatternMatcher:
     def _sort_by(self, sort_fields: Optional[Dict] = None) -> List[Dict]:
         return [{"$sort": sort_fields}] if sort_fields else []
 
-    @staticmethod
-    def _photo_filename_expression() -> Dict:
-        return {
-            "$concat": [
-                "$museumNumber.prefix",
-                ".",
-                "$museumNumber.number",
-                {
-                    "$cond": {
-                        "if": {"$eq": ["$museumNumber.suffix", ""]},
-                        "then": "",
-                        "else": {"$concat": [".", "$museumNumber.suffix"]},
-                    }
-                },
-                ".jpg",
-            ]
-        }
-
     def _items_pipeline(self) -> List[Dict]:
         return [
             *self._limit_result(),
-            {"$addFields": {"filename": self._photo_filename_expression()}},
+            {
+                "$addFields": {
+                    "filename": fragment_photo_filename_expression(),
+                }
+            },
             {
                 "$lookup": {
                     "from": "photos.files",

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -81,16 +81,40 @@ class PatternMatcher:
                 }
             },
             {
+                "$addFields": {
+                    "matchingLinePreview": {
+                        "lines": {
+                            "$map": {
+                                "input": {"$ifNull": ["$matchingLines", []]},
+                                "as": "lineIndex",
+                                "in": {
+                                    "$arrayElemAt": [
+                                        {"$ifNull": ["$textLines", []]},
+                                        "$$lineIndex",
+                                    ]
+                                },
+                            }
+                        },
+                        "parser_version": "$textParserVersion",
+                    }
+                }
+            },
+            {
                 "$project": {
                     "_id": False,
                     "accession": True,
+                    "archaeology": True,
                     "date": True,
                     "description": True,
+                    "dossiers": True,
                     "genres": True,
                     "hasPhoto": True,
                     "matchCount": True,
                     "matchingLines": True,
+                    "matchingLinePreview": True,
                     "museumNumber": True,
+                    "projects": True,
+                    "references": True,
                     "script": True,
                 }
             },
@@ -188,12 +212,21 @@ class PatternMatcher:
                     "_id": True,
                     "museumNumber": True,
                     "accession": True,
+                    "archaeology": {
+                        "excavationNumber": "$archaeology.excavationNumber",
+                        "site": "$archaeology.site",
+                    },
                     "date": True,
                     "description": True,
+                    "dossiers": True,
                     "genres": True,
-                    "matchingLines": [],
+                    "matchingLines": {"$literal": []},
                     "matchCount": {"$literal": 0},
                     "script": True,
+                    "projects": True,
+                    "references": True,
+                    "textLines": {"$literal": []},
+                    "textParserVersion": "$text.parser_version",
                 }
             },
         ]
@@ -224,10 +257,16 @@ class PatternMatcher:
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
                     "accession": {"$first": "$accession"},
+                    "archaeology": {"$first": "$archaeology"},
                     "date": {"$first": "$date"},
                     "description": {"$first": "$description"},
+                    "dossiers": {"$first": "$dossiers"},
                     "genres": {"$first": "$genres"},
+                    "projects": {"$first": "$projects"},
+                    "references": {"$first": "$references"},
                     "script": {"$first": "$script"},
+                    "textLines": {"$first": "$textLines"},
+                    "textParserVersion": {"$first": "$textParserVersion"},
                 },
             },
             {

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -1,7 +1,6 @@
 from typing import List, Dict, Sequence, Optional
 from ebl.common.domain.scopes import Scope
 from ebl.fragmentarium.infrastructure.queries import (
-    fragment_photo_filename_expression,
     match_user_scopes,
     number_is,
 )
@@ -15,6 +14,10 @@ from ebl.provenance.application.provenance_service import ProvenanceService
 from ebl.provenance.domain.provenance_model import ProvenanceRecord
 
 from pydash.arrays import compact
+
+EXACT_COUNT = "exact"
+NO_COUNT = "none"
+PAGE_COUNT = "page"
 
 
 class PatternMatcher:
@@ -44,108 +47,61 @@ class PatternMatcher:
         )
 
     def _limit_result(self):
-        return [{"$limit": self._query["limit"]}] if "limit" in self._query else []
+        return (
+            [{"$limit": self._limit_value()}]
+            if "limit" in self._query
+            else []
+        )
+
+    def _limit_value(self):
+        limit = self._query["limit"]
+        return limit + 1 if self._count_mode() == PAGE_COUNT else limit
+
+    def _count_mode(self):
+        return self._query.get("count", EXACT_COUNT)
+
+    def _count_is_exact(self):
+        return self._count_mode() == EXACT_COUNT
+
+    def _skip_result(self):
+        return [{"$skip": self._query["offset"]}] if self._query.get("offset") else []
 
     def _sort_by(self, sort_fields: Optional[Dict] = None) -> List[Dict]:
         return [{"$sort": sort_fields}] if sort_fields else []
 
-    def _items_pipeline(self) -> List[Dict]:
+    def _summary_items_pipeline(self) -> List[Dict]:
         return [
+            *self._skip_result(),
             *self._limit_result(),
             {
-                "$addFields": {
-                    "filename": fragment_photo_filename_expression(),
-                }
-            },
-            {
-                "$lookup": {
-                    "from": "photos.files",
-                    "localField": "filename",
-                    "foreignField": "filename",
-                    "as": "photoFiles",
-                }
-            },
-            {
-                "$addFields": {
-                    "hasPhoto": {"$gt": [{"$size": "$photoFiles"}, 0]},
-                }
-            },
-            {
-                "$lookup": {
-                    "from": "fragments",
-                    "let": {"fid": "$_id"},
-                    "pipeline": [
-                        {"$match": {"$expr": {"$eq": ["$_id", "$$fid"]}}},
-                        {
-                            "$project": {
-                                "textLines": "$text.lines",
-                                "textParserVersion": "$text.parser_version",
-                            }
-                        },
-                    ],
-                    "as": "_textData",
-                }
-            },
-            {
-                "$addFields": {
-                    "textLines": {
-                        "$ifNull": [
-                            {"$arrayElemAt": ["$_textData.textLines", 0]},
-                            [],
-                        ]
-                    },
-                    "textParserVersion": {
-                        "$ifNull": [
-                            {
-                                "$arrayElemAt": [
-                                    "$_textData.textParserVersion",
-                                    0,
-                                ]
-                            },
-                            None,
-                        ]
-                    },
-                }
-            },
-            {
-                "$addFields": {
-                    "matchingLinePreview": {
-                        "lines": {
-                            "$map": {
-                                "input": {"$ifNull": ["$matchingLines", []]},
-                                "as": "lineIndex",
-                                "in": {
-                                    "$arrayElemAt": [
-                                        "$textLines",
-                                        "$$lineIndex",
-                                    ]
-                                },
-                            }
-                        },
-                        "parser_version": "$textParserVersion",
-                    }
-                }
-            },
-            {
                 "$project": {
-                    "_id": False,
-                    "accession": True,
-                    "archaeology": True,
-                    "date": True,
-                    "description": True,
-                    "dossiers": True,
-                    "genres": True,
-                    "hasPhoto": True,
+                    "_id": True,
                     "matchCount": True,
                     "matchingLines": True,
-                    "matchingLinePreview": True,
                     "museumNumber": True,
-                    "projects": True,
-                    "references": True,
-                    "script": True,
                 }
             },
         ]
+
+    def _lean_items_pipeline(self) -> List[Dict]:
+        return [
+            *self._skip_result(),
+            {
+                "$project": {
+                    "_id": False,
+                    "museumNumber": True,
+                    "matchingLines": True,
+                    "matchCount": True,
+                }
+            },
+        ]
+
+    def _items_pipeline(self) -> List[Dict]:
+        return (
+            self._summary_items_pipeline()
+            if "limit" in self._query
+            else self._lean_items_pipeline()
+        )
 
     def _filter_by_script(self) -> Dict:
         parameters = {
@@ -238,20 +194,10 @@ class PatternMatcher:
                 "$project": {
                     "_id": True,
                     "museumNumber": True,
-                    "accession": True,
-                    "archaeology": {
-                        "excavationNumber": "$archaeology.excavationNumber",
-                        "site": "$archaeology.site",
-                    },
-                    "date": True,
-                    "description": True,
-                    "dossiers": True,
-                    "genres": True,
                     "matchingLines": {"$literal": []},
                     "matchCount": {"$literal": 0},
-                    "script": True,
-                    "projects": True,
-                    "references": True,
+                    "_sortKey": True,
+                    "_scriptSortKey": "$script.sortKey",
                 }
             },
         ]
@@ -281,15 +227,7 @@ class PatternMatcher:
                     "matchingLines": {"$push": "$matchingLines"},
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
-                    "accession": {"$first": "$accession"},
-                    "archaeology": {"$first": "$archaeology"},
-                    "date": {"$first": "$date"},
-                    "description": {"$first": "$description"},
-                    "dossiers": {"$first": "$dossiers"},
-                    "genres": {"$first": "$genres"},
-                    "projects": {"$first": "$projects"},
-                    "references": {"$first": "$references"},
-                    "script": {"$first": "$script"},
+                    "_scriptSortKey": {"$first": "$_scriptSortKey"},
                 },
             },
             {
@@ -334,31 +272,55 @@ class PatternMatcher:
             isinstance(self._sign_matcher, SignMatcher),
         )
 
+        facet = {
+            "items": [
+                *self._sort_by({"_scriptSortKey": 1, "_sortKey": 1}),
+                *self._items_pipeline(),
+            ],
+        }
+        if self._count_is_exact():
+            facet["count"] = self._count_pipeline()
+
         return [
             *self._prefilter(),
             *dispatcher[key](),
-            {
-                "$facet": {
-                    "items": [
-                        *self._sort_by({"script.sortKey": 1, "_sortKey": 1}),
-                        *self._items_pipeline(),
-                    ],
-                    "count": self._count_pipeline(),
-                }
-            },
-            {
-                "$project": {
-                    "_id": False,
-                    "items": True,
-                    "matchCountTotal": {
-                        "$ifNull": [
-                            {"$arrayElemAt": ["$count.matchCountTotal", 0]},
-                            0,
-                        ]
-                    },
-                }
-            },
+            {"$facet": facet},
+            {"$project": self._result_projection()},
         ]
 
     def build_pipeline(self) -> List[Dict]:
         return self._get_pipeline_components()
+
+    def _result_projection(self):
+        return {
+            "_id": False,
+            "items": self._items_projection(),
+            "matchCountTotal": self._match_count_total_projection(),
+            "isMatchCountTotalExact": {"$literal": self._count_is_exact()},
+            "hasNextPage": self._has_next_page_projection(),
+            "_showCountMetadata": {"$literal": True},
+        }
+
+    def _items_projection(self):
+        if self._count_mode() == PAGE_COUNT and "limit" in self._query:
+            return {"$slice": ["$items", self._query["limit"]]}
+        return True
+
+    def _match_count_total_projection(self):
+        if self._count_is_exact():
+            return {
+                "$ifNull": [
+                    {"$arrayElemAt": ["$count.matchCountTotal", 0]},
+                    0,
+                ]
+            }
+        return {"$literal": None}
+
+    def _has_next_page_projection(self):
+        if self._count_mode() == PAGE_COUNT:
+            return (
+                {"$gt": [{"$size": "$items"}, self._query["limit"]]}
+                if "limit" in self._query
+                else {"$literal": False}
+            )
+        return {"$literal": None}

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -47,11 +47,7 @@ class PatternMatcher:
         )
 
     def _limit_result(self):
-        return (
-            [{"$limit": self._limit_value()}]
-            if "limit" in self._query
-            else []
-        )
+        return [{"$limit": self._limit_value()}] if "limit" in self._query else []
 
     def _limit_value(self):
         limit = self._query["limit"]

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -283,9 +283,7 @@ class PatternMatcher:
             {
                 "$group": {
                     "_id": None,
-                    "matchCountTotal": {
-                        "$sum": {"$ifNull": ["$matchCount", 0]}
-                    },
+                    "matchCountTotal": {"$sum": {"$ifNull": ["$matchCount", 0]}},
                 }
             },
             {"$project": {"_id": False, "matchCountTotal": True}},

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -10,14 +10,16 @@ from ebl.fragmentarium.infrastructure.fragment_lemma_matcher import (
 )
 from ebl.common.query.query_result import LemmaQueryType
 from ebl.fragmentarium.infrastructure.fragment_sign_matcher import SignMatcher
+from ebl.fragmentarium.infrastructure.fragment_query_result_projection import (
+    count_is_exact,
+    count_pipeline,
+    items_pipeline,
+    result_projection,
+)
 from ebl.provenance.application.provenance_service import ProvenanceService
 from ebl.provenance.domain.provenance_model import ProvenanceRecord
 
 from pydash.arrays import compact
-
-EXACT_COUNT = "exact"
-NO_COUNT = "none"
-PAGE_COUNT = "page"
 
 
 class PatternMatcher:
@@ -46,58 +48,8 @@ class PatternMatcher:
             else EmptyMatcher()
         )
 
-    def _limit_result(self):
-        return [{"$limit": self._limit_value()}] if "limit" in self._query else []
-
-    def _limit_value(self):
-        limit = self._query["limit"]
-        return limit + 1 if self._count_mode() == PAGE_COUNT else limit
-
-    def _count_mode(self):
-        return self._query.get("count", EXACT_COUNT)
-
-    def _count_is_exact(self):
-        return self._count_mode() == EXACT_COUNT
-
-    def _skip_result(self):
-        return [{"$skip": self._query["offset"]}] if self._query.get("offset") else []
-
     def _sort_by(self, sort_fields: Optional[Dict] = None) -> List[Dict]:
         return [{"$sort": sort_fields}] if sort_fields else []
-
-    def _summary_items_pipeline(self) -> List[Dict]:
-        return [
-            *self._skip_result(),
-            *self._limit_result(),
-            {
-                "$project": {
-                    "_id": True,
-                    "matchCount": True,
-                    "matchingLines": True,
-                    "museumNumber": True,
-                }
-            },
-        ]
-
-    def _lean_items_pipeline(self) -> List[Dict]:
-        return [
-            *self._skip_result(),
-            {
-                "$project": {
-                    "_id": False,
-                    "museumNumber": True,
-                    "matchingLines": True,
-                    "matchCount": True,
-                }
-            },
-        ]
-
-    def _items_pipeline(self) -> List[Dict]:
-        return (
-            self._summary_items_pipeline()
-            if "limit" in self._query
-            else self._lean_items_pipeline()
-        )
 
     def _filter_by_script(self) -> Dict:
         parameters = {
@@ -245,17 +197,6 @@ class PatternMatcher:
             {"$match": {"matchCount": {"$gt": 0}}},
         ]
 
-    def _count_pipeline(self) -> List[Dict]:
-        return [
-            {
-                "$group": {
-                    "_id": None,
-                    "matchCountTotal": {"$sum": {"$ifNull": ["$matchCount", 0]}},
-                }
-            },
-            {"$project": {"_id": False, "matchCountTotal": True}},
-        ]
-
     def _get_pipeline_components(self) -> List[Dict]:
         dispatcher = {
             (True, True): self._merge_pipelines,
@@ -271,52 +212,18 @@ class PatternMatcher:
         facet = {
             "items": [
                 *self._sort_by({"_scriptSortKey": 1, "_sortKey": 1}),
-                *self._items_pipeline(),
+                *items_pipeline(self._query),
             ],
         }
-        if self._count_is_exact():
-            facet["count"] = self._count_pipeline()
+        if count_is_exact(self._query):
+            facet["count"] = count_pipeline()
 
         return [
             *self._prefilter(),
             *dispatcher[key](),
             {"$facet": facet},
-            {"$project": self._result_projection()},
+            {"$project": result_projection(self._query)},
         ]
 
     def build_pipeline(self) -> List[Dict]:
         return self._get_pipeline_components()
-
-    def _result_projection(self):
-        return {
-            "_id": False,
-            "items": self._items_projection(),
-            "matchCountTotal": self._match_count_total_projection(),
-            "isMatchCountTotalExact": {"$literal": self._count_is_exact()},
-            "hasNextPage": self._has_next_page_projection(),
-            "_showCountMetadata": {"$literal": True},
-        }
-
-    def _items_projection(self):
-        if self._count_mode() == PAGE_COUNT and "limit" in self._query:
-            return {"$slice": ["$items", self._query["limit"]]}
-        return True
-
-    def _match_count_total_projection(self):
-        if self._count_is_exact():
-            return {
-                "$ifNull": [
-                    {"$arrayElemAt": ["$count.matchCountTotal", 0]},
-                    0,
-                ]
-            }
-        return {"$literal": None}
-
-    def _has_next_page_projection(self):
-        if self._count_mode() == PAGE_COUNT:
-            return (
-                {"$gt": [{"$size": "$items"}, self._query["limit"]]}
-                if "limit" in self._query
-                else {"$literal": False}
-            )
-        return {"$literal": None}

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -71,6 +71,43 @@ class PatternMatcher:
                 }
             },
             {
+                "$lookup": {
+                    "from": "fragments",
+                    "let": {"fid": "$_id"},
+                    "pipeline": [
+                        {"$match": {"$expr": {"$eq": ["$_id", "$$fid"]}}},
+                        {
+                            "$project": {
+                                "textLines": "$text.lines",
+                                "textParserVersion": "$text.parser_version",
+                            }
+                        },
+                    ],
+                    "as": "_textData",
+                }
+            },
+            {
+                "$addFields": {
+                    "textLines": {
+                        "$ifNull": [
+                            {"$arrayElemAt": ["$_textData.textLines", 0]},
+                            [],
+                        ]
+                    },
+                    "textParserVersion": {
+                        "$ifNull": [
+                            {
+                                "$arrayElemAt": [
+                                    "$_textData.textParserVersion",
+                                    0,
+                                ]
+                            },
+                            None,
+                        ]
+                    },
+                }
+            },
+            {
                 "$addFields": {
                     "matchingLinePreview": {
                         "lines": {
@@ -79,7 +116,7 @@ class PatternMatcher:
                                 "as": "lineIndex",
                                 "in": {
                                     "$arrayElemAt": [
-                                        {"$ifNull": ["$textLines", []]},
+                                        "$textLines",
                                         "$$lineIndex",
                                     ]
                                 },
@@ -215,8 +252,6 @@ class PatternMatcher:
                     "script": True,
                     "projects": True,
                     "references": True,
-                    "textLines": {"$literal": []},
-                    "textParserVersion": "$text.parser_version",
                 }
             },
         ]
@@ -255,8 +290,6 @@ class PatternMatcher:
                     "projects": {"$first": "$projects"},
                     "references": {"$first": "$references"},
                     "script": {"$first": "$script"},
-                    "textLines": {"$first": "$textLines"},
-                    "textParserVersion": {"$first": "$textParserVersion"},
                 },
             },
             {

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -45,21 +45,55 @@ class PatternMatcher:
     def _sort_by(self, sort_fields: Optional[Dict] = None) -> List[Dict]:
         return [{"$sort": sort_fields}] if sort_fields else []
 
-    def _wrap_query_items_with_total(
-        self, sort_fields: Optional[Dict] = None
-    ) -> List[Dict]:
+    @staticmethod
+    def _photo_filename_expression() -> Dict:
+        return {
+            "$concat": [
+                "$museumNumber.prefix",
+                ".",
+                "$museumNumber.number",
+                {
+                    "$cond": {
+                        "if": {"$eq": ["$museumNumber.suffix", ""]},
+                        "then": "",
+                        "else": {"$concat": [".", "$museumNumber.suffix"]},
+                    }
+                },
+                ".jpg",
+            ]
+        }
+
+    def _items_pipeline(self) -> List[Dict]:
         return [
-            *self._sort_by(sort_fields),
             *self._limit_result(),
-            {"$project": {"_id": False, "script": False, "_sortKey": False}},
+            {"$addFields": {"filename": self._photo_filename_expression()}},
             {
-                "$group": {
-                    "_id": None,
-                    "items": {"$push": "$$ROOT"},
-                    "matchCountTotal": {"$sum": "$matchCount"},
+                "$lookup": {
+                    "from": "photos.files",
+                    "localField": "filename",
+                    "foreignField": "filename",
+                    "as": "photoFiles",
                 }
             },
-            {"$project": {"_id": False}},
+            {
+                "$addFields": {
+                    "hasPhoto": {"$gt": [{"$size": "$photoFiles"}, 0]},
+                }
+            },
+            {
+                "$project": {
+                    "_id": False,
+                    "accession": True,
+                    "date": True,
+                    "description": True,
+                    "genres": True,
+                    "hasPhoto": True,
+                    "matchCount": True,
+                    "matchingLines": True,
+                    "museumNumber": True,
+                    "script": True,
+                }
+            },
         ]
 
     def _filter_by_script(self) -> Dict:
@@ -153,6 +187,10 @@ class PatternMatcher:
                 "$project": {
                     "_id": True,
                     "museumNumber": True,
+                    "accession": True,
+                    "date": True,
+                    "description": True,
+                    "genres": True,
                     "matchingLines": [],
                     "matchCount": {"$literal": 0},
                     "script": True,
@@ -185,6 +223,11 @@ class PatternMatcher:
                     "matchingLines": {"$push": "$matchingLines"},
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
+                    "accession": {"$first": "$accession"},
+                    "date": {"$first": "$date"},
+                    "description": {"$first": "$description"},
+                    "genres": {"$first": "$genres"},
+                    "script": {"$first": "$script"},
                 },
             },
             {
@@ -206,6 +249,19 @@ class PatternMatcher:
             {"$match": {"matchCount": {"$gt": 0}}},
         ]
 
+    def _count_pipeline(self) -> List[Dict]:
+        return [
+            {
+                "$group": {
+                    "_id": None,
+                    "matchCountTotal": {
+                        "$sum": {"$ifNull": ["$matchCount", 0]}
+                    },
+                }
+            },
+            {"$project": {"_id": False, "matchCountTotal": True}},
+        ]
+
     def _get_pipeline_components(self) -> List[Dict]:
         dispatcher = {
             (True, True): self._merge_pipelines,
@@ -221,9 +277,27 @@ class PatternMatcher:
         return [
             *self._prefilter(),
             *dispatcher[key](),
-            *self._wrap_query_items_with_total(
-                sort_fields={"script.sortKey": 1, "_sortKey": 1}
-            ),
+            {
+                "$facet": {
+                    "items": [
+                        *self._sort_by({"script.sortKey": 1, "_sortKey": 1}),
+                        *self._items_pipeline(),
+                    ],
+                    "count": self._count_pipeline(),
+                }
+            },
+            {
+                "$project": {
+                    "_id": False,
+                    "items": True,
+                    "matchCountTotal": {
+                        "$ifNull": [
+                            {"$arrayElemAt": ["$count.matchCountTotal", 0]},
+                            0,
+                        ]
+                    },
+                }
+            },
         ]
 
     def build_pipeline(self) -> List[Dict]:

--- a/ebl/fragmentarium/infrastructure/fragment_query_result_projection.py
+++ b/ebl/fragmentarium/infrastructure/fragment_query_result_projection.py
@@ -1,0 +1,97 @@
+from typing import Dict, List
+
+EXACT_COUNT = "exact"
+PAGE_COUNT = "page"
+
+
+def count_mode(query: Dict) -> str:
+    return query.get("count", EXACT_COUNT)
+
+
+def count_is_exact(query: Dict) -> bool:
+    return count_mode(query) == EXACT_COUNT
+
+
+def _limit_result(query: Dict) -> List[Dict]:
+    limit = query["limit"]
+    return [{"$limit": limit + 1 if count_mode(query) == PAGE_COUNT else limit}]
+
+
+def _skip_result(query: Dict) -> List[Dict]:
+    return [{"$skip": query["offset"]}] if query.get("offset") else []
+
+
+def items_pipeline(query: Dict) -> List[Dict]:
+    if "limit" in query:
+        return [
+            *_skip_result(query),
+            *_limit_result(query),
+            {
+                "$project": {
+                    "_id": True,
+                    "matchCount": True,
+                    "matchingLines": True,
+                    "museumNumber": True,
+                }
+            },
+        ]
+    return [
+        *_skip_result(query),
+        {
+            "$project": {
+                "_id": False,
+                "museumNumber": True,
+                "matchingLines": True,
+                "matchCount": True,
+            }
+        },
+    ]
+
+
+def count_pipeline() -> List[Dict]:
+    return [
+        {
+            "$group": {
+                "_id": None,
+                "matchCountTotal": {"$sum": {"$ifNull": ["$matchCount", 0]}},
+            }
+        },
+        {"$project": {"_id": False, "matchCountTotal": True}},
+    ]
+
+
+def _items_projection(query: Dict):
+    if count_mode(query) == PAGE_COUNT and "limit" in query:
+        return {"$slice": ["$items", query["limit"]]}
+    return True
+
+
+def _match_count_total_projection(query: Dict):
+    if count_is_exact(query):
+        return {
+            "$ifNull": [
+                {"$arrayElemAt": ["$count.matchCountTotal", 0]},
+                0,
+            ]
+        }
+    return {"$literal": None}
+
+
+def _has_next_page_projection(query: Dict):
+    if count_mode(query) == PAGE_COUNT:
+        return (
+            {"$gt": [{"$size": "$items"}, query["limit"]]}
+            if "limit" in query
+            else {"$literal": False}
+        )
+    return {"$literal": None}
+
+
+def result_projection(query: Dict) -> Dict:
+    return {
+        "_id": False,
+        "items": _items_projection(query),
+        "matchCountTotal": _match_count_total_projection(query),
+        "isMatchCountTotalExact": {"$literal": count_is_exact(query)},
+        "hasNextPage": _has_next_page_projection(query),
+    }

--- a/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
@@ -1,8 +1,5 @@
 from typing import List, Dict
 from ebl.common.query.util import flatten_field, ngrams
-from ebl.fragmentarium.infrastructure.queries import (
-    fragment_summary_projection_lightweight,
-)
 
 
 class SignMatcher:
@@ -38,6 +35,10 @@ class SignMatcher:
             },
         ]
 
+    def _prefilter_signs(self) -> List[Dict]:
+        predicates = [{"signs": {"$regex": pattern}} for pattern in self.pattern]
+        return [{"$match": {"$and": predicates}}] if predicates else []
+
     def _expand_line_ranges(self) -> Dict:
         return {
             "$map": {
@@ -61,8 +62,9 @@ class SignMatcher:
         return [
             {
                 "$project": {
-                    **fragment_summary_projection_lightweight(),
+                    "museumNumber": True,
                     "_sortKey": True,
+                    "_scriptSortKey": "$script.sortKey",
                     "lineTypes": "$text.lines.type",
                     "signs": True,
                 }
@@ -74,15 +76,7 @@ class SignMatcher:
                     "_id": "$_id",
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
-                    "accession": {"$first": "$accession"},
-                    "archaeology": {"$first": "$archaeology"},
-                    "date": {"$first": "$date"},
-                    "description": {"$first": "$description"},
-                    "dossiers": {"$first": "$dossiers"},
-                    "genres": {"$first": "$genres"},
-                    "projects": {"$first": "$projects"},
-                    "references": {"$first": "$references"},
-                    "script": {"$first": "$script"},
+                    "_scriptSortKey": {"$first": "$_scriptSortKey"},
                     "textLineIndices": {"$push": "$lineIndex"},
                     "signLines": {"$first": {"$split": ["$signs", "\n"]}},
                 }
@@ -91,6 +85,7 @@ class SignMatcher:
 
     def build_pipeline(self, count_matches_per_item=True) -> List[Dict]:
         return [
+            *self._prefilter_signs(),
             *self._map_signs_to_textlines(),
             *(
                 self._match_multiline()
@@ -102,15 +97,7 @@ class SignMatcher:
                     "_id": "$_id",
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
-                    "accession": {"$first": "$accession"},
-                    "archaeology": {"$first": "$archaeology"},
-                    "date": {"$first": "$date"},
-                    "description": {"$first": "$description"},
-                    "dossiers": {"$first": "$dossiers"},
-                    "genres": {"$first": "$genres"},
-                    "projects": {"$first": "$projects"},
-                    "references": {"$first": "$references"},
-                    "script": {"$first": "$script"},
+                    "_scriptSortKey": {"$first": "$_scriptSortKey"},
                     "matchingLines": {
                         "$push": (
                             self._expand_line_ranges()

--- a/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
@@ -3,6 +3,17 @@ from ebl.common.query.util import flatten_field, ngrams
 
 
 class SignMatcher:
+    @staticmethod
+    def _summary_projection() -> Dict:
+        return {
+            "accession": 1,
+            "date": 1,
+            "description": 1,
+            "genres": 1,
+            "museumNumber": 1,
+            "script": 1,
+        }
+
     def __init__(self, pattern: List[str]):
         self.pattern = pattern
         self._pattern_length = len(pattern)
@@ -58,9 +69,8 @@ class SignMatcher:
         return [
             {
                 "$project": {
-                    "museumNumber": True,
+                    **self._summary_projection(),
                     "_sortKey": True,
-                    "script": True,
                     "lineTypes": "$text.lines.type",
                     "signs": True,
                 }
@@ -72,6 +82,10 @@ class SignMatcher:
                     "_id": "$_id",
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
+                    "accession": {"$first": "$accession"},
+                    "date": {"$first": "$date"},
+                    "description": {"$first": "$description"},
+                    "genres": {"$first": "$genres"},
                     "script": {"$first": "$script"},
                     "textLines": {"$push": "$lineIndex"},
                     "signLines": {"$first": {"$split": ["$signs", "\n"]}},
@@ -92,6 +106,10 @@ class SignMatcher:
                     "_id": "$_id",
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
+                    "accession": {"$first": "$accession"},
+                    "date": {"$first": "$date"},
+                    "description": {"$first": "$description"},
+                    "genres": {"$first": "$genres"},
                     "script": {"$first": "$script"},
                     "matchingLines": {
                         "$push": (

--- a/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
@@ -1,28 +1,9 @@
 from typing import List, Dict
 from ebl.common.query.util import flatten_field, ngrams
+from ebl.fragmentarium.infrastructure.queries import fragment_summary_projection
 
 
 class SignMatcher:
-    @staticmethod
-    def _summary_projection() -> Dict:
-        return {
-            "accession": 1,
-            "archaeology": {
-                "excavationNumber": "$archaeology.excavationNumber",
-                "site": "$archaeology.site",
-            },
-            "date": 1,
-            "description": 1,
-            "dossiers": 1,
-            "genres": 1,
-            "museumNumber": 1,
-            "projects": 1,
-            "references": 1,
-            "script": 1,
-            "textLines": "$text.lines",
-            "textParserVersion": "$text.parser_version",
-        }
-
     def __init__(self, pattern: List[str]):
         self.pattern = pattern
         self._pattern_length = len(pattern)
@@ -78,7 +59,7 @@ class SignMatcher:
         return [
             {
                 "$project": {
-                    **self._summary_projection(),
+                    **fragment_summary_projection(),
                     "_sortKey": True,
                     "lineTypes": "$text.lines.type",
                     "signs": True,

--- a/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
@@ -1,6 +1,8 @@
 from typing import List, Dict
 from ebl.common.query.util import flatten_field, ngrams
-from ebl.fragmentarium.infrastructure.queries import fragment_summary_projection
+from ebl.fragmentarium.infrastructure.queries import (
+    fragment_summary_projection_lightweight,
+)
 
 
 class SignMatcher:
@@ -59,7 +61,7 @@ class SignMatcher:
         return [
             {
                 "$project": {
-                    **fragment_summary_projection(),
+                    **fragment_summary_projection_lightweight(),
                     "_sortKey": True,
                     "lineTypes": "$text.lines.type",
                     "signs": True,
@@ -81,8 +83,6 @@ class SignMatcher:
                     "projects": {"$first": "$projects"},
                     "references": {"$first": "$references"},
                     "script": {"$first": "$script"},
-                    "textLines": {"$first": "$textLines"},
-                    "textParserVersion": {"$first": "$textParserVersion"},
                     "textLineIndices": {"$push": "$lineIndex"},
                     "signLines": {"$first": {"$split": ["$signs", "\n"]}},
                 }
@@ -123,8 +123,6 @@ class SignMatcher:
                             }
                         )
                     },
-                    "textLines": {"$first": "$textLines"},
-                    "textParserVersion": {"$first": "$textParserVersion"},
                     **({"matchCount": {"$sum": 1}} if count_matches_per_item else {}),
                 }
             },

--- a/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_sign_matcher.py
@@ -7,11 +7,20 @@ class SignMatcher:
     def _summary_projection() -> Dict:
         return {
             "accession": 1,
+            "archaeology": {
+                "excavationNumber": "$archaeology.excavationNumber",
+                "site": "$archaeology.site",
+            },
             "date": 1,
             "description": 1,
+            "dossiers": 1,
             "genres": 1,
             "museumNumber": 1,
+            "projects": 1,
+            "references": 1,
             "script": 1,
+            "textLines": "$text.lines",
+            "textParserVersion": "$text.parser_version",
         }
 
     def __init__(self, pattern: List[str]):
@@ -61,7 +70,7 @@ class SignMatcher:
                     ]
                 },
                 "as": "index",
-                "in": {"$arrayElemAt": ["$textLines", "$$index"]},
+                "in": {"$arrayElemAt": ["$textLineIndices", "$$index"]},
             }
         }
 
@@ -83,11 +92,17 @@ class SignMatcher:
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
                     "accession": {"$first": "$accession"},
+                    "archaeology": {"$first": "$archaeology"},
                     "date": {"$first": "$date"},
                     "description": {"$first": "$description"},
+                    "dossiers": {"$first": "$dossiers"},
                     "genres": {"$first": "$genres"},
+                    "projects": {"$first": "$projects"},
+                    "references": {"$first": "$references"},
                     "script": {"$first": "$script"},
-                    "textLines": {"$push": "$lineIndex"},
+                    "textLines": {"$first": "$textLines"},
+                    "textParserVersion": {"$first": "$textParserVersion"},
+                    "textLineIndices": {"$push": "$lineIndex"},
                     "signLines": {"$first": {"$split": ["$signs", "\n"]}},
                 }
             },
@@ -107,17 +122,28 @@ class SignMatcher:
                     "museumNumber": {"$first": "$museumNumber"},
                     "_sortKey": {"$first": "$_sortKey"},
                     "accession": {"$first": "$accession"},
+                    "archaeology": {"$first": "$archaeology"},
                     "date": {"$first": "$date"},
                     "description": {"$first": "$description"},
+                    "dossiers": {"$first": "$dossiers"},
                     "genres": {"$first": "$genres"},
+                    "projects": {"$first": "$projects"},
+                    "references": {"$first": "$references"},
                     "script": {"$first": "$script"},
                     "matchingLines": {
                         "$push": (
                             self._expand_line_ranges()
                             if self._is_multiline
-                            else {"$arrayElemAt": ["$textLines", "$signLineIndex"]}
+                            else {
+                                "$arrayElemAt": [
+                                    "$textLineIndices",
+                                    "$signLineIndex",
+                                ]
+                            }
                         )
                     },
+                    "textLines": {"$first": "$textLines"},
+                    "textParserVersion": {"$first": "$textParserVersion"},
                     **({"matchCount": {"$sum": 1}} if count_matches_per_item else {}),
                 }
             },

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_base.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_base.py
@@ -16,6 +16,7 @@ class MongoFragmentRepositoryBase(FragmentRepository):
     ) -> None:
         self._fragments = MongoCollection(database, FRAGMENTS_COLLECTION)
         self._joins = MongoCollection(database, JOINS_COLLECTION)
+        self._photo_files = MongoCollection(database, "photos.files")
         self._provenance_service = provenance_service
 
     def _schema(self, **kwargs):

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -51,7 +51,11 @@ def load_query_result(cursor: Iterator) -> QueryResult:
 
 def load_fragment_query_result(cursor: Iterator) -> FragmentQueryResult:
     data = next(cursor, None)
-    return FragmentQueryResultSchema().load(data) if data else FragmentQueryResult.create_empty()
+    return (
+        FragmentQueryResultSchema().load(data)
+        if data
+        else FragmentQueryResult.create_empty()
+    )
 
 
 def chapter_lemma_pipeline(clean_values: List[str]) -> List[dict]:

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence, Iterator, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Union
 
 from marshmallow import EXCLUDE
 from pymongo.collation import Collation
@@ -35,9 +35,26 @@ from ebl.bibliography.infrastructure.bibliography import join_reference_document
 from ebl.fragmentarium.infrastructure.mongo_fragment_repository_get_extended import (
     MongoFragmentRepositoryGetExtended,
 )
+from ebl.transliteration.domain.atf import DEFAULT_ATF_PARSER_VERSION
 
 
 RETRIEVE_ALL_LIMIT = 1000
+FRAGMENT_QUERY_SUMMARY_PROJECTION = {
+    "_id": True,
+    "accession": True,
+    "archaeology.excavationNumber": True,
+    "archaeology.site": True,
+    "date": True,
+    "description": True,
+    "dossiers": True,
+    "genres": True,
+    "museumNumber": True,
+    "projects": True,
+    "references": True,
+    "script": True,
+    "text.lines": True,
+    "text.parser_version": True,
+}
 
 
 def load_museum_number(data: dict) -> MuseumNumber:
@@ -56,6 +73,40 @@ def load_fragment_query_result(cursor: Iterator) -> FragmentQueryResult:
         if data
         else FragmentQueryResult.create_empty()
     )
+
+
+def fragment_photo_filename(museum_number: Union[dict, MuseumNumber]) -> str:
+    if isinstance(museum_number, MuseumNumber):
+        return f"{museum_number}.jpg"
+
+    suffix = museum_number.get("suffix") or ""
+    suffix_part = f".{suffix}" if suffix else ""
+    return f"{museum_number.get('prefix', '')}.{museum_number.get('number', '')}{suffix_part}.jpg"
+
+
+def compact_preview_token(token: dict) -> dict:
+    data = {
+        "value": token.get("value"),
+        "cleanValue": token.get("cleanValue"),
+        "uniqueLemma": token.get("uniqueLemma"),
+        "type": token.get("type"),
+    }
+    return {
+        key: value
+        for key, value in data.items()
+        if value is not None and (key != "uniqueLemma" or value)
+    }
+
+
+def compact_preview_line(line: dict) -> dict:
+    content = line.get("content") or []
+    prefix = line.get("prefix") or ""
+    return {
+        "number": prefix,
+        "prefix": prefix,
+        "text": " ".join(token.get("value", "") for token in content),
+        "tokens": [compact_preview_token(token) for token in content],
+    }
 
 
 def chapter_lemma_pipeline(clean_values: List[str]) -> List[dict]:
@@ -204,6 +255,103 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
             else []
         )
 
+    def _find_fragment_query_summary_data(
+        self, fragment_ids: Sequence[Any]
+    ) -> Dict[Any, dict]:
+        return {
+            fragment["_id"]: fragment
+            for fragment in self._fragments.find_many(
+                {"_id": {"$in": list(fragment_ids)}},
+                projection=FRAGMENT_QUERY_SUMMARY_PROJECTION,
+            )
+        }
+
+    def _find_fragment_query_photo_filenames(
+        self, items: Sequence[dict]
+    ) -> Sequence[str]:
+        filenames = [
+            fragment_photo_filename(item["museumNumber"])
+            for item in items
+            if item.get("museumNumber")
+        ]
+        return [
+            photo["filename"]
+            for photo in self._photo_files.find_many(
+                {"filename": {"$in": filenames}},
+                projection={"filename": True},
+            )
+        ]
+
+    def _matching_line_preview(self, fragment: dict, matching_lines: Sequence[int]):
+        text = fragment.get("text") or {}
+        lines = text.get("lines") or []
+        return {
+            "lines": [
+                compact_preview_line(lines[line_index])
+                for line_index in matching_lines
+            ],
+            "parser_version": text.get("parser_version")
+            or DEFAULT_ATF_PARSER_VERSION,
+        }
+
+    def _hydrate_fragment_query_item(
+        self,
+        item: dict,
+        fragments_by_id: Dict[Any, dict],
+        photo_filenames: Sequence[str],
+    ) -> dict:
+        fragment = fragments_by_id.get(item["_id"])
+        if fragment is None:
+            raise NotFoundError(
+                f"Fragment summary data for {item.get('museumNumber')} not found."
+            )
+
+        matching_lines = item.get("matchingLines") or []
+        museum_number = fragment.get("museumNumber", item.get("museumNumber"))
+        return {
+            "museumNumber": museum_number,
+            "accession": fragment.get("accession"),
+            "description": fragment["description"],
+            "script": fragment["script"],
+            "date": fragment.get("date"),
+            "genres": fragment.get("genres", []),
+            "archaeology": fragment.get("archaeology"),
+            "references": fragment.get("references", []),
+            "projects": fragment.get("projects", []),
+            "dossiers": fragment.get("dossiers", []),
+            "matchingLines": matching_lines,
+            "matchingLinePreview": self._matching_line_preview(
+                fragment, matching_lines
+            ),
+            "matchCount": item.get("matchCount", 0),
+            "hasPhoto": fragment_photo_filename(museum_number) in photo_filenames,
+        }
+
+    def _load_fragment_query_result(self, data: Optional[dict]) -> FragmentQueryResult:
+        if not data:
+            return FragmentQueryResult.create_empty()
+
+        items = data.get("items", [])
+        fragment_ids = [item["_id"] for item in items]
+        fragments_by_id = self._find_fragment_query_summary_data(fragment_ids)
+        photo_filenames = self._find_fragment_query_photo_filenames(items)
+        return FragmentQueryResultSchema().load(
+            {
+                "items": [
+                    self._hydrate_fragment_query_item(
+                        item, fragments_by_id, photo_filenames
+                    )
+                    for item in items
+                ],
+                "matchCountTotal": data.get("matchCountTotal", 0),
+                "isMatchCountTotalExact": data.get(
+                    "isMatchCountTotalExact", True
+                ),
+                "hasNextPage": data.get("hasNextPage"),
+                "_showCountMetadata": data.get("_showCountMetadata", False),
+            }
+        )
+
     def query_by_museum_number(
         self,
         number: Union[MuseumNumber, ExcavationNumber],
@@ -286,7 +434,7 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
 
     def query(
         self, query: dict, user_scopes: Sequence[Scope] = ()
-    ) -> FragmentQueryResult:
+    ) -> Union[QueryResult, FragmentQueryResult]:
         cursor = (
             self._fragments.aggregate(
                 PatternMatcher(
@@ -299,7 +447,11 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
             if set(query) - {"lemmaOperator"}
             else iter([])
         )
-        return load_fragment_query_result(cursor)
+        return (
+            self._load_fragment_query_result(next(cursor, None))
+            if "limit" in query
+            else load_query_result(cursor)
+        )
 
     def query_latest(self) -> QueryResult:
         return load_query_result(

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -37,7 +37,6 @@ from ebl.fragmentarium.infrastructure.mongo_fragment_repository_get_extended imp
 )
 from ebl.transliteration.domain.atf import DEFAULT_ATF_PARSER_VERSION
 
-
 RETRIEVE_ALL_LIMIT = 1000
 FRAGMENT_QUERY_SUMMARY_PROJECTION = {
     "_id": True,
@@ -64,15 +63,6 @@ def load_museum_number(data: dict) -> MuseumNumber:
 def load_query_result(cursor: Iterator) -> QueryResult:
     data = next(cursor, None)
     return QueryResultSchema().load(data) if data else QueryResult.create_empty()
-
-
-def load_fragment_query_result(cursor: Iterator) -> FragmentQueryResult:
-    data = next(cursor, None)
-    return (
-        FragmentQueryResultSchema().load(data)
-        if data
-        else FragmentQueryResult.create_empty()
-    )
 
 
 def fragment_photo_filename(museum_number: Union[dict, MuseumNumber]) -> str:
@@ -287,7 +277,9 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
         lines = text.get("lines") or []
         return {
             "lines": [
-                compact_preview_line(lines[line_index]) for line_index in matching_lines
+                compact_preview_line(lines[line_index])
+                for line_index in matching_lines
+                if 0 <= line_index < len(lines)
             ],
             "parser_version": text.get("parser_version") or DEFAULT_ATF_PARSER_VERSION,
         }
@@ -309,8 +301,11 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
         return {
             "museumNumber": museum_number,
             "accession": fragment.get("accession"),
-            "description": fragment["description"],
-            "script": fragment["script"],
+            "description": fragment.get("description", ""),
+            "script": fragment.get(
+                "script",
+                {"period": "", "periodModifier": "None", "uncertain": False},
+            ),
             "date": fragment.get("date"),
             "genres": fragment.get("genres", []),
             "archaeology": fragment.get("archaeology"),
@@ -344,7 +339,6 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
                 "matchCountTotal": data.get("matchCountTotal", 0),
                 "isMatchCountTotalExact": data.get("isMatchCountTotalExact", True),
                 "hasNextPage": data.get("hasNextPage"),
-                "_showCountMetadata": data.get("_showCountMetadata", False),
             }
         )
 

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -281,7 +281,7 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
                 for line_index in matching_lines
                 if 0 <= line_index < len(lines)
             ],
-            "parser_version": text.get("parser_version") or DEFAULT_ATF_PARSER_VERSION,
+            "parserVersion": text.get("parser_version") or DEFAULT_ATF_PARSER_VERSION,
         }
 
     def _hydrate_fragment_query_item(

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -10,7 +10,11 @@ from ebl.common.query.query_schemas import (
     AfORegisterToFragmentQueryResultSchema,
 )
 from ebl.errors import NotFoundError
+from ebl.fragmentarium.application.fragment_query_summary_schema import (
+    FragmentQueryResultSchema,
+)
 from ebl.fragmentarium.domain.archaeology import ExcavationNumber
+from ebl.fragmentarium.domain.fragment_query_summary import FragmentQueryResult
 from ebl.fragmentarium.infrastructure.mongo_fragment_repository_base import (
     MongoFragmentRepositoryBase,
 )
@@ -43,6 +47,11 @@ def load_museum_number(data: dict) -> MuseumNumber:
 def load_query_result(cursor: Iterator) -> QueryResult:
     data = next(cursor, None)
     return QueryResultSchema().load(data) if data else QueryResult.create_empty()
+
+
+def load_fragment_query_result(cursor: Iterator) -> FragmentQueryResult:
+    data = next(cursor, None)
+    return FragmentQueryResultSchema().load(data) if data else FragmentQueryResult.create_empty()
 
 
 def chapter_lemma_pipeline(clean_values: List[str]) -> List[dict]:
@@ -271,7 +280,9 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
 
         return FragmentPagerInfo(prev, next_)
 
-    def query(self, query: dict, user_scopes: Sequence[Scope] = ()) -> QueryResult:
+    def query(
+        self, query: dict, user_scopes: Sequence[Scope] = ()
+    ) -> FragmentQueryResult:
         cursor = (
             self._fragments.aggregate(
                 PatternMatcher(
@@ -284,7 +295,7 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
             if set(query) - {"lemmaOperator"}
             else iter([])
         )
-        return load_query_result(cursor)
+        return load_fragment_query_result(cursor)
 
     def query_latest(self) -> QueryResult:
         return load_query_result(

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -287,11 +287,9 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
         lines = text.get("lines") or []
         return {
             "lines": [
-                compact_preview_line(lines[line_index])
-                for line_index in matching_lines
+                compact_preview_line(lines[line_index]) for line_index in matching_lines
             ],
-            "parser_version": text.get("parser_version")
-            or DEFAULT_ATF_PARSER_VERSION,
+            "parser_version": text.get("parser_version") or DEFAULT_ATF_PARSER_VERSION,
         }
 
     def _hydrate_fragment_query_item(
@@ -344,9 +342,7 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
                     for item in items
                 ],
                 "matchCountTotal": data.get("matchCountTotal", 0),
-                "isMatchCountTotalExact": data.get(
-                    "isMatchCountTotalExact", True
-                ),
+                "isMatchCountTotalExact": data.get("isMatchCountTotalExact", True),
                 "hasNextPage": data.get("hasNextPage"),
                 "_showCountMetadata": data.get("_showCountMetadata", False),
             }

--- a/ebl/fragmentarium/infrastructure/queries.py
+++ b/ebl/fragmentarium/infrastructure/queries.py
@@ -20,44 +20,6 @@ LATEST_TRANSLITERATION_LIMIT: int = 50
 LATEST_TRANSLITERATION_LINE_LIMIT: int = 3
 
 
-def fragment_summary_projection() -> Dict:
-    return {
-        "accession": 1,
-        "archaeology": {
-            "excavationNumber": "$archaeology.excavationNumber",
-            "site": "$archaeology.site",
-        },
-        "date": 1,
-        "description": 1,
-        "dossiers": 1,
-        "genres": 1,
-        "museumNumber": 1,
-        "projects": 1,
-        "references": 1,
-        "script": 1,
-        "textLines": "$text.lines",
-        "textParserVersion": "$text.parser_version",
-    }
-
-
-def fragment_summary_projection_lightweight() -> Dict:
-    return {
-        "accession": 1,
-        "archaeology": {
-            "excavationNumber": "$archaeology.excavationNumber",
-            "site": "$archaeology.site",
-        },
-        "date": 1,
-        "description": 1,
-        "dossiers": 1,
-        "genres": 1,
-        "museumNumber": 1,
-        "projects": 1,
-        "references": 1,
-        "script": 1,
-    }
-
-
 def fragment_photo_filename_expression() -> Dict:
     suffix = {"$ifNull": ["$museumNumber.suffix", ""]}
     return {

--- a/ebl/fragmentarium/infrastructure/queries.py
+++ b/ebl/fragmentarium/infrastructure/queries.py
@@ -20,6 +20,45 @@ LATEST_TRANSLITERATION_LIMIT: int = 50
 LATEST_TRANSLITERATION_LINE_LIMIT: int = 3
 
 
+def fragment_summary_projection() -> Dict:
+    return {
+        "accession": 1,
+        "archaeology": {
+            "excavationNumber": "$archaeology.excavationNumber",
+            "site": "$archaeology.site",
+        },
+        "date": 1,
+        "description": 1,
+        "dossiers": 1,
+        "genres": 1,
+        "museumNumber": 1,
+        "projects": 1,
+        "references": 1,
+        "script": 1,
+        "textLines": "$text.lines",
+        "textParserVersion": "$text.parser_version",
+    }
+
+
+def fragment_photo_filename_expression() -> Dict:
+    suffix = {"$ifNull": ["$museumNumber.suffix", ""]}
+    return {
+        "$concat": [
+            {"$ifNull": ["$museumNumber.prefix", ""]},
+            ".",
+            {"$ifNull": ["$museumNumber.number", ""]},
+            {
+                "$cond": {
+                    "if": {"$eq": [suffix, ""]},
+                    "then": "",
+                    "else": {"$concat": [".", suffix]},
+                }
+            },
+            ".jpg",
+        ]
+    }
+
+
 def fragment_is(fragment: Fragment) -> dict:
     return query_number_is(fragment.number)
 
@@ -233,21 +272,7 @@ def aggregate_path_of_the_pioneers(
         },
         {
             "$addFields": {
-                "filename": {
-                    "$concat": [
-                        "$museumNumber.prefix",
-                        ".",
-                        "$museumNumber.number",
-                        {
-                            "$cond": {
-                                "if": {"$eq": ["$museumNumber.suffix", ""]},
-                                "then": "",
-                                "else": {"$concat": [".", "$museumNumber.suffix"]},
-                            }
-                        },
-                        ".jpg",
-                    ]
-                }
+                "filename": fragment_photo_filename_expression()
             }
         },
         {

--- a/ebl/fragmentarium/infrastructure/queries.py
+++ b/ebl/fragmentarium/infrastructure/queries.py
@@ -40,6 +40,24 @@ def fragment_summary_projection() -> Dict:
     }
 
 
+def fragment_summary_projection_lightweight() -> Dict:
+    return {
+        "accession": 1,
+        "archaeology": {
+            "excavationNumber": "$archaeology.excavationNumber",
+            "site": "$archaeology.site",
+        },
+        "date": 1,
+        "description": 1,
+        "dossiers": 1,
+        "genres": 1,
+        "museumNumber": 1,
+        "projects": 1,
+        "references": 1,
+        "script": 1,
+    }
+
+
 def fragment_photo_filename_expression() -> Dict:
     suffix = {"$ifNull": ["$museumNumber.suffix", ""]}
     return {

--- a/ebl/fragmentarium/infrastructure/queries.py
+++ b/ebl/fragmentarium/infrastructure/queries.py
@@ -270,11 +270,7 @@ def aggregate_path_of_the_pioneers(
                 ]
             }
         },
-        {
-            "$addFields": {
-                "filename": fragment_photo_filename_expression()
-            }
-        },
+        {"$addFields": {"filename": fragment_photo_filename_expression()}},
         {
             "$lookup": {
                 "from": "photos.files",

--- a/ebl/fragmentarium/web/fragments.py
+++ b/ebl/fragmentarium/web/fragments.py
@@ -124,7 +124,9 @@ class FragmentsQueryResource:
             parse_non_negative_integer_field("offset"),
         )
         schema = (
-            FragmentQueryResultSchema() if "limit" in query else QueryResultSchema()
+            FragmentQueryResultSchema(include_count_metadata=True)
+            if "limit" in query
+            else QueryResultSchema(include_count_metadata=True)
         )
 
         resp.media = schema.dump(

--- a/ebl/fragmentarium/web/fragments.py
+++ b/ebl/fragmentarium/web/fragments.py
@@ -2,7 +2,6 @@ import json
 import falcon
 from falcon import Request, Response
 from falcon_caching import Cache
-from pydash import flow
 from ebl.cache.application.cache import DEFAULT_TIMEOUT
 
 from ebl.common.query.parameter_parser import (
@@ -36,6 +35,12 @@ from ebl.transliteration.application.transliteration_query_factory import (
     TransliterationQueryFactory,
 )
 from ebl.users.web.require_scope import require_fragment_read_scope
+
+
+def _parse_fragment_query(parameters, *parsers):
+    for parser in parsers:
+        parameters = parser(parameters)
+    return parameters
 
 
 class FragmentsRetrieveAllResource:
@@ -108,7 +113,8 @@ class FragmentsQueryResource:
         self._transliteration_query_factory = transliteration_query_factory
 
     def on_get(self, req: Request, resp: Response):
-        parse = flow(
+        query = _parse_fragment_query(
+            req.params,
             parse_transliteration(self._transliteration_query_factory),
             parse_lemmas,
             parse_pages,
@@ -117,7 +123,6 @@ class FragmentsQueryResource:
             parse_integer_field("limit"),
             parse_non_negative_integer_field("offset"),
         )
-        query = parse(req.params)
         schema = (
             FragmentQueryResultSchema() if "limit" in query else QueryResultSchema()
         )

--- a/ebl/fragmentarium/web/fragments.py
+++ b/ebl/fragmentarium/web/fragments.py
@@ -18,6 +18,9 @@ from ebl.errors import DataError, NotFoundError
 from ebl.files.application.file_repository import FileRepository
 from ebl.fragmentarium.application.fragment_finder import FragmentFinder
 from ebl.fragmentarium.application.fragment_repository import FragmentRepository
+from ebl.fragmentarium.application.fragment_query_summary_schema import (
+    FragmentQueryResultSchema,
+)
 from ebl.fragmentarium.application.fragment_updater import FragmentUpdater
 from ebl.fragmentarium.web.dtos import (
     create_response_dto,
@@ -111,7 +114,7 @@ class FragmentsQueryResource:
             parse_integer_field("limit"),
         )
 
-        resp.media = QueryResultSchema().dump(
+        resp.media = FragmentQueryResultSchema().dump(
             self._repository.query(
                 parse(req.params),
                 req.context.user.get_scopes(prefix="read:", suffix="-fragments"),

--- a/ebl/fragmentarium/web/fragments.py
+++ b/ebl/fragmentarium/web/fragments.py
@@ -12,6 +12,8 @@ from ebl.common.query.parameter_parser import (
     parse_lemmas,
     parse_pages,
     parse_genre,
+    parse_non_negative_integer_field,
+    parse_count,
 )
 from ebl.common.query.query_schemas import QueryResultSchema
 from ebl.errors import DataError, NotFoundError
@@ -111,12 +113,18 @@ class FragmentsQueryResource:
             parse_lemmas,
             parse_pages,
             parse_genre,
+            parse_count,
             parse_integer_field("limit"),
+            parse_non_negative_integer_field("offset"),
+        )
+        query = parse(req.params)
+        schema = (
+            FragmentQueryResultSchema() if "limit" in query else QueryResultSchema()
         )
 
-        resp.media = FragmentQueryResultSchema().dump(
+        resp.media = schema.dump(
             self._repository.query(
-                parse(req.params),
+                query,
                 req.context.user.get_scopes(prefix="read:", suffix="-fragments"),
             )
         )

--- a/ebl/tests/common/test_parameter_parser.py
+++ b/ebl/tests/common/test_parameter_parser.py
@@ -2,10 +2,12 @@ import pytest
 import re
 from ebl.common.query.parameter_parser import (
     parse_integer_field,
+    parse_non_negative_integer_field,
     parse_pages,
     parse_lemmas,
     parse_lines,
     parse_transliteration,
+    parse_count,
 )
 from ebl.common.query.query_result import LemmaQueryType
 from ebl.errors import DataError
@@ -36,6 +38,29 @@ def test_parse_integer_field_invalid():
         DataError, match="invalid_field must be integer, got 'not an int' instead"
     ):
         parse({"invalid_field": "not an int"})
+
+
+def test_parse_non_negative_integer_field():
+    parse = parse_non_negative_integer_field("offset")
+    assert parse({"offset": "0"}) == {"offset": 0}
+    assert parse({"offset": "42"}) == {"offset": 42}
+
+
+def test_parse_non_negative_integer_field_negative():
+    parse = parse_non_negative_integer_field("offset")
+    with pytest.raises(DataError, match="offset must be non-negative"):
+        parse({"offset": "-1"})
+
+
+@pytest.mark.parametrize("count", ["exact", "none", "page"])
+def test_parse_count(count):
+    assert parse_count({"count": count}) == {"count": count}
+
+
+@pytest.mark.parametrize("count", ["false", "0", "random", "approx"])
+def test_parse_count_invalid(count):
+    with pytest.raises(DataError, match=f"unexpected count {count!r}"):
+        parse_count({"count": count})
 
 
 def test_parse_pages():

--- a/ebl/tests/common/test_query_result.py
+++ b/ebl/tests/common/test_query_result.py
@@ -1,0 +1,19 @@
+from ebl.common.query.query_result import QueryResult
+from ebl.common.query.query_schemas import QueryResultSchema
+
+
+def test_query_result_equality_with_unsupported_type_returns_not_implemented():
+    result = QueryResult.create_empty()
+
+    assert result.__eq__(object()) is NotImplemented
+
+
+def test_query_result_schema_can_include_count_metadata():
+    assert QueryResultSchema(include_count_metadata=True).dump(
+        QueryResult.create_empty()
+    ) == {
+        "items": [],
+        "matchCountTotal": 0,
+        "isMatchCountTotalExact": True,
+        "hasNextPage": None,
+    }

--- a/ebl/tests/fragmentarium/test_fragment_query_pipeline.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_pipeline.py
@@ -1,0 +1,163 @@
+from ebl.fragmentarium.infrastructure.fragment_pattern_matcher import PatternMatcher
+from ebl.fragmentarium.infrastructure.fragment_sign_matcher import SignMatcher
+
+
+def _items_facet(pipeline):
+    return next(stage["$facet"]["items"] for stage in pipeline if "$facet" in stage)
+
+
+def _count_facet(pipeline):
+    return next(stage["$facet"]["count"] for stage in pipeline if "$facet" in stage)
+
+
+def _facet(pipeline):
+    return next(stage["$facet"] for stage in pipeline if "$facet" in stage)
+
+
+def _result_projection(pipeline):
+    return next(stage["$project"] for stage in reversed(pipeline) if "$project" in stage)
+
+
+def _contains_key(value, key):
+    if isinstance(value, dict):
+        return key in value or any(_contains_key(item, key) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_key(item, key) for item in value)
+    return False
+
+
+def test_sign_matcher_prefilters_fragments_before_mapping_lines():
+    pattern = [r"(?<![^|\s])kur₂(?![^\s\/])"]
+
+    pipeline = SignMatcher(pattern).build_pipeline()
+
+    assert pipeline[0] == {"$match": {"$and": [{"signs": {"$regex": pattern[0]}}]}}
+    assert "$project" in pipeline[1]
+    assert pipeline[1]["$project"] == {
+        "museumNumber": True,
+        "_sortKey": True,
+        "_scriptSortKey": "$script.sortKey",
+        "lineTypes": "$text.lines.type",
+        "signs": True,
+    }
+
+
+def test_fragment_query_summary_phase_one_has_no_lookup_or_hydration():
+    items = _items_facet(
+        PatternMatcher(
+            {"transliteration": ["kur₂"], "limit": 10}, None
+        ).build_pipeline()
+    )
+
+    assert items == [
+        {"$sort": {"_scriptSortKey": 1, "_sortKey": 1}},
+        {"$limit": 10},
+        {
+            "$project": {
+                "_id": True,
+                "matchCount": True,
+                "matchingLines": True,
+                "museumNumber": True,
+            }
+        }
+    ]
+    assert not any("$lookup" in stage for stage in items)
+    assert not _contains_key(items, "$expr")
+    assert not _contains_key(items, "matchingLinePreview")
+
+
+def test_fragment_query_applies_limit_before_phase_one_projection():
+    items = _items_facet(
+        PatternMatcher(
+            {"transliteration": ["kur₂"], "limit": 10}, None
+        ).build_pipeline()
+    )
+
+    assert items.index({"$limit": 10}) < len(items) - 1
+
+
+def test_fragment_query_applies_offset_before_limit_and_phase_one_projection():
+    items = _items_facet(
+        PatternMatcher(
+            {"transliteration": ["kur₂"], "limit": 10, "offset": 5}, None
+        ).build_pipeline()
+    )
+
+    assert items.index({"$skip": 5}) < items.index({"$limit": 10}) < len(items) - 1
+
+
+def test_fragment_query_without_limit_uses_lean_items():
+    items = _items_facet(
+        PatternMatcher({"transliteration": ["kur₂"]}, None).build_pipeline()
+    )
+
+    assert not any("$limit" in stage for stage in items)
+    assert not any("$lookup" in stage for stage in items)
+    assert items[-1] == {
+        "$project": {
+            "_id": False,
+            "museumNumber": True,
+            "matchingLines": True,
+            "matchCount": True,
+        }
+    }
+
+
+def test_fragment_query_count_facet_stays_lightweight():
+    pipeline = PatternMatcher({"transliteration": ["kur₂"]}, None).build_pipeline()
+    count = _count_facet(pipeline)
+
+    assert count == [
+        {
+            "$group": {
+                "_id": None,
+                "matchCountTotal": {"$sum": {"$ifNull": ["$matchCount", 0]}},
+            }
+        },
+        {"$project": {"_id": False, "matchCountTotal": True}},
+    ]
+    assert _result_projection(pipeline) == {
+        "_id": False,
+        "items": True,
+        "matchCountTotal": {
+            "$ifNull": [{"$arrayElemAt": ["$count.matchCountTotal", 0]}, 0]
+        },
+        "isMatchCountTotalExact": {"$literal": True},
+        "hasNextPage": {"$literal": None},
+        "_showCountMetadata": {"$literal": True},
+    }
+
+
+def test_fragment_query_count_none_omits_exact_count_facet():
+    pipeline = PatternMatcher(
+        {"transliteration": ["kur₂"], "limit": 10, "count": "none"}, None
+    ).build_pipeline()
+
+    assert "count" not in _facet(pipeline)
+    assert _result_projection(pipeline) == {
+        "_id": False,
+        "items": True,
+        "matchCountTotal": {"$literal": None},
+        "isMatchCountTotalExact": {"$literal": False},
+        "hasNextPage": {"$literal": None},
+        "_showCountMetadata": {"$literal": True},
+    }
+
+
+def test_fragment_query_count_page_fetches_sentinel_and_slices_items():
+    pipeline = PatternMatcher(
+        {"transliteration": ["kur₂"], "limit": 10, "count": "page"}, None
+    ).build_pipeline()
+    items = _items_facet(pipeline)
+
+    assert "count" not in _facet(pipeline)
+    assert {"$limit": 11} in items
+    assert {"$limit": 10} not in items
+    assert _result_projection(pipeline) == {
+        "_id": False,
+        "items": {"$slice": ["$items", 10]},
+        "matchCountTotal": {"$literal": None},
+        "isMatchCountTotalExact": {"$literal": False},
+        "hasNextPage": {"$gt": [{"$size": "$items"}, 10]},
+        "_showCountMetadata": {"$literal": True},
+    }

--- a/ebl/tests/fragmentarium/test_fragment_query_pipeline.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_pipeline.py
@@ -126,7 +126,6 @@ def test_fragment_query_count_facet_stays_lightweight():
         },
         "isMatchCountTotalExact": {"$literal": True},
         "hasNextPage": {"$literal": None},
-        "_showCountMetadata": {"$literal": True},
     }
 
 
@@ -142,7 +141,6 @@ def test_fragment_query_count_none_omits_exact_count_facet():
         "matchCountTotal": {"$literal": None},
         "isMatchCountTotalExact": {"$literal": False},
         "hasNextPage": {"$literal": None},
-        "_showCountMetadata": {"$literal": True},
     }
 
 
@@ -161,5 +159,20 @@ def test_fragment_query_count_page_fetches_sentinel_and_slices_items():
         "matchCountTotal": {"$literal": None},
         "isMatchCountTotalExact": {"$literal": False},
         "hasNextPage": {"$gt": [{"$size": "$items"}, 10]},
-        "_showCountMetadata": {"$literal": True},
+    }
+
+
+def test_fragment_query_count_page_without_limit_has_no_next_page():
+    pipeline = PatternMatcher(
+        {"transliteration": ["kur₂"], "count": "page"}, None
+    ).build_pipeline()
+
+    assert "count" not in _facet(pipeline)
+    assert not any("$limit" in stage for stage in _items_facet(pipeline))
+    assert _result_projection(pipeline) == {
+        "_id": False,
+        "items": True,
+        "matchCountTotal": {"$literal": None},
+        "isMatchCountTotalExact": {"$literal": False},
+        "hasNextPage": {"$literal": False},
     }

--- a/ebl/tests/fragmentarium/test_fragment_query_pipeline.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_pipeline.py
@@ -15,7 +15,9 @@ def _facet(pipeline):
 
 
 def _result_projection(pipeline):
-    return next(stage["$project"] for stage in reversed(pipeline) if "$project" in stage)
+    return next(
+        stage["$project"] for stage in reversed(pipeline) if "$project" in stage
+    )
 
 
 def _contains_key(value, key):
@@ -59,7 +61,7 @@ def test_fragment_query_summary_phase_one_has_no_lookup_or_hydration():
                 "matchingLines": True,
                 "museumNumber": True,
             }
-        }
+        },
     ]
     assert not any("$lookup" in stage for stage in items)
     assert not _contains_key(items, "$expr")

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -105,7 +105,9 @@ def test_fragment_query_summary_schema_dump_exact_shape():
         ],
         "dossiers": DossierReferenceSchema().dump(summary.dossiers, many=True),
         "matchingLines": [0, 2],
-        "matchingLinePreview": summary.matching_line_preview,
+        "matchingLinePreview": FragmentQueryMatchingLinePreviewSchema().dump(
+            summary.matching_line_preview
+        ),
         "matchCount": 2,
         "hasPhoto": True,
         "thumbnailPath": f"/fragments/{summary.museum_number}/thumbnail/small",
@@ -116,6 +118,8 @@ def test_fragment_query_summary_schema_dump_exact_shape():
     )
     assert dumped["matchingLinePreview"]["lines"][0]["text"]
     assert dumped["matchingLinePreview"]["lines"][0]["tokens"][0]["value"]
+    assert dumped["matchingLinePreview"]["parserVersion"]
+    assert "parser_version" not in dumped["matchingLinePreview"]
     assert "parts" not in dumped["matchingLinePreview"]["lines"][0]["tokens"][0]
     assert "text" not in dumped
     assert "record" not in dumped
@@ -153,7 +157,12 @@ def test_matching_line_preview_skips_out_of_range_lines():
     empty_preview = matching_line_preview_of(fragment.text, (line_count,))
 
     assert len(preview["lines"]) == 1
-    assert FragmentQueryMatchingLinePreviewSchema().load(empty_preview)["lines"] == []
+    assert (
+        FragmentQueryMatchingLinePreviewSchema().load(
+            FragmentQueryMatchingLinePreviewSchema().dump(empty_preview)
+        )["lines"]
+        == []
+    )
 
 
 def test_fragment_query_result_schema_roundtrip_and_compatibility():

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -108,8 +108,9 @@ def test_fragment_query_summary_schema_dump_exact_shape():
         "hasPhoto": True,
         "thumbnailPath": f"/fragments/{summary.museum_number}/thumbnail/small",
     }
-    assert dumped["matchingLinePreview"]["lines"][0]["prefix"] == (
-        summary.matching_line_preview["lines"][0]["prefix"]
+    assert (
+        dumped["matchingLinePreview"]["lines"][0]["prefix"]
+        == (summary.matching_line_preview["lines"][0]["prefix"])
     )
     assert dumped["matchingLinePreview"]["lines"][0]["text"]
     assert dumped["matchingLinePreview"]["lines"][0]["tokens"][0]["value"]

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -15,6 +15,7 @@ from ebl.fragmentarium.domain.fragment_query_summary import (
     FragmentQueryArchaeology,
     FragmentQueryResult,
     FragmentQuerySummary,
+    matching_line_preview_of,
 )
 from ebl.schemas import ResearchProjectField
 from ebl.tests.factories.bibliography import ReferenceFactory
@@ -24,7 +25,6 @@ from ebl.tests.factories.fragment import (
 )
 from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
 from ebl.transliteration.application.text_schema import TextSchema
-from ebl.transliteration.domain.text import Text
 
 
 def build_summary() -> FragmentQuerySummary:
@@ -32,7 +32,7 @@ def build_summary() -> FragmentQuerySummary:
         references=(ReferenceFactory.build(), ReferenceFactory.build())
     )
     matching_lines = (0, 2)
-    preview = Text.of_iterable(fragment.text.lines[index] for index in matching_lines)
+    preview = matching_line_preview_of(fragment.text, matching_lines)
 
     return FragmentQuerySummary(
         museum_number=fragment.number,

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -6,6 +6,8 @@ from ebl.fragmentarium.application.fragment_fields_schemas import (
     DossierReferenceSchema,
 )
 from ebl.fragmentarium.application.fragment_query_summary_schema import (
+    FragmentQueryArchaeologySchema,
+    FragmentQueryMatchingLinePreviewSchema,
     FragmentQueryResultSchema,
     FragmentQuerySummarySchema,
 )
@@ -129,6 +131,31 @@ def test_fragment_query_summary_schema_roundtrip():
     )
 
 
+def test_fragment_query_summary_compares_with_compatible_query_item():
+    summary = build_summary()
+    item = QueryItem(summary.museum_number, summary.matching_lines, summary.match_count)
+
+    assert summary == item
+    assert summary.__eq__(object()) is NotImplemented
+
+
+def test_fragment_query_archaeology_schema_loads_non_dict_site():
+    archaeology = FragmentQueryArchaeologySchema().load({"site": "Nineveh"})
+
+    assert archaeology.site == "Nineveh"
+
+
+def test_matching_line_preview_skips_out_of_range_lines():
+    fragment = TransliteratedFragmentFactory.build()
+    line_count = len(fragment.text.lines)
+
+    preview = matching_line_preview_of(fragment.text, (0, line_count))
+    empty_preview = matching_line_preview_of(fragment.text, (line_count,))
+
+    assert len(preview["lines"]) == 1
+    assert FragmentQueryMatchingLinePreviewSchema().load(empty_preview)["lines"] == []
+
+
 def test_fragment_query_result_schema_roundtrip_and_compatibility():
     summary = build_summary()
     result = FragmentQueryResult((summary,), 7)
@@ -146,6 +173,13 @@ def test_fragment_query_result_schema_roundtrip_and_compatibility():
     )
     assert result == old_result
     assert old_result == result
+
+    assert FragmentQueryResultSchema(include_count_metadata=True).dump(result) == {
+        "items": [FragmentQuerySummarySchema().dump(summary)],
+        "matchCountTotal": 7,
+        "isMatchCountTotalExact": True,
+        "hasNextPage": None,
+    }
 
 
 def test_fragment_query_result_compatibility_respects_count_metadata():

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -24,7 +24,6 @@ from ebl.tests.factories.fragment import (
     TransliteratedFragmentFactory,
 )
 from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
-from ebl.transliteration.application.text_schema import TextSchema
 
 
 def build_summary() -> FragmentQuerySummary:
@@ -104,18 +103,17 @@ def test_fragment_query_summary_schema_dump_exact_shape():
         ],
         "dossiers": DossierReferenceSchema().dump(summary.dossiers, many=True),
         "matchingLines": [0, 2],
-        "matchingLinePreview": TextSchema().dump(summary.matching_line_preview),
+        "matchingLinePreview": summary.matching_line_preview,
         "matchCount": 2,
         "hasPhoto": True,
         "thumbnailPath": f"/fragments/{summary.museum_number}/thumbnail/small",
     }
-    assert dumped["matchingLinePreview"]["numberOfLines"] == 2
     assert dumped["matchingLinePreview"]["lines"][0]["prefix"] == (
-        summary.matching_line_preview.lines[0].line_number.atf
+        summary.matching_line_preview["lines"][0]["prefix"]
     )
-    assert dumped["matchingLinePreview"]["lines"][1]["prefix"] == (
-        summary.matching_line_preview.lines[1].line_number.atf
-    )
+    assert dumped["matchingLinePreview"]["lines"][0]["text"]
+    assert dumped["matchingLinePreview"]["lines"][0]["tokens"][0]["value"]
+    assert "parts" not in dumped["matchingLinePreview"]["lines"][0]["tokens"][0]
     assert "text" not in dumped
     assert "record" not in dumped
     assert "atf" not in dumped

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -145,3 +145,15 @@ def test_fragment_query_result_schema_roundtrip_and_compatibility():
     )
     assert result == old_result
     assert old_result == result
+
+
+def test_fragment_query_result_compatibility_respects_count_metadata():
+    summary = build_summary()
+    item = QueryItem(summary.museum_number, summary.matching_lines, summary.match_count)
+    result = FragmentQueryResult((summary,), None, False, True)
+    matching_query_result = QueryResult([item], None, False, True)
+    mismatched_query_result = QueryResult([item], None, False, False)
+
+    assert result == matching_query_result
+    assert matching_query_result == result
+    assert result != mismatched_query_result

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -50,9 +50,7 @@ def build_summary() -> FragmentQuerySummary:
         references=fragment.references,
         projects=(ResearchProject.CAIC, ResearchProject.RECC),
         dossiers=(
-            FragmentDossierReferenceFactory.build(
-                dossierId="DOS.1", isUncertain=True
-            ),
+            FragmentDossierReferenceFactory.build(dossierId="DOS.1", isUncertain=True),
         ),
         matching_lines=matching_lines,
         matching_line_preview=preview,

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -1,0 +1,56 @@
+from ebl.common.domain.period import Period
+from ebl.common.query.query_result import QueryItem, QueryResult
+from ebl.fragmentarium.application.fragment_query_summary_schema import (
+    FragmentQueryResultSchema,
+    FragmentQuerySummarySchema,
+)
+from ebl.fragmentarium.domain.fragment import Script
+from ebl.fragmentarium.domain.fragment_query_summary import (
+    FragmentQueryResult,
+    FragmentQuerySummary,
+)
+from ebl.transliteration.domain.museum_number import MuseumNumber
+
+
+def build_summary() -> FragmentQuerySummary:
+    return FragmentQuerySummary(
+        museum_number=MuseumNumber.of("K.1"),
+        accession=None,
+        description="desc",
+        script=Script(Period.OLD_ASSYRIAN),
+        matching_lines=(1, 3),
+        match_count=2,
+        has_photo=True,
+    )
+
+
+def test_fragment_query_summary_schema_dump_is_compact():
+    dumped = FragmentQuerySummarySchema().dump(build_summary())
+
+    assert dumped["museumNumber"] == {"prefix": "K", "number": "1", "suffix": ""}
+    assert dumped["matchingLines"] == [1, 3]
+    assert dumped["matchCount"] == 2
+    assert dumped["hasPhoto"] is True
+    assert dumped["thumbnailPath"] == "/fragments/K.1/thumbnail/small"
+    assert "text" not in dumped
+    assert "record" not in dumped
+
+
+def test_fragment_query_summary_schema_roundtrip():
+    summary = build_summary()
+
+    assert FragmentQuerySummarySchema().load(FragmentQuerySummarySchema().dump(summary)) == summary
+
+
+def test_fragment_query_result_schema_roundtrip_and_compatibility():
+    summary = build_summary()
+    result = FragmentQueryResult((summary,), 2)
+    dumped = FragmentQueryResultSchema().dump(result)
+
+    assert dumped["matchCountTotal"] == 2
+    assert dumped["items"][0]["thumbnailPath"] == "/fragments/K.1/thumbnail/small"
+    assert FragmentQueryResultSchema().load(dumped) == result
+
+    old_result = QueryResult([QueryItem(summary.museum_number, summary.matching_lines, 2)], 2)
+    assert result == old_result
+    assert old_result == result

--- a/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
+++ b/ebl/tests/fragmentarium/test_fragment_query_summary_schema.py
@@ -1,56 +1,151 @@
-from ebl.common.domain.period import Period
+from ebl.bibliography.application.reference_schema import ReferenceSchema
+from ebl.common.application.schemas import AccessionSchema
+from ebl.common.domain.project import ResearchProject
 from ebl.common.query.query_result import QueryItem, QueryResult
+from ebl.fragmentarium.application.fragment_fields_schemas import (
+    DossierReferenceSchema,
+)
 from ebl.fragmentarium.application.fragment_query_summary_schema import (
     FragmentQueryResultSchema,
     FragmentQuerySummarySchema,
 )
-from ebl.fragmentarium.domain.fragment import Script
+from ebl.fragmentarium.application.genre_schema import GenreSchema
+from ebl.fragmentarium.domain.date import DateSchema
 from ebl.fragmentarium.domain.fragment_query_summary import (
+    FragmentQueryArchaeology,
     FragmentQueryResult,
     FragmentQuerySummary,
 )
-from ebl.transliteration.domain.museum_number import MuseumNumber
+from ebl.schemas import ResearchProjectField
+from ebl.tests.factories.bibliography import ReferenceFactory
+from ebl.tests.factories.fragment import (
+    FragmentDossierReferenceFactory,
+    TransliteratedFragmentFactory,
+)
+from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
+from ebl.transliteration.application.text_schema import TextSchema
+from ebl.transliteration.domain.text import Text
 
 
 def build_summary() -> FragmentQuerySummary:
+    fragment = TransliteratedFragmentFactory.build(
+        references=(ReferenceFactory.build(), ReferenceFactory.build())
+    )
+    matching_lines = (0, 2)
+    preview = Text.of_iterable(fragment.text.lines[index] for index in matching_lines)
+
     return FragmentQuerySummary(
-        museum_number=MuseumNumber.of("K.1"),
-        accession=None,
-        description="desc",
-        script=Script(Period.OLD_ASSYRIAN),
-        matching_lines=(1, 3),
+        museum_number=fragment.number,
+        accession=fragment.accession,
+        description=fragment.description,
+        script=fragment.script,
+        date=fragment.date,
+        genres=fragment.genres,
+        archaeology=FragmentQueryArchaeology(
+            excavation_number=MuseumNumberSchema().load(
+                MuseumNumberSchema().dump(fragment.archaeology.excavation_number)
+            ),
+            site=fragment.archaeology.site.long_name,
+        ),
+        references=fragment.references,
+        projects=(ResearchProject.CAIC, ResearchProject.RECC),
+        dossiers=(
+            FragmentDossierReferenceFactory.build(
+                dossierId="DOS.1", isUncertain=True
+            ),
+        ),
+        matching_lines=matching_lines,
+        matching_line_preview=preview,
         match_count=2,
         has_photo=True,
     )
 
 
-def test_fragment_query_summary_schema_dump_is_compact():
-    dumped = FragmentQuerySummarySchema().dump(build_summary())
+def test_fragment_query_summary_schema_dump_exact_shape():
+    summary = build_summary()
+    dumped = FragmentQuerySummarySchema().dump(summary)
 
-    assert dumped["museumNumber"] == {"prefix": "K", "number": "1", "suffix": ""}
-    assert dumped["matchingLines"] == [1, 3]
-    assert dumped["matchCount"] == 2
-    assert dumped["hasPhoto"] is True
-    assert dumped["thumbnailPath"] == "/fragments/K.1/thumbnail/small"
+    assert set(dumped) == {
+        "museumNumber",
+        "accession",
+        "description",
+        "script",
+        "date",
+        "genres",
+        "archaeology",
+        "references",
+        "projects",
+        "dossiers",
+        "matchingLines",
+        "matchingLinePreview",
+        "matchCount",
+        "hasPhoto",
+        "thumbnailPath",
+    }
+    assert dumped == {
+        "museumNumber": MuseumNumberSchema().dump(summary.museum_number),
+        "accession": AccessionSchema().dump(summary.accession),
+        "description": summary.description,
+        "script": {
+            "period": summary.script.period.abbreviation,
+            "periodModifier": summary.script.period_modifier.value,
+            "uncertain": summary.script.uncertain,
+        },
+        "date": DateSchema().dump(summary.date),
+        "genres": GenreSchema().dump(summary.genres, many=True),
+        "archaeology": {
+            "excavationNumber": MuseumNumberSchema().dump(
+                summary.archaeology.excavation_number
+            ),
+            "site": {"name": summary.archaeology.site},
+        },
+        "references": ReferenceSchema().dump(summary.references, many=True),
+        "projects": [
+            ResearchProjectField()._serialize(project, None, None)
+            for project in summary.projects
+        ],
+        "dossiers": DossierReferenceSchema().dump(summary.dossiers, many=True),
+        "matchingLines": [0, 2],
+        "matchingLinePreview": TextSchema().dump(summary.matching_line_preview),
+        "matchCount": 2,
+        "hasPhoto": True,
+        "thumbnailPath": f"/fragments/{summary.museum_number}/thumbnail/small",
+    }
+    assert dumped["matchingLinePreview"]["numberOfLines"] == 2
+    assert dumped["matchingLinePreview"]["lines"][0]["prefix"] == (
+        summary.matching_line_preview.lines[0].line_number.atf
+    )
+    assert dumped["matchingLinePreview"]["lines"][1]["prefix"] == (
+        summary.matching_line_preview.lines[1].line_number.atf
+    )
     assert "text" not in dumped
     assert "record" not in dumped
+    assert "atf" not in dumped
 
 
 def test_fragment_query_summary_schema_roundtrip():
     summary = build_summary()
 
-    assert FragmentQuerySummarySchema().load(FragmentQuerySummarySchema().dump(summary)) == summary
+    assert (
+        FragmentQuerySummarySchema().load(FragmentQuerySummarySchema().dump(summary))
+        == summary
+    )
 
 
 def test_fragment_query_result_schema_roundtrip_and_compatibility():
     summary = build_summary()
-    result = FragmentQueryResult((summary,), 2)
+    result = FragmentQueryResult((summary,), 7)
     dumped = FragmentQueryResultSchema().dump(result)
 
-    assert dumped["matchCountTotal"] == 2
-    assert dumped["items"][0]["thumbnailPath"] == "/fragments/K.1/thumbnail/small"
+    assert dumped == {
+        "items": [FragmentQuerySummarySchema().dump(summary)],
+        "matchCountTotal": 7,
+    }
     assert FragmentQueryResultSchema().load(dumped) == result
 
-    old_result = QueryResult([QueryItem(summary.museum_number, summary.matching_lines, 2)], 2)
+    old_result = QueryResult(
+        [QueryItem(summary.museum_number, summary.matching_lines, summary.match_count)],
+        7,
+    )
     assert result == old_result
     assert old_result == result

--- a/ebl/tests/fragmentarium/test_fragment_repository.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository.py
@@ -12,6 +12,9 @@ from ebl.common.query.query_result import QueryItem, QueryResult
 
 from ebl.dictionary.domain.word import WordId
 from ebl.errors import NotFoundError
+from ebl.fragmentarium.application.fragment_query_summary_schema import (
+    FragmentQueryResultSchema,
+)
 from ebl.fragmentarium.application.fragment_repository import FragmentRepository
 from ebl.fragmentarium.domain.record import RecordType
 from ebl.fragmentarium.infrastructure.queries import LATEST_TRANSLITERATION_LINE_LIMIT
@@ -56,7 +59,10 @@ from ebl.transliteration.domain.transliteration_query import TransliterationQuer
 from ebl.transliteration.domain.word_tokens import Word
 from ebl.transliteration.application.signs_visitor import SignsVisitor
 from ebl.common.query.query_schemas import QueryResultSchema
-from ebl.tests.fragmentarium.test_fragments_search_route import query_item_of
+from ebl.tests.fragmentarium.test_fragments_search_route import (
+    query_item_of,
+    query_summary_of,
+)
 from ebl.transliteration.application.sign_repository import SignRepository
 
 
@@ -688,6 +694,220 @@ def test_query_fragmentarium_sorting(fragment_repository, sign_repository, signs
         {
             "items": items,
             "matchCountTotal": 5,
+        }
+    )
+
+
+def test_query_fragmentarium_transliteration_limit_summary_preserves_order(
+    fragment_repository, sign_repository, signs
+):
+    for sign in signs:
+        sign_repository.create(sign)
+
+    fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(4)
+    ]
+    for index, fragment in enumerate(fragments):
+        fragment_repository.create(fragment, sort_key=index)
+
+    result = fragment_repository.query(
+        {
+            "transliteration": create_tranliteration_query_lines(
+                "KU", sign_repository
+            ),
+            "limit": 2,
+            "offset": 1,
+        }
+    )
+
+    assert result == FragmentQueryResultSchema().load(
+        {
+            "items": [
+                query_summary_of(fragment, matching_lines=[0])
+                for fragment in fragments[1:3]
+            ],
+            "matchCountTotal": 4,
+        }
+    )
+
+
+def test_query_fragmentarium_transliteration_limit_count_none(
+    fragment_repository, sign_repository, signs
+):
+    for sign in signs:
+        sign_repository.create(sign)
+
+    fragments = [
+        TransliteratedFragmentFactory.build(number=MuseumNumber.of(f"X.{index}"))
+        for index in range(3)
+    ]
+    fragment_repository.create_many(fragments)
+
+    result = fragment_repository.query(
+        {
+            "transliteration": create_tranliteration_query_lines(
+                "KU", sign_repository
+            ),
+            "limit": 2,
+            "count": "none",
+        }
+    )
+
+    assert result.match_count_total is None
+    assert result.is_match_count_total_exact is False
+    assert result.has_next_page is None
+    assert len(result.items) == 2
+
+
+def test_query_fragmentarium_transliteration_limit_count_page(
+    fragment_repository, sign_repository, signs
+):
+    for sign in signs:
+        sign_repository.create(sign)
+
+    fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(3)
+    ]
+    for index, fragment in enumerate(fragments):
+        fragment_repository.create(fragment, sort_key=index)
+
+    result = fragment_repository.query(
+        {
+            "transliteration": create_tranliteration_query_lines(
+                "KU", sign_repository
+            ),
+            "limit": 2,
+            "count": "page",
+        }
+    )
+    last_page_result = fragment_repository.query(
+        {
+            "transliteration": create_tranliteration_query_lines(
+                "KU", sign_repository
+            ),
+            "limit": 2,
+            "offset": 2,
+            "count": "page",
+        }
+    )
+
+    assert result.match_count_total is None
+    assert result.is_match_count_total_exact is False
+    assert result.has_next_page is True
+    assert [item.museum_number for item in result.items] == [
+        fragment.number for fragment in fragments[:2]
+    ]
+    assert last_page_result.match_count_total is None
+    assert last_page_result.is_match_count_total_exact is False
+    assert last_page_result.has_next_page is False
+    assert [item.museum_number for item in last_page_result.items] == [
+        fragments[2].number
+    ]
+
+
+def test_query_fragmentarium_limit_summary_hydrates_only_phase_one_ids(
+    monkeypatch, fragment_repository, sign_repository, signs
+):
+    for sign in signs:
+        sign_repository.create(sign)
+
+    visible_fragment = TransliteratedFragmentFactory.build(
+        number=MuseumNumber.of("X.1")
+    )
+    hidden_fragment = TransliteratedFragmentFactory.build(
+        number=MuseumNumber.of("X.2"),
+        authorized_scopes=[Scope.READ_ITALIANNINEVEH_FRAGMENTS],
+    )
+    fragment_repository.create(visible_fragment, sort_key=0)
+    fragment_repository.create(hidden_fragment, sort_key=1)
+
+    summary_queries = []
+    original_find_many = fragment_repository._fragments.find_many
+
+    def find_many(query, *args, **kwargs):
+        summary_queries.append(query)
+        return original_find_many(query, *args, **kwargs)
+
+    monkeypatch.setattr(fragment_repository._fragments, "find_many", find_many)
+
+    result = fragment_repository.query(
+        {
+            "transliteration": create_tranliteration_query_lines(
+                "KU", sign_repository
+            ),
+            "limit": 10,
+        },
+        user_scopes=(),
+    )
+
+    assert result == FragmentQueryResultSchema().load(
+        {
+            "items": [query_summary_of(visible_fragment, matching_lines=[0])],
+            "matchCountTotal": 1,
+        }
+    )
+    assert summary_queries == [{"_id": {"$in": [str(visible_fragment.number)]}}]
+
+
+def test_query_fragmentarium_limit_summary_missing_hydration_fails_clearly(
+    fragment_repository,
+):
+    with pytest.raises(NotFoundError, match="Fragment summary data"):
+        fragment_repository._load_fragment_query_result(
+            {
+                "items": [
+                    {
+                        "_id": "missing",
+                        "museumNumber": {
+                            "prefix": "K",
+                            "number": "1",
+                            "suffix": "",
+                        },
+                        "matchingLines": [],
+                        "matchCount": 0,
+                    }
+                ],
+                "matchCountTotal": 0,
+            }
+        )
+
+
+def test_query_fragmentarium_number_limit_summary_parser_version_fallback(
+    database, fragment_repository
+):
+    fragment = FragmentFactory.build(number=MuseumNumber.of("X.500"))
+    fragment_repository.create(fragment)
+    database[COLLECTION].update_one(
+        {"_id": str(fragment.number)}, {"$set": {"text.parser_version": None}}
+    )
+
+    result = fragment_repository.query({"number": str(fragment.number), "limit": 1})
+    dumped = FragmentQueryResultSchema().dump(result)
+
+    assert dumped["items"][0]["matchingLinePreview"]["parser_version"] is not None
+
+
+def test_query_fragmentarium_number_limit_summary_uses_bulk_photo_lookup(
+    database, fragment_repository
+):
+    fragment = FragmentFactory.build(number=MuseumNumber.of("X.501"))
+    fragment_repository.create(fragment)
+    database["photos.files"].insert_one({"filename": f"{fragment.number}.jpg"})
+
+    result = fragment_repository.query({"number": str(fragment.number), "limit": 1})
+
+    assert result == FragmentQueryResultSchema().load(
+        {
+            "items": [query_summary_of(fragment, has_photo=True)],
+            "matchCountTotal": 0,
         }
     )
 

--- a/ebl/tests/fragmentarium/test_fragment_repository.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository.py
@@ -870,6 +870,40 @@ def test_query_fragmentarium_limit_summary_missing_hydration_fails_clearly(
         )
 
 
+def test_query_fragmentarium_limit_summary_hydration_uses_safe_defaults(
+    fragment_repository,
+):
+    museum_number = {"prefix": "K", "number": "1", "suffix": ""}
+    result = FragmentQueryResultSchema().load(
+        {
+            "items": [
+                fragment_repository._hydrate_fragment_query_item(
+                    {
+                        "_id": "K.1",
+                        "museumNumber": museum_number,
+                        "matchingLines": [0, 1],
+                    },
+                    {
+                        "K.1": {
+                            "museumNumber": museum_number,
+                            "text": {
+                                "lines": [{"prefix": "1.", "content": []}],
+                            },
+                        }
+                    },
+                    (),
+                )
+            ],
+            "matchCountTotal": 0,
+        }
+    )
+    summary = result.items[0]
+
+    assert summary.description == ""
+    assert summary.script == Script()
+    assert len(summary.matching_line_preview["lines"]) == 1
+
+
 def test_query_fragmentarium_number_limit_summary_parser_version_fallback(
     database, fragment_repository
 ):

--- a/ebl/tests/fragmentarium/test_fragment_repository.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository.py
@@ -916,7 +916,7 @@ def test_query_fragmentarium_number_limit_summary_parser_version_fallback(
     result = fragment_repository.query({"number": str(fragment.number), "limit": 1})
     dumped = FragmentQueryResultSchema().dump(result)
 
-    assert dumped["items"][0]["matchingLinePreview"]["parser_version"] is not None
+    assert dumped["items"][0]["matchingLinePreview"]["parserVersion"] is not None
 
 
 def test_query_fragmentarium_number_limit_summary_uses_bulk_photo_lookup(

--- a/ebl/tests/fragmentarium/test_fragment_repository.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository.py
@@ -716,9 +716,7 @@ def test_query_fragmentarium_transliteration_limit_summary_preserves_order(
 
     result = fragment_repository.query(
         {
-            "transliteration": create_tranliteration_query_lines(
-                "KU", sign_repository
-            ),
+            "transliteration": create_tranliteration_query_lines("KU", sign_repository),
             "limit": 2,
             "offset": 1,
         }
@@ -749,9 +747,7 @@ def test_query_fragmentarium_transliteration_limit_count_none(
 
     result = fragment_repository.query(
         {
-            "transliteration": create_tranliteration_query_lines(
-                "KU", sign_repository
-            ),
+            "transliteration": create_tranliteration_query_lines("KU", sign_repository),
             "limit": 2,
             "count": "none",
         }
@@ -781,18 +777,14 @@ def test_query_fragmentarium_transliteration_limit_count_page(
 
     result = fragment_repository.query(
         {
-            "transliteration": create_tranliteration_query_lines(
-                "KU", sign_repository
-            ),
+            "transliteration": create_tranliteration_query_lines("KU", sign_repository),
             "limit": 2,
             "count": "page",
         }
     )
     last_page_result = fragment_repository.query(
         {
-            "transliteration": create_tranliteration_query_lines(
-                "KU", sign_repository
-            ),
+            "transliteration": create_tranliteration_query_lines("KU", sign_repository),
             "limit": 2,
             "offset": 2,
             "count": "page",
@@ -840,9 +832,7 @@ def test_query_fragmentarium_limit_summary_hydrates_only_phase_one_ids(
 
     result = fragment_repository.query(
         {
-            "transliteration": create_tranliteration_query_lines(
-                "KU", sign_repository
-            ),
+            "transliteration": create_tranliteration_query_lines("KU", sign_repository),
             "limit": 10,
         },
         user_scopes=(),

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -40,8 +40,14 @@ from ebl.tests.factories.fragment import (
     LemmatizedFragmentFactory,
 )
 from ebl.tests.factories.record import RecordEntryFactory, RecordFactory
+from ebl.transliteration.domain.line_number import LineNumber
 from ebl.transliteration.domain.museum_number import MuseumNumber
 from ebl.transliteration.application.museum_number_schema import MuseumNumberSchema
+from ebl.transliteration.domain.sign import Sign, Value
+from ebl.transliteration.domain.sign_tokens import Reading
+from ebl.transliteration.domain.text import Text
+from ebl.transliteration.domain.text_line import TextLine
+from ebl.transliteration.domain.word_tokens import Word
 from ebl.fragmentarium.domain.genres import genres
 from ebl.common.domain.scopes import Scope
 from ebl.tests.factories.provenance import build_provenance_records
@@ -74,6 +80,20 @@ def query_item_of(
         "museumNumber": MuseumNumberSchema().dump(fragment.number),
         "matchingLines": lines,
         "matchCount": len(lines) if match_count is None else match_count,
+    }
+
+
+def query_result_of(
+    items: List[Dict],
+    match_count_total: Optional[int],
+    is_match_count_total_exact: bool = True,
+    has_next_page: Optional[bool] = None,
+) -> Dict:
+    return {
+        "items": items,
+        "matchCountTotal": match_count_total,
+        "isMatchCountTotalExact": is_match_count_total_exact,
+        "hasNextPage": has_next_page,
     }
 
 
@@ -146,10 +166,7 @@ def test_query_fragmentarium_number(get_number, client, fragmentarium):
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json == {
-        "items": [query_summary_of(fragment)],
-        "matchCountTotal": 0,
-    }
+    assert result.json == query_result_of([query_item_of(fragment)], 0)
 
 
 def test_query_fragmentarium_number_summary_only(client, fragmentarium):
@@ -157,15 +174,15 @@ def test_query_fragmentarium_number_summary_only(client, fragmentarium):
     fragmentarium.create(fragment)
     result = client.simulate_get(
         "/fragments/query",
-        params={"number": str(fragment.number)},
+        params={"number": str(fragment.number), "limit": "1"},
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json == {
-        "items": [query_summary_of(fragment, has_photo=True)],
-        "matchCountTotal": 0,
-    }
+    assert result.json == query_result_of(
+        [query_summary_of(fragment, has_photo=True)], 0
+    )
     assert result.json["items"][0]["matchingLinePreview"]["lines"] == []
+    assert result.json["items"][0]["matchingLinePreview"]["parser_version"] is not None
     assert "text" not in result.json["items"][0]
     assert "record" not in result.json["items"][0]
     assert "atf" not in result.json["items"][0]
@@ -177,7 +194,7 @@ def test_query_fragmentarium_number_not_found(client):
         params={"number": "K.1"},
     )
 
-    assert result.json == {"items": [], "matchCountTotal": 0}
+    assert result.json == query_result_of([], 0)
 
 
 def test_query_fragmentarium_references(client, fragmentarium, bibliography, user):
@@ -202,10 +219,7 @@ def test_query_fragmentarium_references(client, fragmentarium, bibliography, use
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json == {
-        "items": [query_summary_of(fragment)],
-        "matchCountTotal": 0,
-    }
+    assert result.json == query_result_of([query_item_of(fragment)], 0)
 
 
 def test_query_fragmentarium_transliteration(
@@ -234,20 +248,14 @@ def test_query_fragmentarium_transliteration(
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json == {
-        "items": [
-            query_summary_of(fragment, matching_lines=[3])
+    assert result.json == query_result_of(
+        [
+            query_item_of(fragment, matching_lines=[3])
             for fragment in transliterated_fragments
         ],
-        "matchCountTotal": 3,
-    }
-    preview = result.json["items"][0]["matchingLinePreview"]
-    assert preview["numberOfLines"] == 1
-    assert (
-        preview["lines"][0]["prefix"]
-        == transliterated_fragments[0].text.lines[3].line_number.atf
+        3,
     )
-    assert preview["lines"][0]["content"]
+    assert "matchingLinePreview" not in result.json["items"][0]
     assert "text" not in result.json["items"][0]
     assert "record" not in result.json["items"][0]
     assert "atf" not in result.json["items"][0]
@@ -278,6 +286,289 @@ def test_query_fragmentarium_transliteration_limit_preserves_total_count(
     assert result.status == falcon.HTTP_OK
     assert len(result.json["items"]) == 2
     assert result.json["matchCountTotal"] == 5
+    assert result.json["isMatchCountTotalExact"] is True
+    assert result.json["hasNextPage"] is None
+
+
+def test_query_fragmentarium_transliteration_count_exact(
+    client, fragmentarium, sign_repository, signs
+):
+    transliterated_fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(3)
+    ]
+
+    for fragment in transliterated_fragments:
+        fragmentarium.create(fragment)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂", "limit": "2", "count": "exact"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["matchCountTotal"] == 3
+    assert result.json["isMatchCountTotalExact"] is True
+    assert result.json["hasNextPage"] is None
+
+
+def test_query_fragmentarium_transliteration_count_none(
+    client, fragmentarium, sign_repository, signs
+):
+    transliterated_fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(3)
+    ]
+
+    for fragment in transliterated_fragments:
+        fragmentarium.create(fragment)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂", "limit": "2", "count": "none"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert len(result.json["items"]) == 2
+    assert result.json["matchCountTotal"] is None
+    assert result.json["isMatchCountTotalExact"] is False
+    assert result.json["hasNextPage"] is None
+
+
+def test_query_fragmentarium_transliteration_count_page(
+    client, fragmentarium, sign_repository, signs
+):
+    transliterated_fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(3)
+    ]
+
+    for index, fragment in enumerate(transliterated_fragments):
+        fragmentarium.create(fragment, sort_key=index)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂", "limit": "2", "count": "page"},
+    )
+    last_page_result = client.simulate_get(
+        "/fragments/query",
+        params={
+            "transliteration": "ma-tu₂",
+            "limit": "2",
+            "offset": "2",
+            "count": "page",
+        },
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of(
+        [
+            query_summary_of(fragment, matching_lines=[3])
+            for fragment in transliterated_fragments[:2]
+        ],
+        None,
+        False,
+        True,
+    )
+    assert last_page_result.status == falcon.HTTP_OK
+    assert last_page_result.json == query_result_of(
+        [query_summary_of(transliterated_fragments[2], matching_lines=[3])],
+        None,
+        False,
+        False,
+    )
+
+
+def test_query_fragmentarium_transliteration_limit_with_offset(
+    client, fragmentarium, sign_repository, signs
+):
+    transliterated_fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(4)
+    ]
+
+    for index, fragment in enumerate(transliterated_fragments):
+        fragmentarium.create(fragment, sort_key=index)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂", "limit": "2", "offset": "1"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of(
+        [
+            query_summary_of(fragment, matching_lines=[3])
+            for fragment in transliterated_fragments[1:3]
+        ],
+        4,
+    )
+    assert result.json["items"][0]["matchingLinePreview"]["parser_version"] is not None
+
+
+def test_query_fragmentarium_transliteration_offset_without_limit_returns_lean_items(
+    client, fragmentarium, sign_repository, signs
+):
+    transliterated_fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(4)
+    ]
+
+    for index, fragment in enumerate(transliterated_fragments):
+        fragmentarium.create(fragment, sort_key=index)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂", "offset": "2"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of(
+        [
+            query_item_of(fragment, matching_lines=[3])
+            for fragment in transliterated_fragments[2:]
+        ],
+        4,
+    )
+
+
+def test_query_fragmentarium_transliteration_offset_zero_is_accepted(
+    client, fragmentarium, sign_repository, signs
+):
+    fragment = TransliteratedFragmentFactory.build(
+        number=MuseumNumber.of("X.0"),
+        script=Script(Period.LATE_BABYLONIAN),
+    )
+    fragmentarium.create(fragment)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂", "limit": "1", "offset": "0"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of(
+        [query_summary_of(fragment, matching_lines=[3])], 1
+    )
+
+
+@pytest.mark.parametrize("offset", ["invalid", "-1"])
+def test_query_fragmentarium_offset_invalid(client, offset):
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"number": "K.1", "offset": offset},
+    )
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize("count", ["false", "0", "random", "approx"])
+def test_query_fragmentarium_count_invalid(client, count):
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"number": "K.1", "count": count},
+    )
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+
+
+def test_query_fragmentarium_transliteration_without_limit_returns_all_lean_items(
+    client, fragmentarium, sign_repository, signs
+):
+    transliterated_fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(101)
+    ]
+
+    for fragment in transliterated_fragments:
+        fragmentarium.create(fragment)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert len(result.json["items"]) == 101
+    assert result.json["matchCountTotal"] == 101
+    assert "matchingLinePreview" not in result.json["items"][0]
+
+
+def test_query_fragmentarium_kur2_transliteration_returns_summary(
+    client, fragmentarium, sign_repository
+):
+    fragment = TransliteratedFragmentFactory.build(
+        number=MuseumNumber.of("X.4936"),
+        signs="KUR₂",
+        text=Text(
+            (
+                TextLine.of_iterable(
+                    LineNumber(1), (Word.of([Reading.of_name("kur", 2)]),)
+                ),
+            )
+        ),
+    )
+    fragmentarium.create(fragment)
+    sign_repository.create(Sign("KUR₂", values=(Value("kur", 2),)))
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "kur₂", "limit": "1"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of(
+        [query_summary_of(fragment, matching_lines=[0])], 1
+    )
+    assert result.json["items"][0]["matchingLinePreview"]["parser_version"] is not None
+    assert "description" in result.json["items"][0]
+    assert "script" in result.json["items"][0]
+    assert "hasPhoto" in result.json["items"][0]
+    preview_line = result.json["items"][0]["matchingLinePreview"]["lines"][0]
+    assert preview_line["text"] == "kur₂"
+    assert preview_line["tokens"][0]["value"] == "kur₂"
+    assert preview_line["tokens"][0]["cleanValue"] == "kur₂"
+    assert preview_line["tokens"][0]["type"] == "Word"
+    assert "parts" not in preview_line["tokens"][0]
 
 
 @pytest.mark.parametrize(
@@ -301,10 +592,10 @@ def test_query_fragmentarium_lemmas(
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json == {
-        "items": [query_summary_of(fragment, matching_lines=expected_lines)],
-        "matchCountTotal": len(expected_lines),
-    }
+    assert result.json == query_result_of(
+        [query_item_of(fragment, matching_lines=expected_lines)],
+        len(expected_lines),
+    )
 
 
 def test_query_fragmentarium_lemmas_not_found(client, fragmentarium):
@@ -316,10 +607,7 @@ def test_query_fragmentarium_lemmas_not_found(client, fragmentarium):
         params={"lemmaOperator": "phrase", "lemmas": "u I+u I+u I"},
     )
     assert result.status == falcon.HTTP_OK
-    assert result.json == {
-        "items": [],
-        "matchCountTotal": 0,
-    }
+    assert result.json == query_result_of([], 0)
 
 
 def test_query_fragmentarium_combined_query(
@@ -355,10 +643,9 @@ def test_query_fragmentarium_combined_query(
 
     assert result.status == falcon.HTTP_OK
 
-    assert result.json == {
-        "items": [query_summary_of(fragment, matching_lines=[1, 3])],
-        "matchCountTotal": 2,
-    }
+    assert result.json == query_result_of(
+        [query_item_of(fragment, matching_lines=[1, 3])], 2
+    )
 
 
 def test_query_signs_invalid(client, fragmentarium, sign_repository, signs):
@@ -459,16 +746,32 @@ def test_search_with_scopes(client, guest_client, fragmentarium):
     guest_result = guest_client.simulate_get("/fragments/query", params=params)
 
     assert result.status == falcon.HTTP_OK
-    assert result.json == {
-        "items": [query_summary_of(fragment)],
-        "matchCountTotal": 0,
-    }
+    assert result.json == query_result_of([query_item_of(fragment)], 0)
 
     assert guest_result.status == falcon.HTTP_OK
-    assert guest_result.json == {
-        "items": [],
-        "matchCountTotal": 0,
+    assert guest_result.json == query_result_of([], 0)
+
+
+def test_search_with_scopes_limit_summary(client, guest_client, fragmentarium):
+    fragment = FragmentFactory.build(
+        number=MuseumNumber.of("X.404"),
+        authorized_scopes=[Scope.READ_ITALIANNINEVEH_FRAGMENTS],
+    )
+    params = {
+        "number": str(fragment.number),
+        "limit": "1",
     }
+
+    fragmentarium.create(fragment)
+
+    result = client.simulate_get("/fragments/query", params=params)
+    guest_result = guest_client.simulate_get("/fragments/query", params=params)
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of([query_summary_of(fragment)], 0)
+
+    assert guest_result.status == falcon.HTTP_OK
+    assert guest_result.json == query_result_of([], 0)
 
 
 @pytest.mark.parametrize(
@@ -497,10 +800,9 @@ def test_search_script_period(client, fragmentarium, params, expected):
     for fragment in fragments:
         fragmentarium.create(fragment)
 
-    expected_json = {
-        "items": [query_summary_of(fragments[i]) for i in expected],
-        "matchCountTotal": 0,
-    }
+    expected_json = query_result_of(
+        [query_item_of(fragments[i]) for i in expected], 0
+    )
 
     result = client.simulate_get("/fragments/query", params=params)
 
@@ -525,14 +827,14 @@ def test_search_project(client, fragmentarium, project):
     for fragment in fragments:
         fragmentarium.create(fragment)
 
-    expected_json = {
-        "items": [
-            query_summary_of(fragment)
+    expected_json = query_result_of(
+        [
+            query_item_of(fragment)
             for fragment in fragments
             if project in fragment.projects
         ],
-        "matchCountTotal": 0,
-    }
+        0,
+    )
 
     result = client.simulate_get(
         "/fragments/query", params={"project": project.abbreviation}
@@ -561,14 +863,14 @@ def test_search_museum(client, fragmentarium, museum, attribute):
         fragmentarium.create(fragment)
         print(f"Fragment created in fragmentarium: {fragment}")
 
-    expected_json = {
-        "items": [
-            query_summary_of(fragment)
+    expected_json = query_result_of(
+        [
+            query_item_of(fragment)
             for fragment in fragments
             if fragment.museum == museum
         ],
-        "matchCountTotal": 0,
-    }
+        0,
+    )
 
     print(f"Expected JSON: {expected_json}")
     print(f"Requesting with museum attribute: {getattr(museum, attribute)}")
@@ -604,14 +906,14 @@ def test_search_site(client, fragmentarium, site, attribute):
     for fragment in fragments:
         fragmentarium.create(fragment)
 
-    expected_json = {
-        "items": [
-            query_summary_of(fragment)
+    expected_json = query_result_of(
+        [
+            query_item_of(fragment)
             for fragment in fragments
             if fragment.archaeology.site == site
         ],
-        "matchCountTotal": 0,
-    }
+        0,
+    )
 
     result = client.simulate_get(
         "/fragments/query", params={"site": getattr(site, attribute)}
@@ -645,7 +947,7 @@ def test_search_parent_site_returns_no_results(
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json == {"items": [], "matchCountTotal": 0}
+    assert result.json == query_result_of([], 0)
 
 
 def test_query_latest(client, fragmentarium):

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -800,9 +800,7 @@ def test_search_script_period(client, fragmentarium, params, expected):
     for fragment in fragments:
         fragmentarium.create(fragment)
 
-    expected_json = query_result_of(
-        [query_item_of(fragments[i]) for i in expected], 0
-    )
+    expected_json = query_result_of([query_item_of(fragments[i]) for i in expected], 0)
 
     result = client.simulate_get("/fragments/query", params=params)
 

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -14,6 +14,9 @@ from ebl.fragmentarium.application.fragment_info_schema import (
 from ebl.fragmentarium.application.fragment_query_summary_schema import (
     FragmentQuerySummarySchema,
 )
+from ebl.fragmentarium.application.fragment_fields_schemas import (
+    DossierReferenceSchema,
+)
 from ebl.fragmentarium.domain.fragment_query_summary import (
     FragmentQueryArchaeology,
     FragmentQuerySummary,
@@ -105,8 +108,16 @@ def query_summary_of(
             genres=fragment.genres,
             archaeology=archaeology,
             references=fragment.references,
-            projects=fragment.projects,
-            dossiers=fragment.dossiers,
+            projects=tuple(
+                project
+                if isinstance(project, ResearchProject)
+                else ResearchProject.from_abbreviation(str(project))
+                for project in fragment.projects
+            ),
+            dossiers=tuple(
+                DossierReferenceSchema().load(DossierReferenceSchema().dump(dossier))
+                for dossier in fragment.dossiers
+            ),
             matching_lines=tuple(lines),
             matching_line_preview=preview,
             match_count=len(lines) if match_count is None else match_count,

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -11,6 +11,10 @@ from ebl.fragmentarium.application.fragment_info_schema import (
     ApiFragmentInfoSchema,
     ApiFragmentInfosPaginationSchema,
 )
+from ebl.fragmentarium.application.fragment_query_summary_schema import (
+    FragmentQuerySummarySchema,
+)
+from ebl.fragmentarium.domain.fragment_query_summary import FragmentQuerySummary
 from ebl.fragmentarium.domain.fragment import Fragment, Script
 from ebl.fragmentarium.domain.fragment_info import FragmentInfo
 from ebl.fragmentarium.domain.fragment_infos_pagination import FragmentInfosPagination
@@ -66,6 +70,29 @@ def query_item_of(
     }
 
 
+def query_summary_of(
+    fragment: Fragment,
+    matching_lines: Optional[List[int]] = None,
+    match_count: Optional[int] = None,
+    has_photo: bool = False,
+) -> Dict:
+    lines = [] if matching_lines is None else matching_lines
+
+    return FragmentQuerySummarySchema().dump(
+        FragmentQuerySummary(
+            museum_number=fragment.number,
+            accession=fragment.accession,
+            description=fragment.description,
+            script=fragment.script,
+            date=fragment.date,
+            genres=fragment.genres,
+            matching_lines=tuple(lines),
+            match_count=len(lines) if match_count is None else match_count,
+            has_photo=has_photo,
+        )
+    )
+
+
 @pytest.mark.parametrize(
     "get_number",
     [
@@ -87,9 +114,26 @@ def test_query_fragmentarium_number(get_number, client, fragmentarium):
 
     assert result.status == falcon.HTTP_OK
     assert result.json == {
-        "items": [query_item_of(fragment)],
+        "items": [query_summary_of(fragment)],
         "matchCountTotal": 0,
     }
+
+
+def test_query_fragmentarium_number_summary_only(client, fragmentarium):
+    fragment = FragmentFactory.build(number=MuseumNumber.of("K.1"))
+    fragmentarium.create(fragment)
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"number": str(fragment.number)},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == {
+        "items": [query_summary_of(fragment, has_photo=True)],
+        "matchCountTotal": 0,
+    }
+    assert "text" not in result.json["items"][0]
+    assert "record" not in result.json["items"][0]
 
 
 def test_query_fragmentarium_number_not_found(client):
@@ -124,7 +168,7 @@ def test_query_fragmentarium_references(client, fragmentarium, bibliography, use
 
     assert result.status == falcon.HTTP_OK
     assert result.json == {
-        "items": [query_item_of(fragment)],
+        "items": [query_summary_of(fragment)],
         "matchCountTotal": 0,
     }
 
@@ -157,11 +201,38 @@ def test_query_fragmentarium_transliteration(
     assert result.status == falcon.HTTP_OK
     assert result.json == {
         "items": [
-            query_item_of(fragment, matching_lines=[3])
+            query_summary_of(fragment, matching_lines=[3])
             for fragment in transliterated_fragments
         ],
         "matchCountTotal": 3,
     }
+
+
+def test_query_fragmentarium_transliteration_limit_preserves_total_count(
+    client, fragmentarium, sign_repository, signs
+):
+    transliterated_fragments = [
+        TransliteratedFragmentFactory.build(
+            number=MuseumNumber.of(f"X.{index}"),
+            script=Script(Period.LATE_BABYLONIAN),
+        )
+        for index in range(5)
+    ]
+
+    for fragment in transliterated_fragments:
+        fragmentarium.create(fragment)
+
+    for sign in signs:
+        sign_repository.create(sign)
+
+    result = client.simulate_get(
+        "/fragments/query",
+        params={"transliteration": "ma-tu₂", "limit": "2"},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert len(result.json["items"]) == 2
+    assert result.json["matchCountTotal"] == 5
 
 
 @pytest.mark.parametrize(
@@ -186,7 +257,7 @@ def test_query_fragmentarium_lemmas(
 
     assert result.status == falcon.HTTP_OK
     assert result.json == {
-        "items": [query_item_of(fragment, matching_lines=expected_lines)],
+        "items": [query_summary_of(fragment, matching_lines=expected_lines)],
         "matchCountTotal": len(expected_lines),
     }
 
@@ -240,7 +311,7 @@ def test_query_fragmentarium_combined_query(
     assert result.status == falcon.HTTP_OK
 
     assert result.json == {
-        "items": [query_item_of(fragment, matching_lines=[1, 3])],
+        "items": [query_summary_of(fragment, matching_lines=[1, 3])],
         "matchCountTotal": 2,
     }
 
@@ -344,7 +415,7 @@ def test_search_with_scopes(client, guest_client, fragmentarium):
 
     assert result.status == falcon.HTTP_OK
     assert result.json == {
-        "items": [query_item_of(fragment)],
+        "items": [query_summary_of(fragment)],
         "matchCountTotal": 0,
     }
 
@@ -382,7 +453,7 @@ def test_search_script_period(client, fragmentarium, params, expected):
         fragmentarium.create(fragment)
 
     expected_json = {
-        "items": [query_item_of(fragments[i]) for i in expected],
+        "items": [query_summary_of(fragments[i]) for i in expected],
         "matchCountTotal": 0,
     }
 
@@ -411,7 +482,7 @@ def test_search_project(client, fragmentarium, project):
 
     expected_json = {
         "items": [
-            query_item_of(fragment)
+            query_summary_of(fragment)
             for fragment in fragments
             if project in fragment.projects
         ],
@@ -447,7 +518,7 @@ def test_search_museum(client, fragmentarium, museum, attribute):
 
     expected_json = {
         "items": [
-            query_item_of(fragment)
+            query_summary_of(fragment)
             for fragment in fragments
             if fragment.museum == museum
         ],
@@ -490,7 +561,7 @@ def test_search_site(client, fragmentarium, site, attribute):
 
     expected_json = {
         "items": [
-            query_item_of(fragment)
+            query_summary_of(fragment)
             for fragment in fragments
             if fragment.archaeology.site == site
         ],

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -197,6 +197,13 @@ def test_query_fragmentarium_number_not_found(client):
     assert result.json == query_result_of([], 0)
 
 
+def test_query_fragmentarium_empty_query_includes_count_metadata(client):
+    result = client.simulate_get("/fragments/query")
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of([], 0)
+
+
 def test_query_fragmentarium_references(client, fragmentarium, bibliography, user):
     bib_entry_1 = BibliographyEntryFactory.build(id="RN.0", pages="254")
     bib_entry_2 = BibliographyEntryFactory.build(id="RN.1")

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -182,7 +182,7 @@ def test_query_fragmentarium_number_summary_only(client, fragmentarium):
         [query_summary_of(fragment, has_photo=True)], 0
     )
     assert result.json["items"][0]["matchingLinePreview"]["lines"] == []
-    assert result.json["items"][0]["matchingLinePreview"]["parser_version"] is not None
+    assert result.json["items"][0]["matchingLinePreview"]["parserVersion"] is not None
     assert "text" not in result.json["items"][0]
     assert "record" not in result.json["items"][0]
     assert "atf" not in result.json["items"][0]
@@ -263,6 +263,8 @@ def test_query_fragmentarium_transliteration(
         3,
     )
     assert "matchingLinePreview" not in result.json["items"][0]
+    assert "hasPhoto" not in result.json["items"][0]
+    assert "thumbnailPath" not in result.json["items"][0]
     assert "text" not in result.json["items"][0]
     assert "record" not in result.json["items"][0]
     assert "atf" not in result.json["items"][0]
@@ -434,7 +436,7 @@ def test_query_fragmentarium_transliteration_limit_with_offset(
         ],
         4,
     )
-    assert result.json["items"][0]["matchingLinePreview"]["parser_version"] is not None
+    assert result.json["items"][0]["matchingLinePreview"]["parserVersion"] is not None
 
 
 def test_query_fragmentarium_transliteration_offset_without_limit_returns_lean_items(
@@ -566,7 +568,7 @@ def test_query_fragmentarium_kur2_transliteration_returns_summary(
     assert result.json == query_result_of(
         [query_summary_of(fragment, matching_lines=[0])], 1
     )
-    assert result.json["items"][0]["matchingLinePreview"]["parser_version"] is not None
+    assert result.json["items"][0]["matchingLinePreview"]["parserVersion"] is not None
     assert "description" in result.json["items"][0]
     assert "script" in result.json["items"][0]
     assert "hasPhoto" in result.json["items"][0]

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -14,7 +14,10 @@ from ebl.fragmentarium.application.fragment_info_schema import (
 from ebl.fragmentarium.application.fragment_query_summary_schema import (
     FragmentQuerySummarySchema,
 )
-from ebl.fragmentarium.domain.fragment_query_summary import FragmentQuerySummary
+from ebl.fragmentarium.domain.fragment_query_summary import (
+    FragmentQueryArchaeology,
+    FragmentQuerySummary,
+)
 from ebl.fragmentarium.domain.fragment import Fragment, Script
 from ebl.fragmentarium.domain.fragment_info import FragmentInfo
 from ebl.fragmentarium.domain.fragment_infos_pagination import FragmentInfosPagination
@@ -38,6 +41,7 @@ from ebl.transliteration.application.museum_number_schema import MuseumNumberSch
 from ebl.fragmentarium.domain.genres import genres
 from ebl.common.domain.scopes import Scope
 from ebl.tests.factories.provenance import build_provenance_records
+from ebl.transliteration.domain.text import Text
 
 
 def get_provenance_record(record_id: str):
@@ -77,6 +81,19 @@ def query_summary_of(
     has_photo: bool = False,
 ) -> Dict:
     lines = [] if matching_lines is None else matching_lines
+    archaeology = (
+        FragmentQueryArchaeology(
+            excavation_number=fragment.archaeology.excavation_number,
+            site=(
+                fragment.archaeology.site.long_name
+                if fragment.archaeology.site
+                else None
+            ),
+        )
+        if fragment.archaeology is not None
+        else None
+    )
+    preview = Text.of_iterable(fragment.text.lines[index] for index in lines)
 
     return FragmentQuerySummarySchema().dump(
         FragmentQuerySummary(
@@ -86,7 +103,12 @@ def query_summary_of(
             script=fragment.script,
             date=fragment.date,
             genres=fragment.genres,
+            archaeology=archaeology,
+            references=fragment.references,
+            projects=fragment.projects,
+            dossiers=fragment.dossiers,
             matching_lines=tuple(lines),
+            matching_line_preview=preview,
             match_count=len(lines) if match_count is None else match_count,
             has_photo=has_photo,
         )
@@ -132,8 +154,10 @@ def test_query_fragmentarium_number_summary_only(client, fragmentarium):
         "items": [query_summary_of(fragment, has_photo=True)],
         "matchCountTotal": 0,
     }
+    assert result.json["items"][0]["matchingLinePreview"]["lines"] == []
     assert "text" not in result.json["items"][0]
     assert "record" not in result.json["items"][0]
+    assert "atf" not in result.json["items"][0]
 
 
 def test_query_fragmentarium_number_not_found(client):
@@ -206,6 +230,16 @@ def test_query_fragmentarium_transliteration(
         ],
         "matchCountTotal": 3,
     }
+    preview = result.json["items"][0]["matchingLinePreview"]
+    assert preview["numberOfLines"] == 1
+    assert (
+        preview["lines"][0]["prefix"]
+        == transliterated_fragments[0].text.lines[3].line_number.atf
+    )
+    assert preview["lines"][0]["content"]
+    assert "text" not in result.json["items"][0]
+    assert "record" not in result.json["items"][0]
+    assert "atf" not in result.json["items"][0]
 
 
 def test_query_fragmentarium_transliteration_limit_preserves_total_count(

--- a/ebl/tests/fragmentarium/test_fragments_search_route.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route.py
@@ -17,6 +17,7 @@ from ebl.fragmentarium.application.fragment_query_summary_schema import (
 from ebl.fragmentarium.domain.fragment_query_summary import (
     FragmentQueryArchaeology,
     FragmentQuerySummary,
+    matching_line_preview_of,
 )
 from ebl.fragmentarium.domain.fragment import Fragment, Script
 from ebl.fragmentarium.domain.fragment_info import FragmentInfo
@@ -41,7 +42,6 @@ from ebl.transliteration.application.museum_number_schema import MuseumNumberSch
 from ebl.fragmentarium.domain.genres import genres
 from ebl.common.domain.scopes import Scope
 from ebl.tests.factories.provenance import build_provenance_records
-from ebl.transliteration.domain.text import Text
 
 
 def get_provenance_record(record_id: str):
@@ -93,7 +93,7 @@ def query_summary_of(
         if fragment.archaeology is not None
         else None
     )
-    preview = Text.of_iterable(fragment.text.lines[index] for index in lines)
+    preview = matching_line_preview_of(fragment.text, lines)
 
     return FragmentQuerySummarySchema().dump(
         FragmentQuerySummary(


### PR DESCRIPTION
Optimize fragment search to support lightweight, paginated fragment summary responses with photo metadata, compact matching-line previews, and configurable count behavior.

**New Features**
-Add explicit-limit fragment query summary responses for /fragments/query.
-Return structured fragment summaries including description, date/dating data, genres, archaeology, references, projects, dossiers, match metadata, and compact matching-line previews.
-Expose hasPhoto and thumbnailPath metadata for fragments in search responses.
-Introduce dedicated fragment query summary/result domain models and schemas for rich search result responses.
-Add offset support for paginated fragment search results.
-Add count=exact|none|page support:
count=exact preserves exact matchCountTotal.
count=none skips exact total-count metadata.
count=page supports pagination via hasNextPage.

**Bug Fixes**
-Preserve exact total match counts for transliteration searches when an explicit result limit is applied.
-Preserve parser version fallback for matching-line previews.
-Avoid timeout-prone summary hydration behavior by limiting aggregation output before hydration.