### PR TITLE
dev: change lemmatization for summerian

### DIFF
--- a/ebl/tests/transliteration/test_alignment.py
+++ b/ebl/tests/transliteration/test_alignment.py
@@ -30,6 +30,16 @@ def test_apply_sumerian_word() -> None:
     assert alignment.apply(word) == expected
 
 
+def test_apply_emesal_word() -> None:
+    word = Word.of(language=Language.EMESAL, parts=[Reading.of_name("bu")])
+    alignment = AlignmentToken("bu", 0)
+    expected = Word.of(
+        language=Language.EMESAL, parts=[Reading.of_name("bu")], alignment=0
+    )
+
+    assert alignment.apply(word) == expected
+
+
 @pytest.mark.parametrize(
     "word",
     [

--- a/ebl/tests/transliteration/test_alignment.py
+++ b/ebl/tests/transliteration/test_alignment.py
@@ -20,11 +20,20 @@ def test_apply() -> None:
     assert alignment.apply(word) == expected
 
 
+def test_apply_sumerian_word() -> None:
+    word = Word.of(language=Language.SUMERIAN, parts=[Reading.of_name("bu")])
+    alignment = AlignmentToken("bu", 0)
+    expected = Word.of(
+        language=Language.SUMERIAN, parts=[Reading.of_name("bu")], alignment=0
+    )
+
+    assert alignment.apply(word) == expected
+
+
 @pytest.mark.parametrize(
     "word",
     [
         Word.of([Reading.of_name("mu")]),
-        Word.of(language=Language.SUMERIAN, parts=[Reading.of_name("bu")]),
         Word.of([Reading.of_name("bu"), Joiner.hyphen(), UnclearSign.of()]),
         Word.of([UnidentifiedSign.of(), Joiner.hyphen(), Reading.of_name("bu")]),
         Word.of([Variant.of(Reading.of_name("bu"), Reading.of_name("nu"))]),

--- a/ebl/tests/transliteration/test_greek_tokens.py
+++ b/ebl/tests/transliteration/test_greek_tokens.py
@@ -50,6 +50,15 @@ def test_greek_letter() -> None:
             True,
             True,
         ),
+        (
+            GreekWord.of(
+                (GreekLetter.of("α"), GreekLetter.of("β")), language=Language.EMESAL
+            ),
+            "αβ",
+            Language.EMESAL,
+            True,
+            True,
+        ),
     ],
 )
 def test_greek_word(

--- a/ebl/tests/transliteration/test_greek_tokens.py
+++ b/ebl/tests/transliteration/test_greek_tokens.py
@@ -47,7 +47,7 @@ def test_greek_letter() -> None:
             ),
             "αβ",
             Language.SUMERIAN,
-            False,
+            True,
             True,
         ),
     ],

--- a/ebl/tests/transliteration/test_language.py
+++ b/ebl/tests/transliteration/test_language.py
@@ -8,8 +8,8 @@ from ebl.transliteration.domain.language import DEFAULT_LANGUAGE, Language
     [
         (Language.UNKNOWN, True),
         (Language.AKKADIAN, True),
-        (Language.EMESAL, False),
-        (Language.SUMERIAN, False),
+        (Language.EMESAL, True),
+        (Language.SUMERIAN, True),
         (Language.HITTITE, False),
     ],
 )

--- a/ebl/tests/transliteration/test_word.py
+++ b/ebl/tests/transliteration/test_word.py
@@ -29,8 +29,8 @@ from ebl.transliteration.domain.word_tokens import AbstractWord, ErasureState, W
 
 LEMMATIZABLE_TEST_WORDS: List[Tuple[Word, bool]] = [
     (Word.of([Reading.of_name("un")]), True),
-    (Word.of([Reading.of_name("un")], language=Language.SUMERIAN), False),
-    (Word.of([Reading.of_name("un")], language=Language.EMESAL), False),
+    (Word.of([Reading.of_name("un")], language=Language.SUMERIAN), True),
+    (Word.of([Reading.of_name("un")], language=Language.EMESAL), True),
     (Word.of([Reading.of_name("un"), Joiner.hyphen(), UnclearSign.of()]), False),
     (Word.of([UnidentifiedSign.of(), Joiner.hyphen(), Reading.of_name("un")]), False),
     (Word.of([Variant.of(Reading.of_name("un"), Reading.of_name("ia"))]), False),
@@ -204,7 +204,6 @@ def test_set_unique_lemma_empty() -> None:
     "word",
     [
         Word.of([Reading.of_name("mu")]),
-        Word.of(language=Language.SUMERIAN, parts=[Reading.of_name("bu")]),
         Word.of([Reading.of_name("bu"), Joiner.hyphen(), UnclearSign.of()]),
         Word.of([UnidentifiedSign.of(), Joiner.hyphen(), Reading.of_name("bu")]),
         Word.of([Variant.of(Reading.of_name("bu"), Reading.of_name("nu"))]),
@@ -261,12 +260,20 @@ def test_set_alignment() -> None:
         (
             Word.of(unique_lemma=(WordId("nu I"),), parts=[Reading.of_name("bu")]),
             Word.of(language=Language.SUMERIAN, parts=[Reading.of_name("bu")]),
-            Word.of(language=Language.SUMERIAN, parts=[Reading.of_name("bu")]),
+            Word.of(
+                language=Language.SUMERIAN,
+                parts=[Reading.of_name("bu")],
+                unique_lemma=(WordId("nu I"),),
+            ),
         ),
         (
             Word.of(alignment=1, parts=[Reading.of_name("bu")]),
             Word.of(language=Language.SUMERIAN, parts=[Reading.of_name("bu")]),
-            Word.of(language=Language.SUMERIAN, parts=[Reading.of_name("bu")]),
+            Word.of(
+                language=Language.SUMERIAN,
+                parts=[Reading.of_name("bu")],
+                alignment=1,
+            ),
         ),
         (
             Word.of(

--- a/ebl/transliteration/domain/greek_tokens.py
+++ b/ebl/transliteration/domain/greek_tokens.py
@@ -49,7 +49,7 @@ class GreekWord(AbstractWord):
 
     @property
     def alignable(self) -> bool:
-        return self.lemmatizable or self.language == Language.SUMERIAN
+        return self.lemmatizable
 
     @property
     def value(self) -> str:

--- a/ebl/transliteration/domain/language.py
+++ b/ebl/transliteration/domain/language.py
@@ -11,7 +11,12 @@ class Language(Enum):
 
     @property
     def lemmatizable(self) -> bool:
-        return self.name in ["UNKNOWN", "AKKADIAN", "SUMERIAN", "EMESAL"]
+        return self in {
+            Language.UNKNOWN,
+            Language.AKKADIAN,
+            Language.SUMERIAN,
+            Language.EMESAL,
+        }
 
     @classmethod
     def of_atf(cls, code: str) -> "Language":

--- a/ebl/transliteration/domain/language.py
+++ b/ebl/transliteration/domain/language.py
@@ -11,7 +11,7 @@ class Language(Enum):
 
     @property
     def lemmatizable(self) -> bool:
-        return self.name in ["UNKNOWN", "AKKADIAN"]
+        return self.name in ["UNKNOWN", "AKKADIAN", "SUMERIAN", "EMESAL"]
 
     @classmethod
     def of_atf(cls, code: str) -> "Language":


### PR DESCRIPTION
ebl/transliteration/domain/language.py, add SUMERIAN and EMESAL to the list of lemmatizable (l. 14)

## Summary by Sourcery

Allow lemmatization for Sumerian and Emesal words and update tests accordingly.

New Features:
- Enable lemmatization for Sumerian and Emesal languages in the transliteration domain.

Tests:
- Adjust existing transliteration tests to reflect Sumerian and Emesal as lemmatizable languages and to ensure lemma and alignment properties are preserved for Sumerian words.