### PR TITLE
dev: added alias

### DIFF
--- a/docs/openapi/ebl-partner-bibliography.v1.yaml
+++ b/docs/openapi/ebl-partner-bibliography.v1.yaml
@@ -67,7 +67,7 @@ paths:
   /api/v1/bibliography/{idOrCitationKey}:
     get:
       summary: Get one bibliography entry
-      description: Read-only partner endpoint. Currently resolves by eBL bibliography `id`; citation-key lookup is reserved until stored citation keys exist. Requires `export:bibliography`.
+      description: Read-only partner endpoint. Resolves by eBL bibliography id, citation key, or trusted alias. The literal path segment `resolve` is reserved for `/api/v1/bibliography/resolve`; resolve that identifier with `/api/v1/bibliography/resolve?identifier=resolve`. Generated canonical ids are unaffected. Requires `export:bibliography`.
       security:
         - bearerAuth: []
       parameters:
@@ -120,6 +120,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DuplicateCandidateResponse"
+  /api/v1/bibliography/resolve:
+    get:
+      summary: Resolve a bibliography identifier
+      description: Read-only resolver for eBL bibliography ids, citation keys, or trusted aliases. This static route reserves the literal path segment `resolve`; a literal identifier equal to `resolve` must be resolved with `/api/v1/bibliography/resolve?identifier=resolve`. Generated canonical ids are unaffected. Requires `export:bibliography`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: identifier
+          required: true
+          schema:
+            type: string
+          description: eBL bibliography id, citation key, or trusted alias to resolve.
+      responses:
+        "200":
+          description: Resolved bibliography entry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PartnerBibliographyEntry"
+        "400":
+          description: Missing identifier query parameter.
+        "403":
+          description: Missing `export:bibliography` scope.
+        "404":
+          description: Bibliography entry not found.
+        "409":
+          description: Identifier is ambiguous or follows a redirect loop.
   /api/v1/bibliography/duplicate-candidates:
     post:
       summary: Check a proposed bibliography entry for likely duplicates

--- a/docs/openapi/ebl-partner-bibliography.v1.yaml
+++ b/docs/openapi/ebl-partner-bibliography.v1.yaml
@@ -33,7 +33,7 @@ paths:
           description: Missing `export:bibliography` scope.
     post:
       summary: Create a bibliography entry
-      description: Minimal partner create wrapper around existing bibliography create behavior. Requires `write:bibliography`. Duplicate detection runs before create; likely and possible duplicates return `409 Conflict`. Idempotency, external partner mapping persistence, and citationKey assignment are not implemented yet.
+      description: Create a partner bibliography entry. Requires `write:bibliography`. Duplicate detection runs before create; likely and possible duplicates return `409 Conflict`. The server assigns the canonical eBL bibliography id and citation key when enough citation data is present. A partner-submitted `id` is stored as a trusted alias, not honored as the canonical id. Idempotency and external partner mapping persistence are not implemented yet.
       security:
         - bearerAuth: []
       requestBody:
@@ -59,11 +59,13 @@ paths:
         "403":
           description: Missing `write:bibliography` scope.
         "409":
-          description: Duplicate candidate found; review before creating.
+          description: Duplicate candidate found; review before creating. Also returned when a submitted partner id or generated lookup value collides with an existing id, citation key, or alias.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/DuplicateCandidateResponse"
+        "422":
+          description: Unprocessable partner payload, including server-owned fields, control characters in partner ids, or internal CSL schema validation failures.
   /api/v1/bibliography/{idOrCitationKey}:
     get:
       summary: Get one bibliography entry
@@ -89,7 +91,7 @@ paths:
           description: Bibliography entry not found.
     post:
       summary: Update a bibliography entry
-      description: Minimal partner update wrapper around existing bibliography update behavior. Requires `write:bibliography`. The path value is treated as an eBL bibliography `id`; citationKey lookup is not active until citation keys are stored. Duplicate detection runs before update while excluding the record itself. Idempotency and external partner mapping persistence are not implemented yet.
+      description: Update a partner bibliography entry. Requires `write:bibliography`. The path value is resolved by eBL bibliography id, citation key, or trusted alias using the same lookup rules as GET. Duplicate detection runs before update while excluding the record itself. Idempotency and external partner mapping persistence are not implemented yet.
       security:
         - bearerAuth: []
       parameters:
@@ -98,7 +100,7 @@ paths:
           required: true
           schema:
             type: string
-          description: eBL bibliography id for update.
+          description: eBL bibliography id, citation key, or trusted alias for update. The literal path segment `resolve` is reserved for `/api/v1/bibliography/resolve`.
       requestBody:
         required: true
         content:
@@ -115,11 +117,13 @@ paths:
         "404":
           description: Bibliography entry not found.
         "409":
-          description: Duplicate candidate found; review before updating.
+          description: Duplicate candidate found; review before updating. Also returned when the identifier is ambiguous.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/DuplicateCandidateResponse"
+        "422":
+          description: Unprocessable partner payload, including server-owned fields or internal CSL schema validation failures.
   /api/v1/bibliography/resolve:
     get:
       summary: Resolve a bibliography identifier
@@ -217,12 +221,12 @@ components:
     BibliographyEntry:
       type: object
       required:
-        - id
         - type
-      additionalProperties: true
+      additionalProperties: false
       properties:
         id:
           type: string
+          description: Optional partner-provided id. On create, this value is stored as a trusted alias while the server assigns the canonical eBL bibliography id.
         type:
           type: string
         title:

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -1,64 +1,109 @@
 import re
 from typing import Any, Mapping, Optional, Sequence
 
+import attr
 from pydash import uniq_with
 
 from ebl.bibliography.application.duplicate_detection import (
     BibliographyDuplicateDetector,
 )
-from ebl.bibliography.application.duplicate_override import (
-    BLOCKING_DUPLICATE_DECISIONS,
-    DuplicateOverrideError,
-    validate_duplicate_override,
-)
 from ebl.bibliography.application.bibliography_repository import BibliographyRepository
-from ebl.bibliography.application.serialization import create_mongo_entry
-from ebl.bibliography.domain.reference import Reference
+from ebl.bibliography.application.bibliography_identity import (
+    create_with_identity_claims,
+    update_with_identity_claims,
+)
+from ebl.bibliography.application.partner_bibliography import PartnerBibliography
+from ebl.bibliography.domain.reference import BibliographyId, Reference
 from ebl.changelog import Changelog
-from ebl.errors import DataError, NotFoundError
+from ebl.errors import DataError, DuplicateError, NotFoundError
 from ebl.users.domain.user import User
 
-COLLECTION = "bibliography"
-DEFAULT_EXPORT_LIMIT = 50
-MAX_EXPORT_LIMIT = 100
+MAX_REDIRECT_DEPTH = 5
 
 
 class Bibliography:
     def __init__(self, repository: BibliographyRepository, changelog: Changelog):
         self._repository = repository
         self._changelog = changelog
+        self._partner = PartnerBibliography(self, repository)
 
     def create(self, entry, user: User) -> str:
-        self._changelog.create(
-            COLLECTION, user.profile, {"_id": entry["id"]}, create_mongo_entry(entry)
+        return create_with_identity_claims(
+            self._repository, self._changelog, self.find, entry, user
         )
-        return self._repository.create(entry)
 
     def find(self, id_: str):
-        return self._repository.query_by_id(id_)
+        for query in (
+            self._repository.query_by_id,
+            self._repository.query_by_citation_key,
+            self._repository.query_by_alias,
+        ):
+            try:
+                result = query(id_)
+            except NotFoundError:
+                continue
+            return self._follow_redirect(result)
+        raise NotFoundError(f"bibliography {id_} not found.")
 
     def find_many(self, ids: Sequence[str]):
-        return self._repository.query_by_ids(ids)
+        resolved_entries: list[dict] = []
+        seen_ids: set[str] = set()
+        for entry in self._repository.query_by_ids(ids):
+            resolved_entry = self._follow_redirect(entry)
+            resolved_id = resolved_entry["id"]
+            if resolved_id not in seen_ids:
+                resolved_entries.append(resolved_entry)
+                seen_ids.add(resolved_id)
+        return resolved_entries
+
+    def _follow_redirect(self, entry: dict) -> dict:
+        current = entry
+        visited_ids: set[str] = set()
+        redirects_followed = 0
+
+        while current.get("deprecated", False):
+            current_id = current.get("id")
+            redirect_to = current.get("redirectTo")
+            if not isinstance(redirect_to, str) or not redirect_to:
+                raise NotFoundError(
+                    f"Deprecated bibliography {current_id} has no redirect target."
+                )
+            if current_id in visited_ids or redirect_to in visited_ids:
+                raise DuplicateError(
+                    f"Bibliography redirect loop detected at {current_id}."
+                )
+            if redirects_followed >= MAX_REDIRECT_DEPTH:
+                raise DuplicateError(
+                    f"Bibliography redirect from {entry.get('id')} exceeds "
+                    f"the maximum depth of {MAX_REDIRECT_DEPTH}."
+                )
+
+            if isinstance(current_id, str):
+                visited_ids.add(current_id)
+            try:
+                current = self._repository.query_by_id(redirect_to)
+            except NotFoundError as error:
+                raise NotFoundError(
+                    f"Bibliography redirect target {redirect_to} not found."
+                ) from error
+            redirects_followed += 1
+
+        return current
 
     def update(self, entry, user: User):
-        old_entry = self._repository.query_by_id(entry["id"])
-        self._changelog.create(
-            COLLECTION,
-            user.profile,
-            create_mongo_entry(old_entry),
-            create_mongo_entry(entry),
+        update_with_identity_claims(
+            self._repository, self._changelog, self.find, entry, user
         )
-        self._repository.update(entry)
 
     def search(self, query: str) -> Sequence[dict]:
-        author_query_result = []
+        author_query_result: Sequence[dict] = []
         author_query = self._parse_author_year_and_title(query)
         if any(value is not None for value in author_query.values()):
             author_query_result = self.search_author_year_and_title(
                 author_query["author"], author_query["year"], author_query["title"]
             )
 
-        container_query_result = []
+        container_query_result: Sequence[dict] = []
         container_query = self._parse_container_title_short_and_collection_number(query)
         if any(value is not None for value in list(container_query.values())):
             container_query_result = self.search_container_title_and_collection_number(
@@ -66,17 +111,18 @@ class Bibliography:
                 container_query["collection_number"],
             )
 
-        title_short_volume_result = []
+        title_short_volume_result: Sequence[dict] = []
         title_short_volume_query = self._parse_title_short_and_volume(query)
         if any(value is not None for value in list(title_short_volume_query.values())):
             title_short_volume_result = self.search_title_short_and_volume(
                 title_short_volume_query["title_short"],
                 title_short_volume_query["volume"],
             )
-        return uniq_with(
+        results = uniq_with(
             [*author_query_result, *container_query_result, *title_short_volume_result],
             lambda a, b: a == b,
         )
+        return [entry for entry in results if not entry.get("deprecated", False)]
 
     def list_all_bibliography(self) -> Sequence[str]:
         return self._repository.list_all_bibliography()
@@ -89,52 +135,21 @@ class Bibliography:
         )
 
     def create_partner_entry(self, entry: dict, user: User) -> Optional[dict]:
-        if duplicate_result := self.find_blocking_duplicate_candidates(entry):
-            return duplicate_result
-        self.create(entry, user)
-        return None
+        return self._partner.create_entry(entry, user)
 
     def create_partner_entry_with_duplicate_override(
         self, entry: dict, override: Mapping[str, Any], user: User
     ) -> None:
-        duplicate_result = self.find_duplicate_candidates(entry)
-        if duplicate_result["decision"] not in BLOCKING_DUPLICATE_DECISIONS:
-            raise DuplicateOverrideError(
-                "No current duplicate candidates were found. "
-                "Use POST /api/v1/bibliography instead."
-            )
-        validate_duplicate_override(override, duplicate_result)
-        self.create(entry, user)
+        self._partner.create_entry_with_duplicate_override(entry, override, user)
 
     def update_partner_entry(self, id_: str, entry: dict, user: User) -> Optional[dict]:
-        updated_entry = {**entry, "id": id_}
-        if duplicate_result := self.find_blocking_duplicate_candidates(updated_entry):
-            return duplicate_result
-        self.update(updated_entry, user)
-        return None
+        return self._partner.update_entry(id_, entry, user)
 
-    def find_blocking_duplicate_candidates(self, entry: dict) -> Optional[dict]:
-        duplicate_result = self.find_duplicate_candidates(entry)
-        return (
-            duplicate_result
-            if duplicate_result["decision"] in BLOCKING_DUPLICATE_DECISIONS
-            else None
-        )
-
-    def export_page(
-        self, cursor: Optional[str] = None, limit: int = DEFAULT_EXPORT_LIMIT
-    ) -> dict:
-        result_limit = max(1, min(limit, MAX_EXPORT_LIMIT))
-        entries = list(self._repository.query_page(cursor, result_limit + 1))
-        items = entries[:result_limit]
-        return {
-            "items": [partner_bibliography_entry(entry) for entry in items],
-            "nextCursor": items[-1]["id"] if len(entries) > result_limit else None,
-            "limit": result_limit,
-        }
+    def export_page(self, cursor: Optional[str] = None, limit: int = 50) -> dict:
+        return self._partner.export_page(cursor, limit)
 
     def find_partner_entry(self, id_: str) -> dict:
-        return partner_bibliography_entry(self.find(id_))
+        return self._partner.find_entry(id_)
 
     @staticmethod
     def _parse_author_year_and_title(query: str) -> dict:
@@ -185,26 +200,25 @@ class Bibliography:
     ) -> Sequence[dict]:
         return self._repository.query_by_title_short_and_volume(title_short, volume)
 
-    def validate_references(self, references: Sequence[Reference]):
-        def is_invalid(reference):
-            try:
-                self.find(reference.id)
-                return False
-            except NotFoundError:
-                return True
+    def canonicalize_references(
+        self, references: Sequence[Reference]
+    ) -> tuple[Reference, ...]:
+        canonical_references: list[Reference] = []
+        invalid_references: list[str] = []
 
-        invalid_references = [
-            reference.id for reference in references if is_invalid(reference)
-        ]
+        for reference in references:
+            try:
+                entry = self.find(reference.id)
+            except NotFoundError:
+                invalid_references.append(reference.id)
+            else:
+                canonical_references.append(
+                    attr.evolve(reference, id=BibliographyId(entry["id"]))
+                )
+
         if invalid_references:
             raise DataError(
                 f"Unknown bibliography entries: {', '.join(invalid_references)}."
             )
 
-
-def partner_bibliography_entry(entry: Mapping[str, Any]) -> dict:
-    return {
-        "id": entry["id"],
-        "citationKey": entry.get("citationKey"),
-        "bibliographyEntry": dict(entry),
-    }
+        return tuple(canonical_references)

--- a/ebl/bibliography/application/bibliography_identity.py
+++ b/ebl/bibliography/application/bibliography_identity.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 from ebl.bibliography.application.bibliography_repository import (
@@ -28,7 +28,8 @@ def create_with_identity_claims(
     entry: dict[str, Any],
     user: User,
 ) -> str:
-    operation = new_lookup_reservation_operation(entry["id"], datetime.utcnow())
+    now = datetime.now(timezone.utc)
+    operation = new_lookup_reservation_operation(entry["id"], now)
     created = False
     try:
         repository.claim_lookup_values(operation, bibliography_lookup_values(entry))
@@ -39,7 +40,7 @@ def create_with_identity_claims(
             raise Defect(
                 f"Created bibliography id {created_id} does not match {entry['id']}."
             )
-        repository.commit_lookup_values(operation, datetime.utcnow())
+        repository.commit_lookup_values(operation, datetime.now(timezone.utc))
         changelog.create(
             COLLECTION, user.profile, {"_id": entry["id"]}, create_mongo_entry(entry)
         )
@@ -62,16 +63,17 @@ def update_with_identity_claims(
     new_values = identity_values(entry)
     values_to_claim = sorted(new_values - old_values)
     values_to_retire = sorted(old_values - new_values)
-    operation = new_lookup_reservation_operation(entry["id"], datetime.utcnow())
+    now = datetime.now(timezone.utc)
+    operation = new_lookup_reservation_operation(entry["id"], now)
     updated = False
     try:
         repository.claim_lookup_values(operation, values_to_claim)
         ensure_lookup_values_available(find, entry, entry["id"])
         repository.update(entry)
         updated = True
-        repository.commit_lookup_values(operation, datetime.utcnow())
+        repository.commit_lookup_values(operation, datetime.now(timezone.utc))
         repository.retire_lookup_values(
-            entry["id"], values_to_retire, datetime.utcnow()
+            entry["id"], values_to_retire, datetime.now(timezone.utc)
         )
         changelog.create(
             COLLECTION,

--- a/ebl/bibliography/application/bibliography_identity.py
+++ b/ebl/bibliography/application/bibliography_identity.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from typing import Any, Callable
+
+from ebl.bibliography.application.bibliography_repository import (
+    BibliographyRepository,
+    LookupValueInUseError,
+)
+from ebl.bibliography.application.lookup_identity import bibliography_lookup_values
+from ebl.bibliography.application.lookup_reservation import (
+    new_lookup_reservation_operation,
+)
+from ebl.bibliography.application.serialization import create_mongo_entry
+from ebl.changelog import Changelog
+from ebl.errors import Defect, NotFoundError
+from ebl.users.domain.user import User
+
+COLLECTION = "bibliography"
+
+
+def identity_values(entry: dict[str, Any]) -> set[str]:
+    return set(bibliography_lookup_values(entry))
+
+
+def create_with_identity_claims(
+    repository: BibliographyRepository,
+    changelog: Changelog,
+    find: Callable[[str], dict],
+    entry: dict[str, Any],
+    user: User,
+) -> str:
+    operation = new_lookup_reservation_operation(entry["id"], datetime.utcnow())
+    created = False
+    try:
+        repository.claim_lookup_values(operation, bibliography_lookup_values(entry))
+        ensure_lookup_values_available(find, entry)
+        created_id = repository.create(entry)
+        created = True
+        if created_id != entry["id"]:
+            raise Defect(
+                f"Created bibliography id {created_id} does not match {entry['id']}."
+            )
+        repository.commit_lookup_values(operation, datetime.utcnow())
+        changelog.create(
+            COLLECTION, user.profile, {"_id": entry["id"]}, create_mongo_entry(entry)
+        )
+        return created_id
+    except Exception:
+        if not created:
+            repository.release_pending_lookup_values(operation.owner)
+        raise
+
+
+def update_with_identity_claims(
+    repository: BibliographyRepository,
+    changelog: Changelog,
+    find: Callable[[str], dict],
+    entry: dict[str, Any],
+    user: User,
+) -> None:
+    old_entry = repository.query_by_id(entry["id"])
+    old_values = identity_values(old_entry)
+    new_values = identity_values(entry)
+    values_to_claim = sorted(new_values - old_values)
+    values_to_retire = sorted(old_values - new_values)
+    operation = new_lookup_reservation_operation(entry["id"], datetime.utcnow())
+    updated = False
+    try:
+        repository.claim_lookup_values(operation, values_to_claim)
+        ensure_lookup_values_available(find, entry, entry["id"])
+        repository.update(entry)
+        updated = True
+        repository.commit_lookup_values(operation, datetime.utcnow())
+        repository.retire_lookup_values(
+            entry["id"], values_to_retire, datetime.utcnow()
+        )
+        changelog.create(
+            COLLECTION,
+            user.profile,
+            create_mongo_entry(old_entry),
+            create_mongo_entry(entry),
+        )
+    except Exception:
+        if not updated:
+            repository.release_pending_lookup_values(operation.owner)
+        raise
+
+
+def ensure_lookup_values_available(
+    find: Callable[[str], dict], entry: dict[str, Any], allowed_id: str | None = None
+) -> None:
+    for value in bibliography_lookup_values(entry):
+        try:
+            existing_entry = find(value)
+        except NotFoundError:
+            continue
+        if allowed_id is None or existing_entry["id"] != allowed_id:
+            raise LookupValueInUseError(value)

--- a/ebl/bibliography/application/bibliography_repository.py
+++ b/ebl/bibliography/application/bibliography_repository.py
@@ -1,14 +1,72 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any, Optional, Sequence
+
+from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
+from ebl.errors import DuplicateError
+
+
+class LookupValueReservationError(DuplicateError):
+    def __init__(self, value: str):
+        self.value = value
+        super().__init__(f"Bibliography lookup value {value} is already reserved.")
+
+
+class LookupValueInUseError(DuplicateError):
+    def __init__(self, value: str):
+        self.value = value
+        super().__init__(f"Bibliography lookup value {value} is in use.")
 
 
 class BibliographyRepository(ABC):
+    @abstractmethod
+    def create_indexes(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def claim_lookup_values(
+        self, operation: LookupReservationOperation, values: Sequence[str]
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def commit_lookup_values(
+        self, operation: LookupReservationOperation, now: datetime
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def release_pending_lookup_values(self, owner: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def retire_lookup_values(
+        self, entry_id: str, values: Sequence[str], now: datetime
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def lookup_value_is_reserved(self, value: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def reconcile_lookup_reservations(self, now: datetime, limit: int = 100) -> int:
+        raise NotImplementedError
+
     @abstractmethod
     def create(self, entry: Any) -> str:
         raise NotImplementedError
 
     @abstractmethod
     def query_by_id(self, id_: str) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def query_by_citation_key(self, citation_key: str) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def query_by_alias(self, alias: str) -> Any:
         raise NotImplementedError
 
     @abstractmethod

--- a/ebl/bibliography/application/duplicate_audit_candidates.py
+++ b/ebl/bibliography/application/duplicate_audit_candidates.py
@@ -13,7 +13,8 @@ from ebl.bibliography.application.duplicate_audit_scoring import PairScore, scor
 
 
 def pair_key(left_id: str, right_id: str) -> tuple[str, str]:
-    return tuple(sorted((left_id, right_id)))
+    left, right = sorted((left_id, right_id))
+    return left, right
 
 
 def reviewed_not_duplicate_pairs(path: Optional[Path]) -> set[tuple[str, str]]:

--- a/ebl/bibliography/application/duplicate_audit_summary.py
+++ b/ebl/bibliography/application/duplicate_audit_summary.py
@@ -167,7 +167,7 @@ def count_present(entries: Sequence[NormalizedBibliographyEntry], field: str) ->
 
 
 def score_distribution(pairs: Sequence[PairScore]) -> dict[str, int]:
-    score_buckets = Counter()
+    score_buckets: Counter[str] = Counter()
     for pair in pairs:
         bucket_start = int(pair.score * 10) / 10
         score_buckets[f"{bucket_start:.1f}-{bucket_start + 0.1:.1f}"] += 1

--- a/ebl/bibliography/application/lookup_identity.py
+++ b/ebl/bibliography/application/lookup_identity.py
@@ -1,0 +1,16 @@
+from typing import Mapping
+
+
+def bibliography_lookup_values(entry: Mapping) -> list[str]:
+    values = [entry["id"]]
+    if isinstance(citation_key := entry.get("citationKey"), str) and citation_key:
+        values.append(citation_key)
+    for alias in entry.get("aliases", []):
+        if not isinstance(alias, Mapping):
+            continue
+        values.extend(
+            value
+            for value in (alias.get("value"), alias.get("normalizedValue"))
+            if isinstance(value, str) and value
+        )
+    return values

--- a/ebl/bibliography/application/lookup_reservation.py
+++ b/ebl/bibliography/application/lookup_reservation.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from uuid import uuid4
+
+PENDING_RESERVATION_LIFETIME = timedelta(hours=1)
+
+
+class LookupReservationState(str, Enum):
+    PENDING = "pending"
+    COMMITTED = "committed"
+    ABANDONED = "abandoned"
+
+
+@dataclass(frozen=True)
+class LookupReservationOperation:
+    owner: str
+    entry_id: str
+    expires_at: datetime
+
+
+def new_lookup_reservation_operation(
+    entry_id: str, now: datetime
+) -> LookupReservationOperation:
+    return LookupReservationOperation(
+        owner=uuid4().hex,
+        entry_id=entry_id,
+        expires_at=now + PENDING_RESERVATION_LIFETIME,
+    )

--- a/ebl/bibliography/application/partner_bibliography.py
+++ b/ebl/bibliography/application/partner_bibliography.py
@@ -1,0 +1,238 @@
+from typing import Any, Mapping, Optional, Protocol, Sequence, cast
+
+import jsonschema
+
+from ebl.bibliography.application.bibliography_repository import (
+    BibliographyRepository,
+    LookupValueInUseError,
+    LookupValueReservationError,
+)
+from ebl.bibliography.application.duplicate_override import (
+    BLOCKING_DUPLICATE_DECISIONS,
+    DuplicateOverrideError,
+    validate_duplicate_override,
+)
+from ebl.bibliography.application.partner_identity import (
+    create_partner_alias,
+    generate_partner_citation_key,
+    select_canonical_bibliography_id,
+)
+from ebl.bibliography.domain.bibliography_entry import (
+    CSL_JSON_SCHEMA,
+    SERVER_OWNED_BIBLIOGRAPHY_FIELDS,
+)
+from ebl.errors import DataError, DuplicateError, NotFoundError
+from ebl.users.domain.user import User
+
+DEFAULT_EXPORT_LIMIT = 50
+MAX_EXPORT_LIMIT = 100
+PARTNER_CREATE_RETRY_LIMIT = 5
+PARTNER_METADATA_FIELDS = frozenset(
+    cast(dict[str, Any], CSL_JSON_SCHEMA["properties"])
+) - (SERVER_OWNED_BIBLIOGRAPHY_FIELDS | {"id"})
+
+
+class BibliographyCore(Protocol):
+    def create(self, entry: dict, user: User) -> str:
+        raise NotImplementedError
+
+    def update(self, entry: dict, user: User) -> None:
+        raise NotImplementedError
+
+    def find(self, id_: str) -> dict:
+        raise NotImplementedError
+
+    def find_duplicate_candidates(self, entry: dict, limit: int = 10) -> dict:
+        raise NotImplementedError
+
+
+class PartnerBibliography:
+    def __init__(
+        self, bibliography: BibliographyCore, repository: BibliographyRepository
+    ):
+        self._bibliography = bibliography
+        self._repository = repository
+
+    def create_entry(self, entry: dict, user: User) -> Optional[dict]:
+        prepared_entry = self._prepare_entry(entry)
+        if duplicate_result := self._find_blocking_duplicate_candidates(prepared_entry):
+            return duplicate_result
+        self._create_prepared_entry(entry, prepared_entry, user)
+        return None
+
+    def create_entry_with_duplicate_override(
+        self, entry: dict, override: Mapping[str, Any], user: User
+    ) -> None:
+        prepared_entry = self._prepare_entry(entry)
+        duplicate_result = self._bibliography.find_duplicate_candidates(prepared_entry)
+        if duplicate_result["decision"] not in BLOCKING_DUPLICATE_DECISIONS:
+            raise DuplicateOverrideError(
+                "No current duplicate candidates were found. "
+                "Use POST /api/v1/bibliography instead."
+            )
+        validate_duplicate_override(override, duplicate_result)
+        self._create_prepared_entry(entry, prepared_entry, user)
+
+    def update_entry(self, id_: str, entry: dict, user: User) -> Optional[dict]:
+        self._reject_server_owned_fields(entry)
+        stored_entry = self._bibliography.find(id_)
+        updated_entry = {
+            "id": stored_entry["id"],
+            **self._project_metadata(entry),
+            **{
+                field: stored_entry[field]
+                for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+                if field in stored_entry
+            },
+        }
+        self._validate_internal_entry(updated_entry)
+        if duplicate_result := self._find_blocking_duplicate_candidates(updated_entry):
+            return duplicate_result
+        self._bibliography.update(updated_entry, user)
+        return None
+
+    def export_page(
+        self, cursor: Optional[str] = None, limit: int = DEFAULT_EXPORT_LIMIT
+    ) -> dict:
+        result_limit = max(1, min(limit, MAX_EXPORT_LIMIT))
+        entries = list(self._repository.query_page(cursor, result_limit + 1))
+        items = entries[:result_limit]
+        return {
+            "items": [partner_bibliography_entry(entry) for entry in items],
+            "nextCursor": items[-1]["id"] if len(entries) > result_limit else None,
+            "limit": result_limit,
+        }
+
+    def find_entry(self, id_: str) -> dict:
+        return partner_bibliography_entry(self._bibliography.find(id_))
+
+    def _find_blocking_duplicate_candidates(self, entry: dict) -> Optional[dict]:
+        duplicate_result = self._bibliography.find_duplicate_candidates(entry)
+        return (
+            duplicate_result
+            if duplicate_result["decision"] in BLOCKING_DUPLICATE_DECISIONS
+            else None
+        )
+
+    def _prepare_entry(self, entry: Mapping[str, Any]) -> dict:
+        self._reject_server_owned_fields(entry)
+        submitted_partner_id = entry.get("id")
+        reserved_values = (
+            [submitted_partner_id] if isinstance(submitted_partner_id, str) else []
+        )
+        prepared_entry = self._project_metadata(entry)
+        prepared_entry["id"] = select_canonical_bibliography_id(
+            self._repository.list_all_bibliography(),
+            self._lookup_value_unavailable,
+            reserved_values,
+        )
+        if isinstance(submitted_partner_id, str):
+            self._ensure_lookup_value_available(submitted_partner_id)
+            prepared_entry["aliases"] = [create_partner_alias(submitted_partner_id)]
+
+        citation_key = generate_partner_citation_key(
+            prepared_entry, self._lookup_value_unavailable
+        )
+        if citation_key is not None:
+            prepared_entry["citationKey"] = citation_key
+        self._validate_internal_entry(prepared_entry)
+        return prepared_entry
+
+    def _create_prepared_entry(
+        self, original_entry: dict, prepared_entry: dict, user: User
+    ) -> None:
+        pending_entry = dict(prepared_entry)
+        unavailable_values = (
+            [original_entry["id"]] if isinstance(original_entry.get("id"), str) else []
+        )
+        for _ in range(PARTNER_CREATE_RETRY_LIMIT):
+            try:
+                self._bibliography.create(pending_entry, user)
+            except (LookupValueInUseError, LookupValueReservationError) as error:
+                if error.value == pending_entry["id"]:
+                    unavailable_values.append(error.value)
+                    pending_entry["id"] = select_canonical_bibliography_id(
+                        self._repository.list_all_bibliography(),
+                        self._lookup_value_unavailable,
+                        unavailable_values,
+                    )
+                    continue
+                if error.value == pending_entry.get("citationKey"):
+                    unavailable_values.append(error.value)
+                    self._update_citation_key(pending_entry, unavailable_values)
+                    continue
+                raise
+            except DuplicateError:
+                unavailable_values.append(pending_entry["id"])
+                pending_entry["id"] = select_canonical_bibliography_id(
+                    self._repository.list_all_bibliography(),
+                    self._lookup_value_unavailable,
+                    unavailable_values,
+                )
+                continue
+
+            original_entry.clear()
+            original_entry.update(pending_entry)
+            return
+
+        raise DuplicateError("Unable to generate a unique bibliography id.")
+
+    def _lookup_value_exists(self, value: str) -> bool:
+        try:
+            self._bibliography.find(value)
+        except NotFoundError:
+            return False
+        except DuplicateError:
+            return True
+        return True
+
+    def _lookup_value_unavailable(self, value: str) -> bool:
+        return self._lookup_value_exists(
+            value
+        ) or self._repository.lookup_value_is_reserved(value)
+
+    def _update_citation_key(
+        self, entry: dict, unavailable_values: Sequence[str]
+    ) -> None:
+        citation_key = generate_partner_citation_key(
+            entry,
+            lambda value: (
+                value in unavailable_values or self._lookup_value_unavailable(value)
+            ),
+        )
+        if citation_key is None:
+            entry.pop("citationKey", None)
+        else:
+            entry["citationKey"] = citation_key
+
+    def _ensure_lookup_value_available(self, value: str) -> None:
+        if self._lookup_value_unavailable(value):
+            raise DuplicateError(f"Partner bibliography id {value} is already in use.")
+
+    @staticmethod
+    def _project_metadata(entry: Mapping[str, Any]) -> dict:
+        return {key: entry[key] for key in PARTNER_METADATA_FIELDS if key in entry}
+
+    @staticmethod
+    def _reject_server_owned_fields(entry: Mapping[str, Any]) -> None:
+        forbidden_fields = sorted(SERVER_OWNED_BIBLIOGRAPHY_FIELDS.intersection(entry))
+        if forbidden_fields:
+            raise DataError(
+                "Partner bibliography payload may not include server-owned fields: "
+                f"{', '.join(forbidden_fields)}."
+            )
+
+    @staticmethod
+    def _validate_internal_entry(entry: Mapping[str, Any]) -> None:
+        try:
+            jsonschema.validate(entry, CSL_JSON_SCHEMA)
+        except jsonschema.ValidationError as error:
+            raise DataError(error.message) from error
+
+
+def partner_bibliography_entry(entry: Mapping[str, Any]) -> dict:
+    return {
+        "id": entry["id"],
+        "citationKey": entry.get("citationKey"),
+        "bibliographyEntry": dict(entry),
+    }

--- a/ebl/bibliography/application/partner_bibliography.py
+++ b/ebl/bibliography/application/partner_bibliography.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Any, Mapping, Optional, Protocol, Sequence, cast
 
 import jsonschema
@@ -33,15 +34,19 @@ PARTNER_METADATA_FIELDS = frozenset(
 
 
 class BibliographyCore(Protocol):
+    @abstractmethod
     def create(self, entry: dict, user: User) -> str:
         raise NotImplementedError
 
+    @abstractmethod
     def update(self, entry: dict, user: User) -> None:
         raise NotImplementedError
 
+    @abstractmethod
     def find(self, id_: str) -> dict:
         raise NotImplementedError
 
+    @abstractmethod
     def find_duplicate_candidates(self, entry: dict, limit: int = 10) -> dict:
         raise NotImplementedError
 

--- a/ebl/bibliography/application/partner_identity.py
+++ b/ebl/bibliography/application/partner_identity.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from itertools import count
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
+
+from ebl.bibliography.application.citation_key import (
+    creator_token,
+    generate_citation_key,
+    title_token,
+    year_token,
+)
+from ebl.errors import DataError, DuplicateError
+
+DEFAULT_BIBLIOGRAPHY_ID_START = 30000000
+BIBLIOGRAPHY_ID_PREFIX = "Q"
+PARTNER_ALIAS_TYPE = "partner_id"
+PARTNER_ALIAS_SOURCE = "partner_request"
+PARTNER_ALIAS_STATUS = "redirect"
+MAX_CITATION_KEY_SUFFIX = 100
+_ASCII_APOSTROPHES = str.maketrans(
+    {
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u02bb": "'",
+        "\u02bc": "'",
+        "\uff07": "'",
+    }
+)
+_ASCII_DASHES = str.maketrans(
+    {
+        "\u2010": "-",
+        "\u2011": "-",
+        "\u2012": "-",
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2015": "-",
+        "\u2212": "-",
+    }
+)
+_BIBLIOGRAPHY_ID_PATTERN = re.compile(rf"^{BIBLIOGRAPHY_ID_PREFIX}(\d+)$")
+
+
+def create_partner_alias(value: str) -> dict[str, str]:
+    validate_partner_id(value)
+    normalized_value = normalize_partner_id(value)
+    if not normalized_value:
+        raise DataError(
+            "Partner bibliography id must contain at least one letter or digit."
+        )
+    return {
+        "value": value,
+        "normalizedValue": normalized_value,
+        "type": PARTNER_ALIAS_TYPE,
+        "source": PARTNER_ALIAS_SOURCE,
+        "status": PARTNER_ALIAS_STATUS,
+    }
+
+
+def validate_partner_id(value: Any) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise DataError("Partner bibliography id must be a non-empty string.")
+    if any(unicodedata.category(character).startswith("C") for character in value):
+        raise DataError(
+            "Partner bibliography id must not contain null bytes or control characters."
+        )
+
+
+def normalize_partner_id(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value)
+    normalized = normalized.translate(_ASCII_APOSTROPHES).translate(_ASCII_DASHES)
+    normalized = (
+        unicodedata.normalize("NFKD", normalized)
+        .encode("ascii", "ignore")
+        .decode("ascii")
+    )
+    return re.sub(r"[^a-z0-9]+", "-", normalized.casefold()).strip("-")
+
+
+def canonical_bibliography_id_candidates(existing_ids: Sequence[str]) -> Iterable[str]:
+    width = len(str(DEFAULT_BIBLIOGRAPHY_ID_START))
+    max_numeric_id = DEFAULT_BIBLIOGRAPHY_ID_START - 1
+
+    for id_ in existing_ids:
+        if match := _BIBLIOGRAPHY_ID_PATTERN.fullmatch(id_):
+            width = max(width, len(match.group(1)))
+            max_numeric_id = max(max_numeric_id, int(match.group(1)))
+
+    for numeric_id in count(max_numeric_id + 1):
+        yield f"{BIBLIOGRAPHY_ID_PREFIX}{numeric_id:0{width}d}"
+
+
+def select_canonical_bibliography_id(
+    existing_ids: Sequence[str],
+    lookup_value_exists: Callable[[str], bool],
+    reserved_values: Sequence[str] = (),
+) -> str:
+    reserved = set(reserved_values)
+    for candidate in canonical_bibliography_id_candidates(existing_ids):
+        if candidate in reserved or lookup_value_exists(candidate):
+            continue
+        return candidate
+    raise RuntimeError("Unable to generate bibliography id.")
+
+
+def generate_partner_citation_key(
+    entry: Mapping[str, Any],
+    lookup_value_exists: Callable[[str], bool],
+) -> Optional[str]:
+    if not has_meaningful_citation_key_data(entry):
+        return None
+
+    base_key = generate_citation_key(entry)
+    for suffix in range(1, MAX_CITATION_KEY_SUFFIX + 1):
+        candidate = base_key if suffix == 1 else f"{base_key}-{suffix}"
+        if not lookup_value_exists(candidate):
+            return candidate
+    raise DuplicateError("Unable to generate a unique citation key.")
+
+
+def has_meaningful_citation_key_data(entry: Mapping[str, Any]) -> bool:
+    return bool(creator_token(entry) and year_token(entry) and title_token(entry))

--- a/ebl/bibliography/domain/bibliography_entry.py
+++ b/ebl/bibliography/domain/bibliography_entry.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 NAME_SCHEMA = {
     "type": "object",
     "properties": {
@@ -35,6 +37,31 @@ DATE_SCHEMA = {
     "additionalProperties": False,
 }
 
+
+BIBLIOGRAPHY_ALIAS_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Trusted legacy alias shape. Partner APIs do not accept this field; "
+        "server-owned partner aliases are built by the application layer. "
+        "Optional metadata remains supported for curated and migration records "
+        "with minimal alias objects. Lookup uses value/normalizedValue when "
+        "present; missing type, source, or status is not a fully validated alias "
+        "lifecycle. Future tightening may require a migration."
+    ),
+    "properties": {
+        "value": {"type": "string"},
+        "normalizedValue": {"type": "string"},
+        "type": {"type": "string"},
+        "source": {"type": "string"},
+        "status": {"type": "string"},
+    },
+    "required": ["value"],
+    "additionalProperties": False,
+}
+
+SERVER_OWNED_BIBLIOGRAPHY_FIELDS = frozenset(
+    "aliases citationKey deprecated redirectTo".split()
+)
 
 CSL_JSON_SCHEMA = {
     "type": "object",
@@ -80,6 +107,10 @@ CSL_JSON_SCHEMA = {
             ],
         },
         "id": {"type": "string", "pattern": r"^[^/]+$"},
+        "citationKey": {"type": "string"},
+        "aliases": {"type": "array", "items": BIBLIOGRAPHY_ALIAS_SCHEMA},
+        "deprecated": {"type": "boolean"},
+        "redirectTo": {"type": ["string", "null"]},
         "categories": {"type": "array", "items": {"type": "string"}},
         "language": {"type": "string"},
         "journalAbbreviation": {"type": "string"},
@@ -158,7 +189,29 @@ CSL_JSON_SCHEMA = {
         "year-suffix": {"type": "string"},
     },
     "required": ["type", "id"],
+    "allOf": [
+        {
+            "if": {
+                "properties": {"deprecated": {"const": True}},
+                "required": ["deprecated"],
+            },
+            "then": {
+                "properties": {"redirectTo": {"type": "string", "minLength": 1}},
+                "required": ["redirectTo"],
+            },
+        }
+    ],
     "additionalProperties": False,
+}
+
+PARTNER_CSL_JSON_SCHEMA = {
+    **{key: value for key, value in CSL_JSON_SCHEMA.items() if key != "allOf"},
+    "properties": {
+        key: {"type": "string"} if key == "id" else value
+        for key, value in cast(dict[str, Any], CSL_JSON_SCHEMA["properties"]).items()
+        if key not in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+    },
+    "required": ["type"],
 }
 
 DUPLICATE_CANDIDATE_JSON_SCHEMA = {
@@ -186,4 +239,12 @@ DUPLICATE_OVERRIDE_JSON_SCHEMA = {
     },
     "required": ["bibliographyEntry", "override"],
     "additionalProperties": False,
+}
+
+PARTNER_DUPLICATE_OVERRIDE_JSON_SCHEMA = {
+    **DUPLICATE_OVERRIDE_JSON_SCHEMA,
+    "properties": {
+        **cast(dict[str, Any], DUPLICATE_OVERRIDE_JSON_SCHEMA["properties"]),
+        "bibliographyEntry": PARTNER_CSL_JSON_SCHEMA,
+    },
 }

--- a/ebl/bibliography/infrastructure/bibliography.py
+++ b/ebl/bibliography/infrastructure/bibliography.py
@@ -171,15 +171,21 @@ class MongoBibliographyRepository(BibliographyRepository):
         return self._collection.get_all_values("_id", ACTIVE_BIBLIOGRAPHY_FILTER)
 
     def _entry_owns_lookup_value(self, entry_id: str, value: str) -> bool:
+        if entry_id == value and self._collection.exists({"_id": entry_id}):
+            return True
+
         normalized_value = normalize_partner_id(value)
-        lookup_fields = [
-            {"_id": value},
-            {"citationKey": value},
-            {ALIASES_VALUE_FIELD: value},
-        ]
+        lookup_query: Dict[str, Any] = {
+            "$or": [
+                {"citationKey": value},
+                {ALIASES_VALUE_FIELD: value},
+            ]
+        }
         if normalized_value:
-            lookup_fields.append({"aliases.normalizedValue": normalized_value})
-        return self._collection.exists({"_id": entry_id, "$or": lookup_fields})
+            lookup_query["$or"].append({"aliases.normalizedValue": normalized_value})
+
+        matching_ids = self._collection.get_all_values("_id", lookup_query)
+        return matching_ids == [entry_id]
 
 
 def author_year_title_match(

--- a/ebl/bibliography/infrastructure/bibliography.py
+++ b/ebl/bibliography/infrastructure/bibliography.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Sequence
 
 import pymongo
@@ -41,7 +41,7 @@ class MongoBibliographyRepository(BibliographyRepository):
     def claim_lookup_values(
         self, operation: LookupReservationOperation, values: Sequence[str]
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         self.reconcile_lookup_reservations(now)
         self._lookup_reservations.claim(
             operation, values, now, self._entry_owns_lookup_value
@@ -62,7 +62,7 @@ class MongoBibliographyRepository(BibliographyRepository):
 
     def lookup_value_is_reserved(self, value: str) -> bool:
         return self._lookup_reservations.is_active(
-            value, datetime.utcnow(), self._entry_owns_lookup_value
+            value, datetime.now(timezone.utc), self._entry_owns_lookup_value
         )
 
     def reconcile_lookup_reservations(self, now: datetime, limit: int = 100) -> int:

--- a/ebl/bibliography/infrastructure/bibliography.py
+++ b/ebl/bibliography/infrastructure/bibliography.py
@@ -1,66 +1,74 @@
+from datetime import datetime
 from typing import Any, Dict, Optional, Sequence
+
+import pymongo
 
 from ebl.bibliography.application.bibliography_repository import BibliographyRepository
 from ebl.bibliography.application.duplicate_audit import PROJECTION
-from ebl.bibliography.infrastructure.duplicate_candidate_queries import (
-    duplicate_candidate_queries,
-    year_range,
-)
+from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
+from ebl.bibliography.application.partner_identity import normalize_partner_id
 from ebl.bibliography.application.serialization import (
     create_mongo_entry,
     create_object_entry,
 )
+from ebl.bibliography.infrastructure.duplicate_candidate_queries import (
+    duplicate_candidate_queries,
+    year_range,
+)
+from ebl.bibliography.infrastructure.lookup_reservations import MongoLookupReservations
+from ebl.bibliography.infrastructure.reference_documents import join_reference_documents
+from ebl.errors import DuplicateError, NotFoundError
 from ebl.mongo_collection import MongoCollection
 
 COLLECTION = "bibliography"
 DUPLICATE_CANDIDATE_QUERY_MAX_TIME_MS = 5000
-
-
-def join_reference_documents() -> Sequence[dict]:
-    return [
-        {"$unwind": {"path": "$references", "preserveNullAndEmptyArrays": True}},
-        {
-            "$lookup": {
-                "from": "bibliography",
-                "localField": "references.id",
-                "foreignField": "_id",
-                "as": "references.document",
-            }
-        },
-        {
-            "$set": {
-                "references.document": {"$arrayElemAt": ["$references.document", 0]}
-            }
-        },
-        {
-            "$group": {
-                "_id": "$_id",
-                "references": {"$push": "$references"},
-                "root": {"$first": "$$ROOT"},
-            }
-        },
-        {
-            "$replaceRoot": {
-                "newRoot": {"$mergeObjects": ["$root", {"references": "$references"}]}
-            }
-        },
-        {
-            "$set": {
-                "references": {
-                    "$filter": {
-                        "input": "$references",
-                        "as": "reference",
-                        "cond": {"$ne": ["$$reference", {}]},
-                    }
-                }
-            }
-        },
-    ]
+ACTIVE_BIBLIOGRAPHY_FILTER = {"deprecated": {"$ne": True}}
+ALIASES_VALUE_FIELD = "aliases.value"
+__all__ = ["MongoBibliographyRepository", "join_reference_documents"]
 
 
 class MongoBibliographyRepository(BibliographyRepository):
     def __init__(self, database):
         self._collection = MongoCollection(database, COLLECTION)
+        self._lookup_reservations = MongoLookupReservations(database)
+
+    def create_indexes(self) -> None:
+        self._collection.create_index([("citationKey", pymongo.ASCENDING)])
+        self._collection.create_index([(ALIASES_VALUE_FIELD, pymongo.ASCENDING)])
+        self._collection.create_index([("aliases.normalizedValue", pymongo.ASCENDING)])
+        self._lookup_reservations.create_indexes()
+
+    def claim_lookup_values(
+        self, operation: LookupReservationOperation, values: Sequence[str]
+    ) -> None:
+        now = datetime.utcnow()
+        self.reconcile_lookup_reservations(now)
+        self._lookup_reservations.claim(
+            operation, values, now, self._entry_owns_lookup_value
+        )
+
+    def commit_lookup_values(
+        self, operation: LookupReservationOperation, now: datetime
+    ) -> None:
+        self._lookup_reservations.commit(operation, now)
+
+    def release_pending_lookup_values(self, owner: str) -> None:
+        self._lookup_reservations.release_pending(owner)
+
+    def retire_lookup_values(
+        self, entry_id: str, values: Sequence[str], now: datetime
+    ) -> None:
+        self._lookup_reservations.retire(entry_id, values, now)
+
+    def lookup_value_is_reserved(self, value: str) -> bool:
+        return self._lookup_reservations.is_active(
+            value, datetime.utcnow(), self._entry_owns_lookup_value
+        )
+
+    def reconcile_lookup_reservations(self, now: datetime, limit: int = 100) -> int:
+        return self._lookup_reservations.reconcile(
+            now, self._entry_owns_lookup_value, limit
+        )
 
     def create(self, entry) -> str:
         mongo_entry = create_mongo_entry(entry)
@@ -69,6 +77,33 @@ class MongoBibliographyRepository(BibliographyRepository):
     def query_by_id(self, id_: str) -> dict:
         data = self._collection.find_one_by_id(id_)
         return create_object_entry(data)
+
+    def query_by_citation_key(self, citation_key: str) -> dict:
+        data = list(self._collection.find_many({"citationKey": citation_key}).limit(2))
+        if not data:
+            raise NotFoundError(f"bibliography citation key {citation_key} not found.")
+        if len(data) > 1:
+            raise DuplicateError(
+                f"bibliography citation key {citation_key} is ambiguous."
+            )
+        return create_object_entry(data[0])
+
+    def query_by_alias(self, alias: str) -> dict:
+        normalized_alias = normalize_partner_id(alias)
+        query: Dict[str, Any] = {ALIASES_VALUE_FIELD: alias}
+        if normalized_alias:
+            query = {
+                "$or": [
+                    {ALIASES_VALUE_FIELD: alias},
+                    {"aliases.normalizedValue": normalized_alias},
+                ]
+            }
+        data = list(self._collection.find_many(query))
+        if not data:
+            raise NotFoundError(f"bibliography alias {alias} not found.")
+        if len({item["_id"] for item in data}) > 1:
+            raise DuplicateError(f"bibliography alias {alias} is ambiguous.")
+        return create_object_entry(data[0])
 
     def query_by_ids(self, ids: Sequence[str]) -> Sequence[dict]:
         data = self._collection.find_many({"_id": {"$in": ids}})
@@ -110,14 +145,16 @@ class MongoBibliographyRepository(BibliographyRepository):
         candidates: dict[str, dict] = {}
         for query in duplicate_candidate_queries(entry):
             cursor = self._collection.find_many(
-                query, projection=PROJECTION
+                {"$and": [query, ACTIVE_BIBLIOGRAPHY_FILTER]}, projection=PROJECTION
             ).max_time_ms(DUPLICATE_CANDIDATE_QUERY_MAX_TIME_MS)
             for data in cursor.limit(limit):
                 candidates[data["_id"]] = create_object_entry(data)
         return list(candidates.values())[:limit]
 
     def query_page(self, after: Optional[str], limit: int) -> Sequence[Any]:
-        query = {"_id": {"$gt": after}} if after else {}
+        query: Dict[str, Any] = dict(ACTIVE_BIBLIOGRAPHY_FILTER)
+        if after:
+            query["_id"] = {"$gt": after}
         data = self._collection.find_many(query).sort("_id", 1).limit(limit)
         return [create_object_entry(item) for item in data]
 
@@ -131,7 +168,18 @@ class MongoBibliographyRepository(BibliographyRepository):
         ]
 
     def list_all_bibliography(self) -> Sequence[str]:
-        return self._collection.get_all_values("_id")
+        return self._collection.get_all_values("_id", ACTIVE_BIBLIOGRAPHY_FILTER)
+
+    def _entry_owns_lookup_value(self, entry_id: str, value: str) -> bool:
+        normalized_value = normalize_partner_id(value)
+        lookup_fields = [
+            {"_id": value},
+            {"citationKey": value},
+            {ALIASES_VALUE_FIELD: value},
+        ]
+        if normalized_value:
+            lookup_fields.append({"aliases.normalizedValue": normalized_value})
+        return self._collection.exists({"_id": entry_id, "$or": lookup_fields})
 
 
 def author_year_title_match(
@@ -151,7 +199,7 @@ def bibliography_query_pipeline(
     match: Dict[str, Any], trailing_sort_field: str
 ) -> list[dict]:
     return [
-        {"$match": match},
+        {"$match": {**match, **ACTIVE_BIBLIOGRAPHY_FILTER}},
         {"$addFields": {"primaryYear": primary_year_expression()}},
         {
             "$sort": {
@@ -165,9 +213,4 @@ def bibliography_query_pipeline(
 
 
 def primary_year_expression() -> dict:
-    return {
-        "$arrayElemAt": [
-            {"$arrayElemAt": ["$issued.date-parts", 0]},
-            0,
-        ]
-    }
+    return {"$arrayElemAt": [{"$arrayElemAt": ["$issued.date-parts", 0]}, 0]}

--- a/ebl/bibliography/infrastructure/duplicate_candidate_queries.py
+++ b/ebl/bibliography/infrastructure/duplicate_candidate_queries.py
@@ -11,7 +11,7 @@ from ebl.bibliography.application.duplicate_audit import (
 
 
 def duplicate_candidate_queries(entry: dict) -> Sequence[dict]:
-    queries = []
+    queries: list[dict] = []
     queries.extend(duplicate_strong_identifier_queries(entry))
     if author_year_query := contributor_year_query(entry):
         queries.append(author_year_query)

--- a/ebl/bibliography/infrastructure/lookup_reservations.py
+++ b/ebl/bibliography/infrastructure/lookup_reservations.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Callable, Sequence
 
@@ -15,6 +16,13 @@ from ebl.errors import DuplicateError, NotFoundError
 from ebl.mongo_collection import MongoCollection
 
 COLLECTION = "bibliography_lookup_reservations"
+
+
+@dataclass(frozen=True)
+class LookupReservationClaim:
+    operation: LookupReservationOperation
+    value: str
+    now: datetime
 
 
 class MongoLookupReservations:
@@ -45,8 +53,9 @@ class MongoLookupReservations:
     ) -> None:
         claimed: list[str] = []
         for value in dict.fromkeys(values):
+            claim = LookupReservationClaim(operation, value, now)
             try:
-                self._insert_pending(operation, value, now, owns_value)
+                self._insert_pending(claim, owns_value)
             except LookupValueReservationError:
                 self._release_values(operation.owner, claimed)
                 raise
@@ -122,24 +131,22 @@ class MongoLookupReservations:
 
     def _insert_pending(
         self,
-        operation: LookupReservationOperation,
-        value: str,
-        now: datetime,
+        claim: LookupReservationClaim,
         owns_value: Callable[[str, str], bool],
     ) -> None:
         try:
-            self._collection.insert_one(self._pending_document(operation, value))
+            self._collection.insert_one(self._pending_document(claim))
         except DuplicateError as error:
-            self._handle_existing_reservation(operation, value, now, owns_value, error)
+            self._handle_existing_reservation(claim, owns_value, error)
 
     def _handle_existing_reservation(
         self,
-        operation: LookupReservationOperation,
-        value: str,
-        now: datetime,
+        claim: LookupReservationClaim,
         owns_value: Callable[[str, str], bool],
         error: DuplicateError,
     ) -> None:
+        operation = claim.operation
+        value = claim.value
         reservation = self._collection.find_one_by_id(value)
         if (
             reservation.get("owner") == operation.owner
@@ -152,27 +159,26 @@ class MongoLookupReservations:
             and owns_value(operation.entry_id, value)
         ):
             return
-        self._reconcile_reservation(reservation, now, owns_value)
+        self._reconcile_reservation(reservation, claim.now, owns_value)
         reservation = self._collection.find_one_by_id(value)
         if reservation.get("state") == LookupReservationState.ABANDONED.value:
             self._collection.replace_one(
-                self._pending_document(operation, value),
+                self._pending_document(claim),
                 {"_id": value, "state": LookupReservationState.ABANDONED.value},
+                upsert=True,
             )
             return
         raise LookupValueReservationError(value) from error
 
-    def _pending_document(
-        self, operation: LookupReservationOperation, value: str
-    ) -> dict:
+    def _pending_document(self, claim: LookupReservationClaim) -> dict:
         return {
-            "_id": value,
-            "value": value,
-            "entryId": operation.entry_id,
-            "owner": operation.owner,
+            "_id": claim.value,
+            "value": claim.value,
+            "entryId": claim.operation.entry_id,
+            "owner": claim.operation.owner,
             "state": LookupReservationState.PENDING.value,
-            "createdAt": datetime.utcnow(),
-            "expiresAt": operation.expires_at,
+            "createdAt": claim.now,
+            "expiresAt": claim.operation.expires_at,
         }
 
     def _reconcile_reservation(

--- a/ebl/bibliography/infrastructure/lookup_reservations.py
+++ b/ebl/bibliography/infrastructure/lookup_reservations.py
@@ -1,6 +1,6 @@
 from contextlib import suppress
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Sequence
 
 import pymongo
@@ -16,6 +16,14 @@ from ebl.errors import DuplicateError, NotFoundError
 from ebl.mongo_collection import MongoCollection
 
 COLLECTION = "bibliography_lookup_reservations"
+
+
+def _to_utc_datetime(value: datetime) -> datetime:
+    return (
+        value.replace(tzinfo=timezone.utc)
+        if value.tzinfo is None
+        else value.astimezone(timezone.utc)
+    )
 
 
 @dataclass(frozen=True)
@@ -188,19 +196,20 @@ class MongoLookupReservations:
         entry_id = reservation["entryId"]
         state = LookupReservationState(reservation["state"])
         expires_at = reservation.get("expiresAt")
+        comparison_now = _to_utc_datetime(now)
         if (
             state == LookupReservationState.PENDING
             and isinstance(expires_at, datetime)
-            and expires_at <= now
+            and _to_utc_datetime(expires_at) <= comparison_now
         ):
             if owns_value(entry_id, value):
-                self._commit_value(value, now)
+                self._commit_value(value, comparison_now)
             else:
-                self._abandon_value(value, now, entry_id, state)
+                self._abandon_value(value, comparison_now, entry_id, state)
         elif state == LookupReservationState.COMMITTED and not owns_value(
             entry_id, value
         ):
-            self._abandon_value(value, now, entry_id, state)
+            self._abandon_value(value, comparison_now, entry_id, state)
 
     def _release_values(self, owner: str, values: Sequence[str]) -> None:
         for value in values:

--- a/ebl/bibliography/infrastructure/lookup_reservations.py
+++ b/ebl/bibliography/infrastructure/lookup_reservations.py
@@ -1,0 +1,238 @@
+from contextlib import suppress
+from datetime import datetime
+from typing import Callable, Sequence
+
+import pymongo
+
+from ebl.bibliography.application.bibliography_repository import (
+    LookupValueReservationError,
+)
+from ebl.bibliography.application.lookup_reservation import (
+    LookupReservationOperation,
+    LookupReservationState,
+)
+from ebl.errors import DuplicateError, NotFoundError
+from ebl.mongo_collection import MongoCollection
+
+COLLECTION = "bibliography_lookup_reservations"
+
+
+class MongoLookupReservations:
+    def __init__(self, database):
+        self._collection = MongoCollection(database, COLLECTION)
+
+    def create_indexes(self) -> None:
+        self._collection.create_index(
+            [("value", pymongo.ASCENDING)],
+            unique=True,
+            name="bibliography_lookup_value_unique",
+        )
+        self._collection.create_index([("owner", pymongo.ASCENDING)])
+        self._collection.create_index([("entryId", pymongo.ASCENDING)])
+        self._collection.create_index(
+            [("state", pymongo.ASCENDING), ("expiresAt", pymongo.ASCENDING)]
+        )
+        self._collection.create_index(
+            [("deleteAt", pymongo.ASCENDING)], expireAfterSeconds=0
+        )
+
+    def claim(
+        self,
+        operation: LookupReservationOperation,
+        values: Sequence[str],
+        now: datetime,
+        owns_value: Callable[[str, str], bool],
+    ) -> None:
+        claimed: list[str] = []
+        for value in dict.fromkeys(values):
+            try:
+                self._insert_pending(operation, value, now, owns_value)
+            except LookupValueReservationError:
+                self._release_values(operation.owner, claimed)
+                raise
+            claimed.append(value)
+
+    def commit(self, operation: LookupReservationOperation, now: datetime) -> None:
+        self._collection.update_many(
+            {
+                "owner": operation.owner,
+                "entryId": operation.entry_id,
+                "state": LookupReservationState.PENDING.value,
+            },
+            {
+                "$set": {
+                    "state": LookupReservationState.COMMITTED.value,
+                    "committedAt": now,
+                },
+                "$unset": {"expiresAt": "", "deleteAt": ""},
+            },
+        )
+
+    def release_pending(self, owner: str) -> None:
+        with suppress(NotFoundError):
+            self._collection.delete_many(
+                {"owner": owner, "state": LookupReservationState.PENDING.value}
+            )
+
+    def retire(self, entry_id: str, values: Sequence[str], now: datetime) -> None:
+        for value in dict.fromkeys(values):
+            with suppress(NotFoundError):
+                self._abandon_value(
+                    value, now, entry_id, LookupReservationState.COMMITTED
+                )
+
+    def is_active(
+        self, value: str, now: datetime, owns_value: Callable[[str, str], bool]
+    ) -> bool:
+        self.reconcile_value(value, now, owns_value)
+        try:
+            reservation = self._collection.find_one_by_id(value)
+        except NotFoundError:
+            return False
+        return reservation.get("state") != LookupReservationState.ABANDONED.value
+
+    def reconcile(
+        self, now: datetime, owns_value: Callable[[str, str], bool], limit: int
+    ) -> int:
+        candidates = list(
+            self._collection.find_many(
+                {
+                    "$or": [
+                        {
+                            "state": LookupReservationState.PENDING.value,
+                            "expiresAt": {"$lte": now},
+                        },
+                        {"state": LookupReservationState.COMMITTED.value},
+                    ]
+                }
+            ).limit(limit)
+        )
+        for reservation in candidates:
+            self._reconcile_reservation(reservation, now, owns_value)
+        return len(candidates)
+
+    def reconcile_value(
+        self, value: str, now: datetime, owns_value: Callable[[str, str], bool]
+    ) -> None:
+        try:
+            reservation = self._collection.find_one_by_id(value)
+        except NotFoundError:
+            return
+        self._reconcile_reservation(reservation, now, owns_value)
+
+    def _insert_pending(
+        self,
+        operation: LookupReservationOperation,
+        value: str,
+        now: datetime,
+        owns_value: Callable[[str, str], bool],
+    ) -> None:
+        try:
+            self._collection.insert_one(self._pending_document(operation, value))
+        except DuplicateError as error:
+            self._handle_existing_reservation(operation, value, now, owns_value, error)
+
+    def _handle_existing_reservation(
+        self,
+        operation: LookupReservationOperation,
+        value: str,
+        now: datetime,
+        owns_value: Callable[[str, str], bool],
+        error: DuplicateError,
+    ) -> None:
+        reservation = self._collection.find_one_by_id(value)
+        if (
+            reservation.get("owner") == operation.owner
+            and reservation.get("state") == LookupReservationState.PENDING.value
+        ):
+            return
+        if (
+            reservation.get("entryId") == operation.entry_id
+            and reservation.get("state") == LookupReservationState.COMMITTED.value
+            and owns_value(operation.entry_id, value)
+        ):
+            return
+        self._reconcile_reservation(reservation, now, owns_value)
+        reservation = self._collection.find_one_by_id(value)
+        if reservation.get("state") == LookupReservationState.ABANDONED.value:
+            self._collection.replace_one(
+                self._pending_document(operation, value),
+                {"_id": value, "state": LookupReservationState.ABANDONED.value},
+            )
+            return
+        raise LookupValueReservationError(value) from error
+
+    def _pending_document(
+        self, operation: LookupReservationOperation, value: str
+    ) -> dict:
+        return {
+            "_id": value,
+            "value": value,
+            "entryId": operation.entry_id,
+            "owner": operation.owner,
+            "state": LookupReservationState.PENDING.value,
+            "createdAt": datetime.utcnow(),
+            "expiresAt": operation.expires_at,
+        }
+
+    def _reconcile_reservation(
+        self, reservation: dict, now: datetime, owns_value: Callable[[str, str], bool]
+    ) -> None:
+        value = reservation["_id"]
+        entry_id = reservation["entryId"]
+        state = LookupReservationState(reservation["state"])
+        expires_at = reservation.get("expiresAt")
+        if (
+            state == LookupReservationState.PENDING
+            and isinstance(expires_at, datetime)
+            and expires_at <= now
+        ):
+            if owns_value(entry_id, value):
+                self._commit_value(value, now)
+            else:
+                self._abandon_value(value, now, entry_id, state)
+        elif state == LookupReservationState.COMMITTED and not owns_value(
+            entry_id, value
+        ):
+            self._abandon_value(value, now, entry_id, state)
+
+    def _release_values(self, owner: str, values: Sequence[str]) -> None:
+        for value in values:
+            with suppress(NotFoundError):
+                self._collection.delete_one(
+                    {
+                        "_id": value,
+                        "owner": owner,
+                        "state": LookupReservationState.PENDING.value,
+                    }
+                )
+
+    def _commit_value(self, value: str, now: datetime) -> None:
+        self._collection.update_one(
+            {"_id": value, "state": LookupReservationState.PENDING.value},
+            {
+                "$set": {
+                    "state": LookupReservationState.COMMITTED.value,
+                    "committedAt": now,
+                },
+                "$unset": {"expiresAt": "", "deleteAt": ""},
+            },
+        )
+
+    def _abandon_value(
+        self,
+        value: str,
+        now: datetime,
+        entry_id: str,
+        state: LookupReservationState,
+    ) -> None:
+        self._collection.update_one(
+            {"_id": value, "entryId": entry_id, "state": state.value},
+            {
+                "$set": {
+                    "state": LookupReservationState.ABANDONED.value,
+                    "deleteAt": now,
+                },
+                "$unset": {"expiresAt": ""},
+            },
+        )

--- a/ebl/bibliography/infrastructure/reference_documents.py
+++ b/ebl/bibliography/infrastructure/reference_documents.py
@@ -1,0 +1,43 @@
+from typing import Sequence
+
+
+def join_reference_documents() -> Sequence[dict]:
+    return [
+        {"$unwind": {"path": "$references", "preserveNullAndEmptyArrays": True}},
+        {
+            "$lookup": {
+                "from": "bibliography",
+                "localField": "references.id",
+                "foreignField": "_id",
+                "as": "references.document",
+            }
+        },
+        {
+            "$set": {
+                "references.document": {"$arrayElemAt": ["$references.document", 0]}
+            }
+        },
+        {
+            "$group": {
+                "_id": "$_id",
+                "references": {"$push": "$references"},
+                "root": {"$first": "$$ROOT"},
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": {"$mergeObjects": ["$root", {"references": "$references"}]}
+            }
+        },
+        {
+            "$set": {
+                "references": {
+                    "$filter": {
+                        "input": "$references",
+                        "as": "reference",
+                        "cond": {"$ne": ["$$reference", {}]},
+                    }
+                }
+            }
+        },
+    ]

--- a/ebl/bibliography/web/bibliography_entries.py
+++ b/ebl/bibliography/web/bibliography_entries.py
@@ -8,13 +8,38 @@ from ebl.cache.application.cache import DAILY_TIMEOUT
 from ebl.bibliography.domain.bibliography_entry import (
     CSL_JSON_SCHEMA,
     DUPLICATE_CANDIDATE_JSON_SCHEMA,
-    DUPLICATE_OVERRIDE_JSON_SCHEMA,
+    PARTNER_CSL_JSON_SCHEMA,
+    PARTNER_DUPLICATE_OVERRIDE_JSON_SCHEMA,
+    SERVER_OWNED_BIBLIOGRAPHY_FIELDS,
 )
+from ebl.errors import DataError
 from ebl.users.web.require_scope import require_scope
-from ebl.bibliography.application.bibliography import (
-    Bibliography,
-    DuplicateOverrideError,
-)
+from ebl.bibliography.application.bibliography import Bibliography
+from ebl.bibliography.application.duplicate_override import DuplicateOverrideError
+
+
+def reject_server_owned_partner_fields(req, _resp, _resource, _params) -> None:
+    media = req.media
+    if not isinstance(media, dict):
+        return
+
+    candidate_entries = [media]
+    if isinstance(media.get("bibliographyEntry"), dict):
+        candidate_entries.append(media["bibliographyEntry"])
+
+    forbidden_fields = sorted(
+        {
+            field
+            for entry in candidate_entries
+            for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+            if field in entry
+        }
+    )
+    if forbidden_fields:
+        raise DataError(
+            "Partner bibliography payload may not include server-owned fields: "
+            f"{', '.join(forbidden_fields)}."
+        )
 
 
 class BibliographyResource:
@@ -95,7 +120,8 @@ class PartnerBibliographyResource:
         resp.media = self._bibliography.export_page(req.get_param("cursor"), limit)
 
     @falcon.before(require_scope, "write:bibliography")
-    @validate(CSL_JSON_SCHEMA)
+    @falcon.before(reject_server_owned_partner_fields)
+    @validate(PARTNER_CSL_JSON_SCHEMA)
     def on_post(self, req: Request, resp: Response) -> None:
         bibliography_entry = req.media
         if duplicate_result := self._bibliography.create_partner_entry(
@@ -118,7 +144,8 @@ class PartnerBibliographyEntryResource:
         resp.media = self._bibliography.find_partner_entry(id_or_citation_key)
 
     @falcon.before(require_scope, "write:bibliography")
-    @validate(CSL_JSON_SCHEMA)
+    @falcon.before(reject_server_owned_partner_fields)
+    @validate(PARTNER_CSL_JSON_SCHEMA)
     def on_post(self, req: Request, resp: Response, id_or_citation_key: str) -> None:
         if duplicate_result := self._bibliography.update_partner_entry(
             id_or_citation_key, req.media, req.context.user
@@ -129,12 +156,28 @@ class PartnerBibliographyEntryResource:
         resp.status = falcon.HTTP_NO_CONTENT
 
 
+class PartnerBibliographyResolveResource:
+    def __init__(self, bibliography: Bibliography):
+        self._bibliography = bibliography
+
+    @falcon.before(require_scope, "export:bibliography")
+    def on_get(self, req: Request, resp: Response) -> None:
+        identifier = req.get_param("identifier")
+        if identifier is None:
+            raise falcon.HTTPBadRequest(
+                title="Missing identifier",
+                description="Query parameter 'identifier' is required.",
+            )
+        resp.media = self._bibliography.find_partner_entry(identifier)
+
+
 class PartnerBibliographyDuplicateOverrideResource:
     def __init__(self, bibliography: Bibliography):
         self._bibliography = bibliography
 
     @falcon.before(require_scope, "write:bibliography")
-    @validate(DUPLICATE_OVERRIDE_JSON_SCHEMA)
+    @falcon.before(reject_server_owned_partner_fields)
+    @validate(PARTNER_DUPLICATE_OVERRIDE_JSON_SCHEMA)
     def on_post(self, req: Request, resp: Response) -> None:
         bibliography_entry = req.media["bibliographyEntry"]
         override = req.media["override"]

--- a/ebl/bibliography/web/bootstrap.py
+++ b/ebl/bibliography/web/bootstrap.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import falcon
 
 from ebl.bibliography.web.bibliography_entries import (
@@ -8,12 +10,15 @@ from ebl.bibliography.web.bibliography_entries import (
     BibliographyList,
     PartnerBibliographyDuplicateOverrideResource,
     PartnerBibliographyEntryResource,
+    PartnerBibliographyResolveResource,
     PartnerBibliographyResource,
 )
 from ebl.context import Context
 
 
 def create_bibliography_routes(api: falcon.App, context: Context):
+    context.bibliography_repository.create_indexes()
+    context.bibliography_repository.reconcile_lookup_reservations(datetime.utcnow())
     bibliography = context.get_bibliography()
     bibliography_resource = BibliographyResource(bibliography)
     bibliography_entries = BibliographyEntriesResource(bibliography)
@@ -25,6 +30,7 @@ def create_bibliography_routes(api: falcon.App, context: Context):
         PartnerBibliographyDuplicateOverrideResource(bibliography)
     )
     partner_bibliography_entry = PartnerBibliographyEntryResource(bibliography)
+    partner_bibliography_resolve = PartnerBibliographyResolveResource(bibliography)
 
     api.add_route("/bibliography", bibliography_resource)
     api.add_route("/bibliography/all", bibliography_all)
@@ -36,6 +42,7 @@ def create_bibliography_routes(api: falcon.App, context: Context):
         "/api/v1/bibliography/duplicate-override",
         partner_bibliography_duplicate_override,
     )
+    api.add_route("/api/v1/bibliography/resolve", partner_bibliography_resolve)
     api.add_route(
         "/api/v1/bibliography/{id_or_citation_key}", partner_bibliography_entry
     )

--- a/ebl/bibliography/web/bootstrap.py
+++ b/ebl/bibliography/web/bootstrap.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import falcon
 
@@ -18,7 +18,9 @@ from ebl.context import Context
 
 def create_bibliography_routes(api: falcon.App, context: Context):
     context.bibliography_repository.create_indexes()
-    context.bibliography_repository.reconcile_lookup_reservations(datetime.utcnow())
+    context.bibliography_repository.reconcile_lookup_reservations(
+        datetime.now(timezone.utc)
+    )
     bibliography = context.get_bibliography()
     bibliography_resource = BibliographyResource(bibliography)
     bibliography_entries = BibliographyEntriesResource(bibliography)

--- a/ebl/fragmentarium/application/fragment_updater.py
+++ b/ebl/fragmentarium/application/fragment_updater.py
@@ -144,9 +144,9 @@ class FragmentUpdater:
         self, number: MuseumNumber, references: Sequence[Reference], user: User
     ) -> Tuple[Fragment, bool]:
         fragment = self._repository.query_by_museum_number(number)
-        self._bibliography.validate_references(references)
+        canonical_references = self._bibliography.canonicalize_references(references)
 
-        updated_fragment = fragment.set_references(references)
+        updated_fragment = fragment.set_references(canonical_references)
 
         self._create_changelog(user, fragment, updated_fragment)
         self._repository.update_field("references", updated_fragment)

--- a/ebl/fragmentarium/web/fragments.py
+++ b/ebl/fragmentarium/web/fragments.py
@@ -39,6 +39,10 @@ from ebl.users.web.require_scope import require_fragment_read_scope
 
 def _parse_fragment_query(parameters, *parsers):
     for parser in parsers:
+        if not callable(parser):
+            raise DataError(
+                f"Invalid query parser '{parser}': expected a callable parser function."
+            )
         parameters = parser(parameters)
     return parameters
 

--- a/ebl/fragmentarium/web/fragments.py
+++ b/ebl/fragmentarium/web/fragments.py
@@ -39,10 +39,6 @@ from ebl.users.web.require_scope import require_fragment_read_scope
 
 def _parse_fragment_query(parameters, *parsers):
     for parser in parsers:
-        if not callable(parser):
-            raise DataError(
-                f"Invalid query parser '{parser}': expected a callable parser function."
-            )
         parameters = parser(parameters)
     return parameters
 

--- a/ebl/tests/bibliography/duplicate_detection_test_helpers.py
+++ b/ebl/tests/bibliography/duplicate_detection_test_helpers.py
@@ -1,16 +1,51 @@
+from datetime import datetime
 from typing import Any, Optional, Sequence
 
 from ebl.bibliography.application.bibliography_repository import BibliographyRepository
+from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
 
 
 class FakeBibliographyRepository(BibliographyRepository):
     def __init__(self, candidates: Sequence[dict[str, Any]]):
         self._candidates = candidates
 
+    def create_indexes(self) -> None:
+        raise NotImplementedError
+
+    def claim_lookup_values(
+        self, operation: LookupReservationOperation, values: Sequence[str]
+    ) -> None:
+        raise NotImplementedError
+
+    def commit_lookup_values(
+        self, operation: LookupReservationOperation, now: datetime
+    ) -> None:
+        raise NotImplementedError
+
+    def release_pending_lookup_values(self, owner: str) -> None:
+        raise NotImplementedError
+
+    def retire_lookup_values(
+        self, entry_id: str, values: Sequence[str], now: datetime
+    ) -> None:
+        raise NotImplementedError
+
+    def lookup_value_is_reserved(self, value: str) -> bool:
+        raise NotImplementedError
+
+    def reconcile_lookup_reservations(self, now: datetime, limit: int = 100) -> int:
+        raise NotImplementedError
+
     def create(self, entry: Any) -> str:
         raise NotImplementedError
 
     def query_by_id(self, id_: str) -> Any:
+        raise NotImplementedError
+
+    def query_by_citation_key(self, citation_key: str) -> Any:
+        raise NotImplementedError
+
+    def query_by_alias(self, alias: str) -> Any:
         raise NotImplementedError
 
     def query_by_ids(self, ids: Sequence[str]) -> Sequence[Any]:

--- a/ebl/tests/bibliography/test_bibliography.py
+++ b/ebl/tests/bibliography/test_bibliography.py
@@ -1,10 +1,24 @@
 import pytest
-from mockito import verify
+from mockito import ANY, verify
 
-from ebl.errors import DataError, DuplicateError, NotFoundError
+from ebl.errors import DataError, Defect, DuplicateError, NotFoundError
 from ebl.tests.factories.bibliography import ReferenceFactory, BibliographyEntryFactory
 
 COLLECTION = "bibliography"
+
+
+def allow_identity_create(bibliography_repository, when, entry):
+    when(bibliography_repository).claim_lookup_values(ANY, [entry["id"]]).thenReturn()
+    when(bibliography_repository).query_by_id(entry["id"]).thenRaise(NotFoundError)
+    when(bibliography_repository).query_by_citation_key(entry["id"]).thenRaise(
+        NotFoundError
+    )
+    when(bibliography_repository).query_by_alias(entry["id"]).thenRaise(NotFoundError)
+
+
+def allow_identity_update(bibliography_repository, when, entry):
+    when(bibliography_repository).claim_lookup_values(ANY, []).thenReturn()
+    when(bibliography_repository).query_by_id(entry["id"]).thenReturn(entry)
 
 
 def test_search_container_short_collection_number(
@@ -66,14 +80,23 @@ def test_search_author_title_year(bibliography, bibliography_repository, when):
     assert [bibliography_entry] == bibliography.search(query)
 
 
-def test_find(bibliography, bibliography_repository, when):
-    bibliography_entry = BibliographyEntryFactory.build()
+def test_search_excludes_deprecated_entries(
+    bibliography, bibliography_repository, when
+):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo="CANONICAL_ID"
+    )
+    author = canonical_entry["author"][0]["family"]
+    year = canonical_entry["issued"]["date-parts"][0][0]
+    title = canonical_entry["title"]
     (
         when(bibliography_repository)
-        .query_by_id(bibliography_entry["id"])
-        .thenReturn(bibliography_entry)
+        .query_by_author_year_and_title(author, year, title)
+        .thenReturn([deprecated_entry, canonical_entry])
     )
-    assert bibliography.find(bibliography_entry["id"]) == bibliography_entry
+
+    assert bibliography.search(f"{author} {year} {title}") == [canonical_entry]
 
 
 def test_create(
@@ -85,6 +108,9 @@ def test_create(
     create_mongo_bibliography_entry,
 ):
     bibliography_entry = BibliographyEntryFactory.build()
+    created_id = bibliography_entry["id"]
+    allow_identity_create(bibliography_repository, when, bibliography_entry)
+    when(bibliography_repository).commit_lookup_values(ANY, ANY).thenReturn()
     (
         when(changelog)
         .create(
@@ -95,9 +121,25 @@ def test_create(
         )
         .thenReturn()
     )
-    (when(bibliography_repository).create(bibliography_entry).thenReturn())
+    (when(bibliography_repository).create(bibliography_entry).thenReturn(created_id))
 
-    bibliography.create(bibliography_entry, user)
+    assert bibliography.create(bibliography_entry, user) == created_id
+    verify(bibliography_repository).commit_lookup_values(ANY, ANY)
+
+
+def test_create_rejects_mismatched_repository_id(
+    bibliography, bibliography_repository, user, when
+):
+    bibliography_entry = BibliographyEntryFactory.build()
+    allow_identity_create(bibliography_repository, when, bibliography_entry)
+    (
+        when(bibliography_repository)
+        .create(bibliography_entry)
+        .thenReturn("DIFFERENT_ID")
+    )
+
+    with pytest.raises(Defect, match="does not match"):
+        bibliography.create(bibliography_entry, user)
 
 
 def test_create_duplicate(
@@ -109,6 +151,8 @@ def test_create_duplicate(
     create_mongo_bibliography_entry,
 ):
     bibliography_entry = BibliographyEntryFactory.build()
+    allow_identity_create(bibliography_repository, when, bibliography_entry)
+    when(bibliography_repository).release_pending_lookup_values(ANY).thenReturn()
     (
         when(changelog)
         .create(
@@ -122,17 +166,13 @@ def test_create_duplicate(
     (when(bibliography_repository).create(bibliography_entry).thenRaise(DuplicateError))
     with pytest.raises(DuplicateError):
         bibliography.create(bibliography_entry, user)
-
-
-def test_entry_not_found(bibliography, bibliography_repository, when):
-    bibliography_entry = BibliographyEntryFactory.build()
-    (
-        when(bibliography_repository)
-        .query_by_id(bibliography_entry["id"])
-        .thenRaise(NotFoundError)
+    verify(bibliography_repository).release_pending_lookup_values(ANY)
+    verify(changelog, times=0).create(
+        COLLECTION,
+        user.profile,
+        {"_id": bibliography_entry["id"]},
+        create_mongo_bibliography_entry(),
     )
-    with pytest.raises(NotFoundError):
-        bibliography.find(bibliography_entry["id"])
 
 
 def test_update(
@@ -144,11 +184,11 @@ def test_update(
     create_mongo_bibliography_entry,
 ):
     bibliography_entry = BibliographyEntryFactory.build()
-    (
-        when(bibliography_repository)
-        .query_by_id(bibliography_entry["id"])
-        .thenReturn(bibliography_entry)
-    )
+    allow_identity_update(bibliography_repository, when, bibliography_entry)
+    when(bibliography_repository).commit_lookup_values(ANY, ANY).thenReturn()
+    when(bibliography_repository).retire_lookup_values(
+        bibliography_entry["id"], [], ANY
+    ).thenReturn()
     (
         when(changelog)
         .create(
@@ -174,23 +214,23 @@ def test_update_not_found(bibliography_repository, bibliography, user, when):
         bibliography.update(bibliography_entry, user)
 
 
-def test_validate_references(
+def test_canonicalize_references(
     bibliography_repository, bibliography, user, changelog, when
 ):
     reference = ReferenceFactory.build(with_document=True)
 
-    (when(bibliography).find(reference.id).thenReturn(reference))
-    bibliography.validate_references([reference])
+    (when(bibliography).find(reference.id).thenReturn(reference.document))
+    assert bibliography.canonicalize_references([reference]) == (reference,)
 
 
-def test_validate_references_invalid(
+def test_canonicalize_references_invalid(
     bibliography_repository, bibliography, user, changelog, when
 ):
     valid_reference = ReferenceFactory.build(with_document=True)
     first_invalid = ReferenceFactory.build(with_document=True)
     second_invalid = ReferenceFactory.build(with_document=True)
     bibliography.create(valid_reference.document, user)
-    (when(bibliography).find(valid_reference.id).thenReturn(valid_reference))
+    (when(bibliography).find(valid_reference.id).thenReturn(valid_reference.document))
     (when(bibliography).find(first_invalid.id).thenRaise(NotFoundError))
     (when(bibliography).find(second_invalid.id).thenRaise(NotFoundError))
 
@@ -199,7 +239,7 @@ def test_validate_references_invalid(
     )
 
     with pytest.raises(DataError, match=expected_error):
-        bibliography.validate_references(
+        bibliography.canonicalize_references(
             [first_invalid, valid_reference, second_invalid]
         )
 

--- a/ebl/tests/bibliography/test_bibliography_duplicate_candidates_route.py
+++ b/ebl/tests/bibliography/test_bibliography_duplicate_candidates_route.py
@@ -1,0 +1,97 @@
+import json
+
+import falcon
+import pydash
+
+from ebl.tests.bibliography.bibliography_route_test_helpers import client_with_scope
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+def test_duplicate_candidates(client, database, saved_entry):
+    proposed_entry = {**saved_entry, "id": "Q30000001"}
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-candidates",
+        body=json.dumps(proposed_entry),
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["decision"] == "likely_duplicate"
+    assert result.json["highestScore"] >= 0.92
+    assert result.json["candidates"][0]["id"] == saved_entry["id"]
+    assert result.json["candidates"][0]["recommendation"] == "block_or_request_override"
+    assert result.json["candidates"][0]["matchedFields"]["doi"] == 1.0
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+def test_duplicate_candidates_allows_missing_id(client, saved_entry):
+    proposed_entry = pydash.omit(saved_entry, "id")
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-candidates",
+        body=json.dumps(proposed_entry),
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["decision"] == "likely_duplicate"
+
+
+def test_duplicate_candidates_series_sibling_is_not_likely(
+    client, bibliography, user, database
+):
+    existing_entry = BibliographyEntryFactory.build(
+        id="Q30000000",
+        type="book",
+        title="Babylonian Provincial Officials Part One",
+        author=[{"given": "Mark", "family": "Smith"}],
+        issued={"date-parts": [[2010]]},
+        DOI="",
+        publisher="Eisenbrauns",
+        **{"collection-title": "Babylonian Provincial Officials"},
+    )
+    proposed_entry = {
+        **existing_entry,
+        "id": "Q30000001",
+        "title": "Babylonian Provincial Officials Part Two",
+    }
+    bibliography.create(existing_entry, user)
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-candidates",
+        body=json.dumps(proposed_entry),
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["decision"] == "no_duplicate"
+    assert result.json["candidates"][0]["decision"] == "no_duplicate"
+    assert "series_part" in result.json["candidates"][0]["conflictingFields"]
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+def test_duplicate_candidates_invalid(client):
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-candidates",
+        body=json.dumps({"title": "Missing type"}),
+    )
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
+
+
+def test_duplicate_candidates_requires_duplicate_check_scope(guest_client, saved_entry):
+    result = guest_client.simulate_post(
+        "/api/v1/bibliography/duplicate-candidates",
+        body=json.dumps(saved_entry),
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN
+
+
+def test_duplicate_candidates_rejects_write_only_scope(context, saved_entry):
+    client = client_with_scope(context, "write:bibliography")
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-candidates",
+        body=json.dumps(saved_entry),
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN

--- a/ebl/tests/bibliography/test_bibliography_identity.py
+++ b/ebl/tests/bibliography/test_bibliography_identity.py
@@ -5,6 +5,7 @@ from ebl.bibliography.application.bibliography_identity import (
     update_with_identity_claims,
 )
 from ebl.bibliography.application.bibliography_repository import LookupValueInUseError
+from ebl.bibliography.application.lookup_identity import bibliography_lookup_values
 from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
 from ebl.errors import NotFoundError
 
@@ -58,6 +59,15 @@ def test_create_releases_claims_when_post_claim_lookup_finds_existing_entry(user
         )
 
     assert repository.released_owners == [repository.operation.owner]
+
+
+def test_lookup_values_skip_non_mapping_aliases():
+    entry = {
+        "id": "Q30000000",
+        "aliases": ["legacy-id", {"value": "alias-id", "normalizedValue": "alias-id"}],
+    }
+
+    assert bibliography_lookup_values(entry) == ["Q30000000", "alias-id", "alias-id"]
 
 
 class UpdateRepositorySpy:

--- a/ebl/tests/bibliography/test_bibliography_identity.py
+++ b/ebl/tests/bibliography/test_bibliography_identity.py
@@ -1,0 +1,139 @@
+import pytest
+
+from ebl.bibliography.application.bibliography_identity import (
+    create_with_identity_claims,
+    update_with_identity_claims,
+)
+from ebl.bibliography.application.bibliography_repository import LookupValueInUseError
+from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
+from ebl.errors import NotFoundError
+
+
+class ChangelogSpy:
+    def create(self, *_args):
+        raise AssertionError("changelog should not be created")
+
+
+class ChangelogNoop:
+    def create(self, *_args):
+        return None
+
+
+class RepositorySpy:
+    def __init__(self, create_error=None):
+        self.create_error = create_error
+        self.operation = None
+        self.released_owners = []
+
+    def claim_lookup_values(
+        self, operation: LookupReservationOperation, _values
+    ) -> None:
+        self.operation = operation
+
+    def create(self, _entry):
+        if self.create_error:
+            raise self.create_error
+        return "Q30000000"
+
+    def commit_lookup_values(self, *_args):
+        raise AssertionError("claims should not be committed")
+
+    def retire_lookup_values(self, *_args):
+        raise AssertionError("claims should not be retired")
+
+    def release_pending_lookup_values(self, owner):
+        self.released_owners.append(owner)
+
+
+def test_create_releases_claims_when_post_claim_lookup_finds_existing_entry(user):
+    repository = RepositorySpy()
+
+    with pytest.raises(LookupValueInUseError):
+        create_with_identity_claims(
+            repository,
+            ChangelogSpy(),
+            lambda _value: {"id": "OTHER"},
+            {"id": "Q30000000", "type": "book"},
+            user,
+        )
+
+    assert repository.released_owners == [repository.operation.owner]
+
+
+class UpdateRepositorySpy:
+    def __init__(self, old_entry, update_error=None):
+        self.old_entry = old_entry
+        self.update_error = update_error
+        self.claimed_values = None
+        self.retired_values = None
+        self.released_owners = []
+
+    def query_by_id(self, _id):
+        return self.old_entry
+
+    def claim_lookup_values(self, _operation, values):
+        self.claimed_values = values
+
+    def update(self, _entry):
+        if self.update_error:
+            raise self.update_error
+
+    def commit_lookup_values(self, *_args):
+        return None
+
+    def retire_lookup_values(self, _entry_id, values, _now):
+        self.retired_values = values
+
+    def release_pending_lookup_values(self, owner):
+        self.released_owners.append(owner)
+
+
+def missing_lookup(_value):
+    raise NotFoundError("missing")
+
+
+def test_update_claims_added_alias_and_retires_removed_citation_key(user):
+    old_entry = {"id": "Q30000000", "type": "book", "citationKey": "old-key"}
+    new_entry = {
+        "id": "Q30000000",
+        "type": "book",
+        "aliases": [{"value": "new-alias", "normalizedValue": "new-alias"}],
+    }
+    repository = UpdateRepositorySpy(old_entry)
+
+    update_with_identity_claims(
+        repository, ChangelogNoop(), missing_lookup, new_entry, user
+    )
+
+    assert repository.claimed_values == ["new-alias"]
+    assert repository.retired_values == ["old-key"]
+
+
+def test_update_failure_releases_new_claims_without_retiring_old_claims(user):
+    old_entry = {"id": "Q30000000", "type": "book", "citationKey": "old-key"}
+    new_entry = {"id": "Q30000000", "type": "book", "citationKey": "new-key"}
+    repository = UpdateRepositorySpy(old_entry, RuntimeError("update failed"))
+
+    with pytest.raises(RuntimeError, match="update failed"):
+        update_with_identity_claims(
+            repository, ChangelogSpy(), missing_lookup, new_entry, user
+        )
+
+    assert repository.claimed_values == ["new-key"]
+    assert repository.retired_values is None
+    assert repository.released_owners
+
+
+def test_create_releases_claims_when_repository_insert_fails(user):
+    repository = RepositorySpy(RuntimeError("insert failed"))
+
+    with pytest.raises(RuntimeError, match="insert failed"):
+        create_with_identity_claims(
+            repository,
+            ChangelogSpy(),
+            lambda _value: (_ for _ in ()).throw(NotFoundError("missing")),
+            {"id": "Q30000000", "type": "book"},
+            user,
+        )
+
+    assert repository.released_owners == [repository.operation.owner]

--- a/ebl/tests/bibliography/test_bibliography_identity_post_persistence.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_post_persistence.py
@@ -1,0 +1,131 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+import pytest
+from pymongo.database import Database
+
+from ebl.bibliography.application.bibliography import Bibliography
+from ebl.bibliography.application.lookup_reservation import (
+    LookupReservationState,
+)
+from ebl.bibliography.infrastructure.bibliography import MongoBibliographyRepository
+from ebl.changelog import Changelog
+from ebl.errors import DuplicateError
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+from ebl.users.domain.user import User
+
+RESERVATIONS = "bibliography_lookup_reservations"
+FUTURE = datetime(2099, 1, 1)
+
+
+@dataclass(frozen=True)
+class BibliographyIdentityContext:
+    bibliography: Bibliography
+    bibliography_repository: MongoBibliographyRepository
+    database: Database
+    changelog: Changelog
+    user: User
+
+
+@pytest.fixture
+def bibliography_identity_context(request: pytest.FixtureRequest):
+    return BibliographyIdentityContext(
+        request.getfixturevalue("bibliography"),
+        request.getfixturevalue("bibliography_repository"),
+        request.getfixturevalue("database"),
+        request.getfixturevalue("changelog"),
+        request.getfixturevalue("user"),
+    )
+
+
+def bibliography_entry(id_: str, citation_key: str, **overrides):
+    return BibliographyEntryFactory.build(
+        id=id_, citationKey=citation_key, DOI=f"10.1000/{id_}", PMID=id_, **overrides
+    )
+
+
+def state(database, value: str):
+    return database[RESERVATIONS].find_one({"_id": value})["state"]
+
+
+def assert_no_pending(database):
+    assert database[RESERVATIONS].count_documents({"state": "pending"}) == 0
+
+
+def fail_once(monkeypatch, target, name: str, message: str):
+    original = getattr(target, name)
+    calls = {"count": 0}
+
+    def failing(*args, **kwargs):
+        if calls["count"] == 0:
+            calls["count"] += 1
+            raise RuntimeError(message)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(target, name, failing)
+    return original
+
+
+def test_create_commit_failure_recovers_lookup_claims(
+    monkeypatch, bibliography_identity_context
+):
+    context = bibliography_identity_context
+    entry = bibliography_entry("Q30000000", "create-commit-key")
+    original_commit = fail_once(
+        monkeypatch,
+        context.bibliography_repository,
+        "commit_lookup_values",
+        "commit failed",
+    )
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        context.bibliography.create(entry, context.user)
+
+    assert context.bibliography_repository.query_by_id(entry["id"]) == entry
+    assert state(context.database, entry["id"]) == LookupReservationState.PENDING.value
+    assert (
+        state(context.database, entry["citationKey"])
+        == LookupReservationState.PENDING.value
+    )
+    monkeypatch.setattr(
+        context.bibliography_repository, "commit_lookup_values", original_commit
+    )
+    context.bibliography_repository.reconcile_lookup_reservations(FUTURE)
+
+    assert (
+        state(context.database, entry["id"]) == LookupReservationState.COMMITTED.value
+    )
+    assert (
+        state(context.database, entry["citationKey"])
+        == LookupReservationState.COMMITTED.value
+    )
+    assert context.bibliography.find(entry["citationKey"]) == entry
+    with pytest.raises(DuplicateError):
+        context.bibliography.create(entry, context.user)
+    assert context.database["bibliography"].count_documents({"_id": entry["id"]}) == 1
+
+
+def test_create_changelog_failure_keeps_committed_claims(
+    monkeypatch, bibliography_identity_context
+):
+    context = bibliography_identity_context
+    entry = bibliography_entry("Q30000000", "create-changelog-key")
+    fail_once(monkeypatch, context.changelog, "create", "changelog failed")
+
+    with pytest.raises(RuntimeError, match="changelog failed"):
+        context.bibliography.create(entry, context.user)
+
+    assert context.bibliography_repository.query_by_id(entry["id"]) == entry
+    assert (
+        state(context.database, entry["id"]) == LookupReservationState.COMMITTED.value
+    )
+    assert (
+        state(context.database, entry["citationKey"])
+        == LookupReservationState.COMMITTED.value
+    )
+    context.bibliography_repository.reconcile_lookup_reservations(FUTURE)
+    with pytest.raises(DuplicateError):
+        context.bibliography.create(
+            bibliography_entry("Q30000001", entry["citationKey"]), context.user
+        )
+    assert_no_pending(context.database)

--- a/ebl/tests/bibliography/test_bibliography_identity_update_recovery.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_update_recovery.py
@@ -1,0 +1,198 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import pytest
+from pymongo.database import Database
+
+from ebl.bibliography.application.bibliography import Bibliography
+from ebl.bibliography.application.lookup_reservation import (
+    LookupReservationOperation,
+    LookupReservationState,
+)
+from ebl.bibliography.infrastructure.bibliography import MongoBibliographyRepository
+from ebl.changelog import Changelog
+from ebl.errors import NotFoundError
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+from ebl.users.domain.user import User
+
+RESERVATIONS = "bibliography_lookup_reservations"
+FUTURE = datetime(2099, 1, 1)
+
+
+@dataclass(frozen=True)
+class BibliographyIdentityUpdateContext:
+    bibliography: Bibliography
+    bibliography_repository: MongoBibliographyRepository
+    database: Database
+    changelog: Changelog
+    user: User
+
+
+@pytest.fixture
+def bibliography_identity_update_context(request: pytest.FixtureRequest):
+    return BibliographyIdentityUpdateContext(
+        request.getfixturevalue("bibliography"),
+        request.getfixturevalue("bibliography_repository"),
+        request.getfixturevalue("database"),
+        request.getfixturevalue("changelog"),
+        request.getfixturevalue("user"),
+    )
+
+
+def bibliography_entry(id_: str, citation_key: str, **overrides):
+    return BibliographyEntryFactory.build(
+        id=id_, citationKey=citation_key, DOI=f"10.1000/{id_}", PMID=id_, **overrides
+    )
+
+
+def alias(value: str):
+    return {"value": value, "normalizedValue": value}
+
+
+def state(database, value: str):
+    return database[RESERVATIONS].find_one({"_id": value})["state"]
+
+
+def claim(database, value: str):
+    return database[RESERVATIONS].find_one({"_id": value})
+
+
+def reclaim(bibliography_repository, value: str):
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation("other", "Q39999999", FUTURE + timedelta(hours=1)),
+        [value],
+    )
+
+
+def fail_once(monkeypatch, target, name: str, message: str):
+    original = getattr(target, name)
+    calls = {"count": 0}
+
+    def failing(*args, **kwargs):
+        if calls["count"] == 0:
+            calls["count"] += 1
+            raise RuntimeError(message)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(target, name, failing)
+    return original
+
+
+def test_update_commit_failure_recovers_new_claims_and_retires_old(
+    monkeypatch, bibliography_identity_update_context
+):
+    context = bibliography_identity_update_context
+    old_entry = bibliography_entry("Q30000000", "old-update-key")
+    new_entry = {
+        **old_entry,
+        "citationKey": "new-update-key",
+        "aliases": [alias("new-update-alias")],
+    }
+    context.bibliography.create(old_entry, context.user)
+    original_commit = fail_once(
+        monkeypatch,
+        context.bibliography_repository,
+        "commit_lookup_values",
+        "commit failed",
+    )
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        context.bibliography.update(new_entry, context.user)
+
+    assert context.bibliography_repository.query_by_id(old_entry["id"]) == new_entry
+    assert (
+        state(context.database, old_entry["citationKey"])
+        == LookupReservationState.COMMITTED.value
+    )
+    assert (
+        state(context.database, new_entry["citationKey"])
+        == LookupReservationState.PENDING.value
+    )
+    monkeypatch.setattr(
+        context.bibliography_repository, "commit_lookup_values", original_commit
+    )
+    context.bibliography_repository.reconcile_lookup_reservations(FUTURE)
+
+    assert (
+        state(context.database, new_entry["citationKey"])
+        == LookupReservationState.COMMITTED.value
+    )
+    assert (
+        state(context.database, old_entry["citationKey"])
+        == LookupReservationState.ABANDONED.value
+    )
+    assert context.bibliography.find("new-update-alias") == new_entry
+    context.bibliography.update(new_entry, context.user)
+    assert (
+        context.database["bibliography"].count_documents({"_id": old_entry["id"]}) == 1
+    )
+
+
+def test_update_retirement_failure_reconciles_stale_old_claim(
+    monkeypatch, bibliography_identity_update_context
+):
+    context = bibliography_identity_update_context
+    old_entry = bibliography_entry("Q30000000", "old-retire-key")
+    new_entry = {**old_entry, "citationKey": "new-retire-key"}
+    context.bibliography.create(old_entry, context.user)
+    fail_once(
+        monkeypatch,
+        context.bibliography_repository,
+        "retire_lookup_values",
+        "retire failed",
+    )
+
+    with pytest.raises(RuntimeError, match="retire failed"):
+        context.bibliography.update(new_entry, context.user)
+
+    assert context.bibliography.find(new_entry["citationKey"]) == new_entry
+    assert (
+        state(context.database, new_entry["citationKey"])
+        == LookupReservationState.COMMITTED.value
+    )
+    assert (
+        state(context.database, old_entry["citationKey"])
+        == LookupReservationState.COMMITTED.value
+    )
+    context.bibliography_repository.reconcile_lookup_reservations(FUTURE)
+
+    assert (
+        state(context.database, old_entry["citationKey"])
+        == LookupReservationState.ABANDONED.value
+    )
+    reclaim(context.bibliography_repository, old_entry["citationKey"])
+    assert claim(context.database, old_entry["citationKey"])["state"] == "pending"
+    context.bibliography_repository.release_pending_lookup_values("other")
+    assert context.bibliography.find(new_entry["citationKey"]) == new_entry
+
+
+def test_update_changelog_failure_keeps_persisted_update(
+    monkeypatch, bibliography_identity_update_context
+):
+    context = bibliography_identity_update_context
+    old_entry = bibliography_entry("Q30000000", "old-changelog-key")
+    new_entry = {**old_entry, "citationKey": "new-changelog-key"}
+    context.bibliography.create(old_entry, context.user)
+    fail_once(monkeypatch, context.changelog, "create", "changelog failed")
+
+    with pytest.raises(RuntimeError, match="changelog failed"):
+        context.bibliography.update(new_entry, context.user)
+
+    assert context.bibliography_repository.query_by_id(old_entry["id"]) == new_entry
+    assert (
+        state(context.database, new_entry["citationKey"])
+        == LookupReservationState.COMMITTED.value
+    )
+    assert (
+        state(context.database, old_entry["citationKey"])
+        == LookupReservationState.ABANDONED.value
+    )
+    context.bibliography_repository.reconcile_lookup_reservations(FUTURE)
+    context.bibliography.update(new_entry, context.user)
+
+    with pytest.raises(NotFoundError):
+        context.bibliography.find(old_entry["citationKey"])
+    assert context.bibliography.find(new_entry["citationKey"]) == new_entry
+    assert (
+        context.database["bibliography"].count_documents({"_id": old_entry["id"]}) == 1
+    )

--- a/ebl/tests/bibliography/test_bibliography_lookup.py
+++ b/ebl/tests/bibliography/test_bibliography_lookup.py
@@ -55,6 +55,17 @@ def test_find_many_deduplicates_redirected_canonical_entries(
     assert bibliography.find_many(ids) == [canonical_entry]
 
 
+def test_find_many_resolves_canonical_ids_only(
+    bibliography, bibliography_repository, when
+):
+    alias = "legacy-id"
+    ids = [alias]
+    when(bibliography_repository).query_by_ids(ids).thenReturn([])
+
+    assert bibliography.find_many(ids) == []
+    verify(bibliography_repository, times=0).query_by_alias(alias)
+
+
 def test_find_redirects_deprecated_citation_key(
     bibliography, bibliography_repository, when
 ):
@@ -95,6 +106,25 @@ def test_find_rejects_missing_redirect_target(
     when(bibliography_repository).query_by_id("MISSING_ID").thenRaise(NotFoundError)
 
     with pytest.raises(NotFoundError, match="redirect target MISSING_ID not found"):
+        bibliography.find(deprecated_entry["id"])
+
+
+@pytest.mark.parametrize("redirect_to", [None, ""])
+def test_find_rejects_deprecated_entry_without_redirect_target(
+    redirect_to, bibliography, bibliography_repository, when
+):
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True
+    )
+    if redirect_to is not None:
+        deprecated_entry["redirectTo"] = redirect_to
+    (
+        when(bibliography_repository)
+        .query_by_id(deprecated_entry["id"])
+        .thenReturn(deprecated_entry)
+    )
+
+    with pytest.raises(NotFoundError, match="has no redirect target"):
         bibliography.find(deprecated_entry["id"])
 
 

--- a/ebl/tests/bibliography/test_bibliography_lookup.py
+++ b/ebl/tests/bibliography/test_bibliography_lookup.py
@@ -1,0 +1,206 @@
+import pytest
+from mockito import verify
+
+from ebl.bibliography.application.bibliography import MAX_REDIRECT_DEPTH
+from ebl.errors import DuplicateError, NotFoundError
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+def test_find(bibliography, bibliography_repository, when):
+    bibliography_entry = BibliographyEntryFactory.build()
+    (
+        when(bibliography_repository)
+        .query_by_id(bibliography_entry["id"])
+        .thenReturn(bibliography_entry)
+    )
+    assert bibliography.find(bibliography_entry["id"]) == bibliography_entry
+
+
+def test_find_redirects_deprecated_id(bibliography, bibliography_repository, when):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo="CANONICAL_ID"
+    )
+    (
+        when(bibliography_repository)
+        .query_by_id(deprecated_entry["id"])
+        .thenReturn(deprecated_entry)
+    )
+    (
+        when(bibliography_repository)
+        .query_by_id(canonical_entry["id"])
+        .thenReturn(canonical_entry)
+    )
+
+    assert bibliography.find(deprecated_entry["id"]) == canonical_entry
+
+
+def test_find_many_deduplicates_redirected_canonical_entries(
+    bibliography, bibliography_repository, when
+):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    ids = [deprecated_entry["id"], canonical_entry["id"]]
+    when(bibliography_repository).query_by_ids(ids).thenReturn(
+        [deprecated_entry, canonical_entry]
+    )
+    (
+        when(bibliography_repository)
+        .query_by_id(canonical_entry["id"])
+        .thenReturn(canonical_entry)
+    )
+
+    assert bibliography.find_many(ids) == [canonical_entry]
+
+
+def test_find_redirects_deprecated_citation_key(
+    bibliography, bibliography_repository, when
+):
+    citation_key = "duplicateCitationKey"
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID",
+        citationKey=citation_key,
+        deprecated=True,
+        redirectTo=canonical_entry["id"],
+    )
+    when(bibliography_repository).query_by_id(citation_key).thenRaise(NotFoundError)
+    (
+        when(bibliography_repository)
+        .query_by_citation_key(citation_key)
+        .thenReturn(deprecated_entry)
+    )
+    (
+        when(bibliography_repository)
+        .query_by_id(canonical_entry["id"])
+        .thenReturn(canonical_entry)
+    )
+
+    assert bibliography.find(citation_key) == canonical_entry
+
+
+def test_find_rejects_missing_redirect_target(
+    bibliography, bibliography_repository, when
+):
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo="MISSING_ID"
+    )
+    (
+        when(bibliography_repository)
+        .query_by_id(deprecated_entry["id"])
+        .thenReturn(deprecated_entry)
+    )
+    when(bibliography_repository).query_by_id("MISSING_ID").thenRaise(NotFoundError)
+
+    with pytest.raises(NotFoundError, match="redirect target MISSING_ID not found"):
+        bibliography.find(deprecated_entry["id"])
+
+
+def test_find_rejects_redirect_loop(bibliography, bibliography_repository, when):
+    first_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_A", deprecated=True, redirectTo="DUPLICATE_B"
+    )
+    second_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_B", deprecated=True, redirectTo="DUPLICATE_A"
+    )
+    when(bibliography_repository).query_by_id("DUPLICATE_A").thenReturn(first_entry)
+    when(bibliography_repository).query_by_id("DUPLICATE_B").thenReturn(second_entry)
+
+    with pytest.raises(DuplicateError, match="redirect loop"):
+        bibliography.find(first_entry["id"])
+
+
+def test_find_by_citation_key(bibliography, bibliography_repository, when):
+    bibliography_entry = BibliographyEntryFactory.build(citationKey="miccadei2002")
+    (
+        when(bibliography_repository)
+        .query_by_id(bibliography_entry["citationKey"])
+        .thenRaise(NotFoundError)
+    )
+    (
+        when(bibliography_repository)
+        .query_by_citation_key(bibliography_entry["citationKey"])
+        .thenReturn(bibliography_entry)
+    )
+
+    assert bibliography.find(bibliography_entry["citationKey"]) == bibliography_entry
+
+
+def test_find_by_alias(bibliography, bibliography_repository, when):
+    alias = "legacy-id"
+    bibliography_entry = BibliographyEntryFactory.build(
+        aliases=[{"value": alias, "normalizedValue": alias}]
+    )
+    (when(bibliography_repository).query_by_id(alias).thenRaise(NotFoundError))
+    (
+        when(bibliography_repository)
+        .query_by_citation_key(alias)
+        .thenRaise(NotFoundError)
+    )
+    (when(bibliography_repository).query_by_alias(alias).thenReturn(bibliography_entry))
+
+    assert bibliography.find(alias) == bibliography_entry
+
+
+def test_find_canonical_id_takes_precedence_over_alias(
+    bibliography, bibliography_repository, when
+):
+    shared_lookup = "Q30000000"
+    bibliography_entry = BibliographyEntryFactory.build(id=shared_lookup)
+    (
+        when(bibliography_repository)
+        .query_by_id(shared_lookup)
+        .thenReturn(bibliography_entry)
+    )
+
+    assert bibliography.find(shared_lookup) == bibliography_entry
+    verify(bibliography_repository, times=0).query_by_citation_key(shared_lookup)
+    verify(bibliography_repository, times=0).query_by_alias(shared_lookup)
+
+
+def test_find_citation_key_takes_precedence_over_alias(
+    bibliography, bibliography_repository, when
+):
+    shared_lookup = "miccadei2002"
+    bibliography_entry = BibliographyEntryFactory.build(citationKey=shared_lookup)
+    (when(bibliography_repository).query_by_id(shared_lookup).thenRaise(NotFoundError))
+    (
+        when(bibliography_repository)
+        .query_by_citation_key(shared_lookup)
+        .thenReturn(bibliography_entry)
+    )
+
+    assert bibliography.find(shared_lookup) == bibliography_entry
+    verify(bibliography_repository, times=0).query_by_alias(shared_lookup)
+
+
+def test_entry_not_found(bibliography, bibliography_repository, when):
+    bibliography_entry = BibliographyEntryFactory.build()
+    (
+        when(bibliography_repository)
+        .query_by_id(bibliography_entry["id"])
+        .thenRaise(NotFoundError)
+    )
+    with pytest.raises(NotFoundError):
+        bibliography.find(bibliography_entry["id"])
+
+
+def test_find_rejects_redirect_chain_over_max_depth(
+    bibliography, bibliography_repository, when
+):
+    deprecated_entries = [
+        BibliographyEntryFactory.build(
+            id=f"DUPLICATE_{index}",
+            deprecated=True,
+            redirectTo=f"DUPLICATE_{index + 1}",
+        )
+        for index in range(MAX_REDIRECT_DEPTH + 1)
+    ]
+
+    for entry in deprecated_entries:
+        when(bibliography_repository).query_by_id(entry["id"]).thenReturn(entry)
+
+    with pytest.raises(DuplicateError, match="maximum depth"):
+        bibliography.find(deprecated_entries[0]["id"])

--- a/ebl/tests/bibliography/test_bibliography_lookup_reservations.py
+++ b/ebl/tests/bibliography/test_bibliography_lookup_reservations.py
@@ -175,6 +175,29 @@ def test_expired_abandoned_reservation_can_be_reclaimed(
     assert reservation["state"] == LookupReservationState.PENDING.value
 
 
+def test_reclaim_survives_abandoned_reservation_ttl_delete(
+    monkeypatch, database, bibliography_repository
+):
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation("owner", "Q30000000", NOW), ["legacy-id"]
+    )
+    bibliography_repository.reconcile_lookup_reservations(LATER)
+    collection = bibliography_repository._lookup_reservations._collection
+    original_replace_one = collection.replace_one
+
+    def replace_after_ttl_delete(document, filter_=None, upsert=False):
+        database[COLLECTION].delete_one(filter_)
+        return original_replace_one(document, filter_, upsert)
+
+    monkeypatch.setattr(collection, "replace_one", replace_after_ttl_delete)
+
+    bibliography_repository.claim_lookup_values(operation("other"), ["legacy-id"])
+
+    reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
+    assert reservation["owner"] == "other"
+    assert reservation["state"] == LookupReservationState.PENDING.value
+
+
 def test_retire_lookup_values_abandons_only_matching_committed_claim(
     database, bibliography_repository
 ):

--- a/ebl/tests/bibliography/test_bibliography_lookup_reservations.py
+++ b/ebl/tests/bibliography/test_bibliography_lookup_reservations.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -11,8 +11,12 @@ from ebl.bibliography.application.lookup_reservation import (
 )
 
 COLLECTION = "bibliography_lookup_reservations"
-NOW = datetime(2099, 1, 1)
+NOW = datetime(2099, 1, 1, tzinfo=timezone.utc)
 LATER = NOW + timedelta(minutes=10)
+
+
+def mongo_datetime(value: datetime) -> datetime:
+    return value.replace(tzinfo=None)
 
 
 def operation(owner: str, entry_id: str = "Q30000000") -> LookupReservationOperation:
@@ -31,7 +35,7 @@ def test_claim_lookup_values_creates_pending_reservation(
         "owner": "owner",
         "state": LookupReservationState.PENDING.value,
         "createdAt": database[COLLECTION].find_one({"_id": "legacy-id"})["createdAt"],
-        "expiresAt": LATER,
+        "expiresAt": mongo_datetime(LATER),
     }
 
 
@@ -78,7 +82,7 @@ def test_commit_lookup_values(database, bibliography_repository):
 
     reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
     assert reservation["state"] == LookupReservationState.COMMITTED.value
-    assert reservation["committedAt"] == NOW
+    assert reservation["committedAt"] == mongo_datetime(NOW)
     assert "expiresAt" not in reservation
 
 
@@ -103,7 +107,7 @@ def test_reconcile_abandons_expired_pending_reservation(
 
     reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
     assert reservation["state"] == LookupReservationState.ABANDONED.value
-    assert reservation["deleteAt"] == LATER
+    assert reservation["deleteAt"] == mongo_datetime(LATER)
 
 
 def test_reconcile_retains_unexpired_pending_reservation(
@@ -134,6 +138,73 @@ def test_reconcile_commits_expired_pending_reservation_with_entry(
     assert "expiresAt" not in reservation
 
 
+def test_reconcile_abandons_duplicate_citation_key_reservation_and_keeps_unique_one(
+    database, bibliography_repository, create_mongo_bibliography_entry
+):
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation("owner-a", "Q30000000", NOW), ["shared-key"]
+    )
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation("owner-b", "Q30000002", NOW), ["unique-key"]
+    )
+    database["bibliography"].insert_many(
+        [
+            create_mongo_bibliography_entry(
+                {"id": "Q30000000", "type": "book", "citationKey": "shared-key"}
+            ),
+            create_mongo_bibliography_entry(
+                {"id": "Q30000001", "type": "book", "citationKey": "shared-key"}
+            ),
+            create_mongo_bibliography_entry(
+                {"id": "Q30000002", "type": "book", "citationKey": "unique-key"}
+            ),
+        ]
+    )
+
+    assert bibliography_repository.reconcile_lookup_reservations(LATER) == 2
+
+    assert (
+        database[COLLECTION].find_one({"_id": "shared-key"})["state"]
+        == LookupReservationState.ABANDONED.value
+    )
+    assert (
+        database[COLLECTION].find_one({"_id": "unique-key"})["state"]
+        == LookupReservationState.COMMITTED.value
+    )
+
+
+def test_lookup_value_is_reserved_fails_closed_for_duplicate_alias(
+    database, bibliography_repository, create_mongo_bibliography_entry
+):
+    current_operation = operation("owner", entry_id="Q30000000")
+    bibliography_repository.claim_lookup_values(current_operation, ["legacy-id"])
+    bibliography_repository.commit_lookup_values(current_operation, NOW)
+    database["bibliography"].insert_many(
+        [
+            create_mongo_bibliography_entry(
+                {
+                    "id": "Q30000000",
+                    "type": "book",
+                    "aliases": [{"value": "legacy-id", "normalizedValue": "legacy-id"}],
+                }
+            ),
+            create_mongo_bibliography_entry(
+                {
+                    "id": "Q30000001",
+                    "type": "book",
+                    "aliases": [{"value": "legacy-id", "normalizedValue": "legacy-id"}],
+                }
+            ),
+        ]
+    )
+
+    assert bibliography_repository.lookup_value_is_reserved("legacy-id") is False
+    assert (
+        database[COLLECTION].find_one({"_id": "legacy-id"})["state"]
+        == LookupReservationState.ABANDONED.value
+    )
+
+
 def test_reconcile_retires_stale_committed_reservation(
     database, bibliography_repository
 ):
@@ -145,7 +216,7 @@ def test_reconcile_retires_stale_committed_reservation(
 
     reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
     assert reservation["state"] == LookupReservationState.ABANDONED.value
-    assert reservation["deleteAt"] == LATER
+    assert reservation["deleteAt"] == mongo_datetime(LATER)
 
 
 def test_lookup_value_is_reserved_repairs_stale_committed_reservation(

--- a/ebl/tests/bibliography/test_bibliography_lookup_reservations.py
+++ b/ebl/tests/bibliography/test_bibliography_lookup_reservations.py
@@ -1,0 +1,188 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from ebl.bibliography.application.bibliography_repository import (
+    LookupValueReservationError,
+)
+from ebl.bibliography.application.lookup_reservation import (
+    LookupReservationOperation,
+    LookupReservationState,
+)
+
+COLLECTION = "bibliography_lookup_reservations"
+NOW = datetime(2099, 1, 1)
+LATER = NOW + timedelta(minutes=10)
+
+
+def operation(owner: str, entry_id: str = "Q30000000") -> LookupReservationOperation:
+    return LookupReservationOperation(owner, entry_id, LATER)
+
+
+def test_claim_lookup_values_creates_pending_reservation(
+    database, bibliography_repository
+):
+    bibliography_repository.claim_lookup_values(operation("owner"), ["legacy-id"])
+
+    assert database[COLLECTION].find_one({"_id": "legacy-id"}) == {
+        "_id": "legacy-id",
+        "value": "legacy-id",
+        "entryId": "Q30000000",
+        "owner": "owner",
+        "state": LookupReservationState.PENDING.value,
+        "createdAt": database[COLLECTION].find_one({"_id": "legacy-id"})["createdAt"],
+        "expiresAt": LATER,
+    }
+
+
+def test_same_operation_reclaim_is_idempotent(database, bibliography_repository):
+    current_operation = operation("owner")
+
+    bibliography_repository.claim_lookup_values(current_operation, ["legacy-id"])
+    bibliography_repository.claim_lookup_values(current_operation, ["legacy-id"])
+
+    assert database[COLLECTION].count_documents({"_id": "legacy-id"}) == 1
+
+
+def test_different_operation_conflicts(database, bibliography_repository):
+    bibliography_repository.claim_lookup_values(operation("owner"), ["legacy-id"])
+
+    with pytest.raises(LookupValueReservationError):
+        bibliography_repository.claim_lookup_values(operation("other"), ["legacy-id"])
+
+
+def test_release_is_owner_scoped(database, bibliography_repository):
+    bibliography_repository.claim_lookup_values(operation("owner"), ["legacy-id"])
+
+    bibliography_repository.release_pending_lookup_values("other")
+
+    assert database[COLLECTION].count_documents({"_id": "legacy-id"}) == 1
+
+
+def test_partial_claim_failure_rolls_back_new_values(database, bibliography_repository):
+    bibliography_repository.claim_lookup_values(operation("owner"), ["reserved"])
+
+    with pytest.raises(LookupValueReservationError):
+        bibliography_repository.claim_lookup_values(
+            operation("other"), ["new-value", "reserved"]
+        )
+
+    assert database[COLLECTION].find_one({"_id": "new-value"}) is None
+
+
+def test_commit_lookup_values(database, bibliography_repository):
+    current_operation = operation("owner")
+    bibliography_repository.claim_lookup_values(current_operation, ["legacy-id"])
+
+    bibliography_repository.commit_lookup_values(current_operation, NOW)
+
+    reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
+    assert reservation["state"] == LookupReservationState.COMMITTED.value
+    assert reservation["committedAt"] == NOW
+    assert "expiresAt" not in reservation
+
+
+def test_committed_claim_is_not_released_as_pending(database, bibliography_repository):
+    current_operation = operation("owner")
+    bibliography_repository.claim_lookup_values(current_operation, ["legacy-id"])
+    bibliography_repository.commit_lookup_values(current_operation, NOW)
+
+    bibliography_repository.release_pending_lookup_values("owner")
+
+    assert database[COLLECTION].count_documents({"_id": "legacy-id"}) == 1
+
+
+def test_reconcile_abandons_expired_pending_reservation(
+    database, bibliography_repository
+):
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation("owner", "Q30000000", NOW), ["legacy-id"]
+    )
+
+    assert bibliography_repository.reconcile_lookup_reservations(LATER) == 1
+
+    reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
+    assert reservation["state"] == LookupReservationState.ABANDONED.value
+    assert reservation["deleteAt"] == LATER
+
+
+def test_reconcile_retains_unexpired_pending_reservation(
+    database, bibliography_repository
+):
+    bibliography_repository.claim_lookup_values(operation("owner"), ["legacy-id"])
+
+    assert bibliography_repository.reconcile_lookup_reservations(NOW) == 0
+    assert database[COLLECTION].find_one({"_id": "legacy-id"})["state"] == "pending"
+
+
+def test_reconcile_commits_expired_pending_reservation_with_entry(
+    database, bibliography_repository, create_mongo_bibliography_entry
+):
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation("owner", "Q30000000", NOW), ["legacy-id"]
+    )
+    database["bibliography"].insert_one(
+        create_mongo_bibliography_entry(
+            {"id": "Q30000000", "type": "book", "aliases": [{"value": "legacy-id"}]}
+        )
+    )
+
+    assert bibliography_repository.reconcile_lookup_reservations(LATER) == 1
+
+    reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
+    assert reservation["state"] == LookupReservationState.COMMITTED.value
+    assert "expiresAt" not in reservation
+
+
+def test_reconcile_retires_stale_committed_reservation(
+    database, bibliography_repository
+):
+    current_operation = operation("owner")
+    bibliography_repository.claim_lookup_values(current_operation, ["legacy-id"])
+    bibliography_repository.commit_lookup_values(current_operation, NOW)
+
+    assert bibliography_repository.reconcile_lookup_reservations(LATER) == 1
+
+    reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
+    assert reservation["state"] == LookupReservationState.ABANDONED.value
+    assert reservation["deleteAt"] == LATER
+
+
+def test_lookup_value_is_reserved_repairs_stale_committed_reservation(
+    database, bibliography_repository
+):
+    current_operation = operation("owner")
+    bibliography_repository.claim_lookup_values(current_operation, ["legacy-id"])
+    bibliography_repository.commit_lookup_values(current_operation, NOW)
+
+    assert bibliography_repository.lookup_value_is_reserved("legacy-id") is False
+
+    assert database[COLLECTION].find_one({"_id": "legacy-id"})["state"] == "abandoned"
+
+
+def test_expired_abandoned_reservation_can_be_reclaimed(
+    database, bibliography_repository
+):
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation("owner", "Q30000000", NOW), ["legacy-id"]
+    )
+    bibliography_repository.reconcile_lookup_reservations(LATER)
+
+    bibliography_repository.claim_lookup_values(operation("other"), ["legacy-id"])
+
+    reservation = database[COLLECTION].find_one({"_id": "legacy-id"})
+    assert reservation["owner"] == "other"
+    assert reservation["state"] == LookupReservationState.PENDING.value
+
+
+def test_retire_lookup_values_abandons_only_matching_committed_claim(
+    database, bibliography_repository
+):
+    current_operation = operation("owner")
+    bibliography_repository.claim_lookup_values(current_operation, ["old", "kept"])
+    bibliography_repository.commit_lookup_values(current_operation, NOW)
+
+    bibliography_repository.retire_lookup_values("Q30000000", ["old"], LATER)
+
+    assert database[COLLECTION].find_one({"_id": "old"})["state"] == "abandoned"
+    assert database[COLLECTION].find_one({"_id": "kept"})["state"] == "committed"

--- a/ebl/tests/bibliography/test_bibliography_query_builders.py
+++ b/ebl/tests/bibliography/test_bibliography_query_builders.py
@@ -1,4 +1,5 @@
 from ebl.bibliography.infrastructure.bibliography import (
+    ACTIVE_BIBLIOGRAPHY_FILTER,
     MongoBibliographyRepository,
     author_year_title_match,
     bibliography_query_pipeline,
@@ -19,7 +20,7 @@ def test_author_year_title_match_and_pipeline() -> None:
 
     assert match["author.0.family"] == "George"
     assert match["issued.date-parts.0.0"] == {"$gte": 2003, "$lt": 2004}
-    assert pipeline[0] == {"$match": match}
+    assert pipeline[0] == {"$match": {**match, **ACTIVE_BIBLIOGRAPHY_FILTER}}
     assert pipeline[2]["$sort"]["title"] == 1
 
 

--- a/ebl/tests/bibliography/test_bibliography_query_builders.py
+++ b/ebl/tests/bibliography/test_bibliography_query_builders.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ebl.bibliography.infrastructure.bibliography import (
     ACTIVE_BIBLIOGRAPHY_FILTER,
     MongoBibliographyRepository,
@@ -24,7 +26,9 @@ def test_author_year_title_match_and_pipeline() -> None:
     assert pipeline[2]["$sort"]["title"] == 1
 
 
-def test_query_by_author_year_and_title_uses_title_sort() -> None:
+def test_query_by_author_year_and_title_uses_title_sort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     repository = object.__new__(MongoBibliographyRepository)
     seen = {}
 
@@ -33,7 +37,7 @@ def test_query_by_author_year_and_title_uses_title_sort() -> None:
         seen["trailing_sort_field"] = trailing_sort_field
         return ["result"]
 
-    repository._query = fake_query
+    monkeypatch.setattr(repository, "_query", fake_query)
 
     assert repository.query_by_author_year_and_title("George", 2003, "Gilgamesh") == [
         "result"

--- a/ebl/tests/bibliography/test_bibliography_repository.py
+++ b/ebl/tests/bibliography/test_bibliography_repository.py
@@ -14,6 +14,35 @@ from ebl.tests.factories.bibliography import BibliographyEntryFactory
 COLLECTION = "bibliography"
 
 
+def test_create_indexes(database, bibliography_repository):
+    bibliography_repository.create_indexes()
+
+    index_keys = [
+        index["key"] for index in database[COLLECTION].index_information().values()
+    ]
+
+    assert [("citationKey", 1)] in index_keys
+    assert [("aliases.value", 1)] in index_keys
+    assert [("aliases.normalizedValue", 1)] in index_keys
+    reservation_indexes = database[
+        "bibliography_lookup_reservations"
+    ].index_information()
+    reservation_index_keys = [index["key"] for index in reservation_indexes.values()]
+    assert reservation_indexes["bibliography_lookup_value_unique"]["unique"] is True
+    assert reservation_indexes["bibliography_lookup_value_unique"]["key"] == [
+        ("value", 1)
+    ]
+    assert [("entryId", 1)] in reservation_index_keys
+    assert [("owner", 1)] in reservation_index_keys
+    assert [("state", 1), ("expiresAt", 1)] in reservation_index_keys
+    ttl_indexes = [
+        index
+        for index in reservation_indexes.values()
+        if index["key"] == [("deleteAt", 1)]
+    ]
+    assert ttl_indexes[0]["expireAfterSeconds"] == 0
+
+
 def test_create(database, bibliography_repository, create_mongo_bibliography_entry):
     bibliography_entry = BibliographyEntryFactory.build()
     bibliography_repository.create(bibliography_entry)
@@ -40,6 +69,122 @@ def test_find(database, bibliography_repository, create_mongo_bibliography_entry
         bibliography_repository.query_by_id(bibliography_entry["id"])
         == bibliography_entry
     )
+
+
+def test_find_by_citation_key(
+    database, bibliography_repository, create_mongo_bibliography_entry
+):
+    bibliography_entry = BibliographyEntryFactory.build(citationKey="miccadei2002")
+    mongo_entry_ = create_mongo_bibliography_entry(bibliography_entry)
+    database[COLLECTION].insert_one(mongo_entry_)
+
+    assert (
+        bibliography_repository.query_by_citation_key(bibliography_entry["citationKey"])
+        == bibliography_entry
+    )
+
+
+def test_find_by_ambiguous_citation_key(bibliography_repository):
+    first_entry = BibliographyEntryFactory.build(
+        id="Q30000001", citationKey="miccadei2002"
+    )
+    second_entry = BibliographyEntryFactory.build(
+        id="Q30000002", citationKey="miccadei2002"
+    )
+    bibliography_repository.create(first_entry)
+    bibliography_repository.create(second_entry)
+
+    with pytest.raises(DuplicateError):
+        bibliography_repository.query_by_citation_key("miccadei2002")
+
+
+def test_find_by_alias_value(
+    database, bibliography_repository, create_mongo_bibliography_entry
+):
+    alias = "Leipzig/ABC 123"
+    bibliography_entry = BibliographyEntryFactory.build(
+        aliases=[{"value": alias, "normalizedValue": "leipzig-abc-123"}]
+    )
+    mongo_entry_ = create_mongo_bibliography_entry(bibliography_entry)
+    database[COLLECTION].insert_one(mongo_entry_)
+
+    assert bibliography_repository.query_by_alias(alias) == bibliography_entry
+
+
+def test_find_by_normalized_alias(
+    database, bibliography_repository, create_mongo_bibliography_entry
+):
+    bibliography_entry = BibliographyEntryFactory.build(
+        aliases=[
+            {
+                "value": "Leipzig/ABC 123",
+                "normalizedValue": "leipzig-abc-123",
+            }
+        ]
+    )
+    mongo_entry_ = create_mongo_bibliography_entry(bibliography_entry)
+    database[COLLECTION].insert_one(mongo_entry_)
+
+    assert (
+        bibliography_repository.query_by_alias("Leipzig ABC 123") == bibliography_entry
+    )
+
+
+@pytest.mark.parametrize(
+    "alias_case",
+    [
+        ("Leipzig/ABC 123", "Leipzig ABC 123", "leipzig-abc-123"),
+        ("Von_Soden:Alte/Orient", "Von Soden Alte Orient", "von-soden-alte-orient"),
+        ("D’Agostino", "D'Agostino", "d-agostino"),
+        ("Müller", "Muller", "muller"),
+        ("šulgi", "sulgi", "sulgi"),
+        ("Moon(-Killick)", "Moon Killick", "moon-killick"),
+    ],
+)
+def test_find_by_special_character_alias(
+    alias_case,
+    database,
+    bibliography_repository,
+    create_mongo_bibliography_entry,
+):
+    alias, lookup, normalized_value = alias_case
+    bibliography_entry = BibliographyEntryFactory.build(
+        aliases=[{"value": alias, "normalizedValue": normalized_value}]
+    )
+    mongo_entry_ = create_mongo_bibliography_entry(bibliography_entry)
+    database[COLLECTION].insert_one(mongo_entry_)
+
+    assert bibliography_repository.query_by_alias(lookup) == bibliography_entry
+
+
+def test_find_by_ambiguous_alias(bibliography_repository):
+    first_entry = BibliographyEntryFactory.build(
+        id="Q30000001", aliases=[{"value": "legacy", "normalizedValue": "legacy"}]
+    )
+    second_entry = BibliographyEntryFactory.build(
+        id="Q30000002", aliases=[{"value": "legacy", "normalizedValue": "legacy"}]
+    )
+    bibliography_repository.create(first_entry)
+    bibliography_repository.create(second_entry)
+
+    with pytest.raises(DuplicateError):
+        bibliography_repository.query_by_alias("legacy")
+
+
+def test_find_by_conflicting_normalized_alias(bibliography_repository):
+    first_entry = BibliographyEntryFactory.build(
+        id="Q30000001",
+        aliases=[{"value": "D’Agostino", "normalizedValue": "d-agostino"}],
+    )
+    second_entry = BibliographyEntryFactory.build(
+        id="Q30000002",
+        aliases=[{"value": "D'Agostino", "normalizedValue": "d-agostino"}],
+    )
+    bibliography_repository.create(first_entry)
+    bibliography_repository.create(second_entry)
+
+    with pytest.raises(DuplicateError):
+        bibliography_repository.query_by_alias("D'Agostino")
 
 
 def test_entry_not_found(bibliography_repository):

--- a/ebl/tests/bibliography/test_bibliography_route.py
+++ b/ebl/tests/bibliography/test_bibliography_route.py
@@ -4,10 +4,7 @@ import falcon
 import pydash
 import pytest
 
-from ebl.tests.bibliography.bibliography_route_test_helpers import (
-    INVALID_ENTRIES,
-    client_with_scope,
-)
+from ebl.tests.bibliography.bibliography_route_test_helpers import INVALID_ENTRIES
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
 
 
@@ -17,6 +14,20 @@ def test_get_entry(client, saved_entry):
 
     assert result.json == saved_entry
     assert result.status == falcon.HTTP_OK
+
+
+def test_get_deprecated_entry_redirects_to_canonical(client, bibliography, user):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    bibliography.create(canonical_entry, user)
+    bibliography.create(deprecated_entry, user)
+
+    result = client.simulate_get(f"/bibliography/{deprecated_entry['id']}")
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == canonical_entry
 
 
 def test_get_entry_not_found(client):
@@ -57,6 +68,14 @@ def test_create_entry_invalid(transform, client):
     put_result = client.simulate_post("/bibliography", body=body)
 
     assert put_result.status == falcon.HTTP_BAD_REQUEST
+
+
+def test_create_deprecated_entry_requires_redirect_target(client):
+    bibliography_entry = BibliographyEntryFactory.build(deprecated=True)
+
+    result = client.simulate_post("/bibliography", json=bibliography_entry)
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
 
 
 def test_update_entry(client, saved_entry):
@@ -121,6 +140,20 @@ def test_list_all_bibliography(client, saved_entry):
     assert result.status == falcon.HTTP_OK
 
 
+def test_list_all_bibliography_excludes_deprecated(client, bibliography, user):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    bibliography.create(canonical_entry, user)
+    bibliography.create(deprecated_entry, user)
+
+    result = client.simulate_get("/bibliography/all")
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == [canonical_entry["id"]]
+
+
 def test_list_bibliography(client, saved_entries):
     ids = [entry["id"] for entry in saved_entries]
     result = client.simulate_get(f"/bibliography/list?ids={','.join(ids)}")
@@ -129,91 +162,36 @@ def test_list_bibliography(client, saved_entries):
     assert result.status == falcon.HTTP_OK
 
 
-def test_duplicate_candidates(client, database, saved_entry):
-    proposed_entry = {**saved_entry, "id": "Q30000001"}
-    before_count = database["bibliography"].count_documents({})
+def test_list_bibliography_resolves_deprecated_ids(client, bibliography, user):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    bibliography.create(canonical_entry, user)
+    bibliography.create(deprecated_entry, user)
 
-    result = client.simulate_post(
-        "/api/v1/bibliography/duplicate-candidates",
-        body=json.dumps(proposed_entry),
+    result = client.simulate_get(
+        "/bibliography/list", params={"ids": deprecated_entry["id"]}
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json["decision"] == "likely_duplicate"
-    assert result.json["highestScore"] >= 0.92
-    assert result.json["candidates"][0]["id"] == saved_entry["id"]
-    assert result.json["candidates"][0]["recommendation"] == "block_or_request_override"
-    assert result.json["candidates"][0]["matchedFields"]["doi"] == 1.0
-    assert database["bibliography"].count_documents({}) == before_count
+    assert result.json == [canonical_entry]
 
 
-def test_duplicate_candidates_allows_missing_id(client, saved_entry):
-    proposed_entry = pydash.omit(saved_entry, "id")
-    result = client.simulate_post(
-        "/api/v1/bibliography/duplicate-candidates",
-        body=json.dumps(proposed_entry),
-    )
-
-    assert result.status == falcon.HTTP_OK
-    assert result.json["decision"] == "likely_duplicate"
-
-
-def test_duplicate_candidates_series_sibling_is_not_likely(
-    client, bibliography, user, database
+def test_list_bibliography_deduplicates_redirected_canonical_entries(
+    client, bibliography, user
 ):
-    existing_entry = BibliographyEntryFactory.build(
-        id="Q30000000",
-        type="book",
-        title="Babylonian Provincial Officials Part One",
-        author=[{"given": "Mark", "family": "Smith"}],
-        issued={"date-parts": [[2010]]},
-        DOI="",
-        publisher="Eisenbrauns",
-        **{"collection-title": "Babylonian Provincial Officials"},
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
     )
-    proposed_entry = {
-        **existing_entry,
-        "id": "Q30000001",
-        "title": "Babylonian Provincial Officials Part Two",
-    }
-    bibliography.create(existing_entry, user)
-    before_count = database["bibliography"].count_documents({})
+    bibliography.create(canonical_entry, user)
+    bibliography.create(deprecated_entry, user)
 
-    result = client.simulate_post(
-        "/api/v1/bibliography/duplicate-candidates",
-        body=json.dumps(proposed_entry),
+    result = client.simulate_get(
+        "/bibliography/list",
+        params={"ids": f"{deprecated_entry['id']},{canonical_entry['id']}"},
     )
 
     assert result.status == falcon.HTTP_OK
-    assert result.json["decision"] == "no_duplicate"
-    assert result.json["candidates"][0]["decision"] == "no_duplicate"
-    assert "series_part" in result.json["candidates"][0]["conflictingFields"]
-    assert database["bibliography"].count_documents({}) == before_count
-
-
-def test_duplicate_candidates_invalid(client):
-    result = client.simulate_post(
-        "/api/v1/bibliography/duplicate-candidates",
-        body=json.dumps({"title": "Missing type"}),
-    )
-
-    assert result.status == falcon.HTTP_BAD_REQUEST
-
-
-def test_duplicate_candidates_requires_duplicate_check_scope(guest_client, saved_entry):
-    result = guest_client.simulate_post(
-        "/api/v1/bibliography/duplicate-candidates",
-        body=json.dumps(saved_entry),
-    )
-
-    assert result.status == falcon.HTTP_FORBIDDEN
-
-
-def test_duplicate_candidates_rejects_write_only_scope(context, saved_entry):
-    client = client_with_scope(context, "write:bibliography")
-    result = client.simulate_post(
-        "/api/v1/bibliography/duplicate-candidates",
-        body=json.dumps(saved_entry),
-    )
-
-    assert result.status == falcon.HTTP_FORBIDDEN
+    assert result.json == [canonical_entry]

--- a/ebl/tests/bibliography/test_partner_bibliography_application.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_application.py
@@ -1,0 +1,173 @@
+import pytest
+
+from ebl.bibliography.application.bibliography_repository import (
+    LookupValueReservationError,
+)
+from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
+from ebl.bibliography.application.partner_bibliography import PartnerBibliography
+from ebl.errors import DataError, DuplicateError, NotFoundError
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+class FakeRepository:
+    def __init__(self, existing_ids=None, reserved_values=()):
+        self._existing_ids = list(existing_ids or [])
+        self._reserved_values = set(reserved_values)
+        self.calls = 0
+        self.released_entry_ids = []
+
+    def list_all_bibliography(self):
+        self.calls += 1
+        return self._existing_ids[: self.calls - 1]
+
+    def claim_lookup_values(self, _operation: LookupReservationOperation, values):
+        for value in set(values):
+            if value in self._reserved_values:
+                raise LookupValueReservationError(value)
+
+    def commit_lookup_values(self, _operation, _now):
+        return None
+
+    def release_pending_lookup_values(self, owner):
+        self.released_entry_ids.append(owner)
+
+    def retire_lookup_values(self, _entry_id, _values, _now):
+        return None
+
+    def lookup_value_is_reserved(self, value):
+        return value in self._reserved_values
+
+    def reconcile_lookup_reservations(self, _now, _limit=100):
+        return 0
+
+
+class FakeBibliography:
+    def __init__(self, duplicate_creates=0, ambiguous_lookups=()):
+        self._duplicate_creates = duplicate_creates
+        self._ambiguous_lookups = set(ambiguous_lookups)
+        self.created_entries = []
+
+    def create(self, entry, _user):
+        if self._duplicate_creates:
+            self._duplicate_creates -= 1
+            raise DuplicateError("duplicate id")
+        self.created_entries.append(dict(entry))
+        return entry["id"]
+
+    def update(self, _entry, _user):
+        raise NotImplementedError
+
+    def find(self, id_):
+        if id_ in self._ambiguous_lookups:
+            raise DuplicateError("ambiguous")
+        raise NotFoundError(f"{id_} not found")
+
+    def find_duplicate_candidates(self, _entry, limit=10):
+        return {"decision": "unique", "candidates": []}
+
+
+def test_create_entry_retries_duplicate_canonical_ids(user):
+    bibliography = FakeBibliography(duplicate_creates=1)
+    repository = FakeRepository(existing_ids=["Q30000000"])
+    partner_bibliography = PartnerBibliography(bibliography, repository)
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    partner_bibliography.create_entry(entry, user)
+
+    assert entry["id"] == "Q30000001"
+    assert bibliography.created_entries[0]["id"] == "Q30000001"
+
+
+def test_create_entry_retries_reserved_canonical_id(user):
+    bibliography = FakeBibliography()
+    repository = FakeRepository(reserved_values=["Q30000000"])
+    partner_bibliography = PartnerBibliography(bibliography, repository)
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    partner_bibliography.create_entry(entry, user)
+
+    assert entry["id"] == "Q30000001"
+    assert bibliography.created_entries[0]["id"] == "Q30000001"
+
+
+def test_create_entry_uses_next_citation_key_when_base_reserved(user):
+    bibliography = FakeBibliography()
+    repository = FakeRepository(reserved_values=["miccadei2002Synergistic"])
+    partner_bibliography = PartnerBibliography(bibliography, repository)
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    partner_bibliography.create_entry(entry, user)
+
+    assert entry["citationKey"] == "miccadei2002Synergistic-2"
+    assert bibliography.created_entries[0]["citationKey"] == entry["citationKey"]
+
+
+def test_create_entry_uses_third_citation_key_when_base_and_second_reserved(user):
+    bibliography = FakeBibliography()
+    repository = FakeRepository(
+        reserved_values=["miccadei2002Synergistic", "miccadei2002Synergistic-2"]
+    )
+    partner_bibliography = PartnerBibliography(bibliography, repository)
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    partner_bibliography.create_entry(entry, user)
+
+    assert entry["citationKey"] == "miccadei2002Synergistic-3"
+
+
+def test_create_entry_bounds_citation_key_generation(user):
+    base_key = "miccadei2002Synergistic"
+    reserved_values = [base_key, *(f"{base_key}-{suffix}" for suffix in range(2, 101))]
+    bibliography = FakeBibliography()
+    repository = FakeRepository(reserved_values=reserved_values)
+    partner_bibliography = PartnerBibliography(bibliography, repository)
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    with pytest.raises(
+        DuplicateError, match="Unable to generate a unique citation key"
+    ):
+        partner_bibliography.create_entry(entry, user)
+
+    assert bibliography.created_entries == []
+
+
+def test_create_entry_rejects_reserved_alias_before_create(user):
+    bibliography = FakeBibliography()
+    repository = FakeRepository(reserved_values=["partner-id"])
+    partner_bibliography = PartnerBibliography(bibliography, repository)
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    with pytest.raises(DuplicateError, match="already in use"):
+        partner_bibliography.create_entry(entry, user)
+
+    assert bibliography.created_entries == []
+
+
+def test_create_entry_raises_when_canonical_id_retries_are_exhausted(user):
+    bibliography = FakeBibliography(duplicate_creates=5)
+    partner_bibliography = PartnerBibliography(bibliography, FakeRepository())
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    with pytest.raises(DuplicateError, match="Unable to generate"):
+        partner_bibliography.create_entry(entry, user)
+
+    assert entry["id"] == "partner-id"
+
+
+def test_create_entry_rejects_ambiguous_partner_id_before_create(user):
+    bibliography = FakeBibliography(ambiguous_lookups=["ambiguous-id"])
+    partner_bibliography = PartnerBibliography(bibliography, FakeRepository())
+    entry = BibliographyEntryFactory.build(id="ambiguous-id")
+
+    with pytest.raises(DuplicateError, match="already in use"):
+        partner_bibliography.create_entry(entry, user)
+
+    assert bibliography.created_entries == []
+
+
+def test_create_entry_converts_internal_schema_failure_to_data_error(user):
+    partner_bibliography = PartnerBibliography(FakeBibliography(), FakeRepository())
+    entry = BibliographyEntryFactory.build(id="partner-id", type="not-a-csl-type")
+
+    with pytest.raises(DataError):
+        partner_bibliography.create_entry(entry, user)

--- a/ebl/tests/bibliography/test_partner_bibliography_create_duplicate_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_create_duplicate_route.py
@@ -1,0 +1,101 @@
+import json
+
+import falcon
+
+from ebl.tests.bibliography.bibliography_route_test_helpers import (
+    insufficient_data_duplicate_result,
+    patch_duplicate_override_result,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+def test_partner_bibliography_create_duplicate_conflict_does_not_mutate(
+    client, database, saved_entry
+):
+    duplicate_entry = {**saved_entry, "id": "Q30000001"}
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(duplicate_entry)
+    )
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert result.json["decision"] == "likely_duplicate"
+    assert result.json["candidates"][0]["id"] == saved_entry["id"]
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+def test_partner_bibliography_create_insufficient_data_conflict_does_not_mutate(
+    monkeypatch, client, database
+):
+    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
+    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert result.json["decision"] == "insufficient_data"
+    assert result.json["candidates"][0]["recommendation"] == "confirm_before_create"
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+def test_partner_bibliography_create_alias_collision_returns_conflict(
+    client, bibliography, user, database
+):
+    existing_entry = BibliographyEntryFactory.build(
+        id="Q30000000",
+        aliases=[
+            {
+                "value": "Leipzig/ABC 123",
+                "normalizedValue": "leipzig-abc-123",
+            }
+        ],
+    )
+    bibliography.create(existing_entry, user)
+    before_count = database["bibliography"].count_documents({})
+    bibliography_entry = BibliographyEntryFactory.build(
+        id="Leipzig ABC 123",
+        DOI="10.1000/two",
+        title="A Different Title",
+        issued={"date-parts": [[2005, 1, 1]]},
+    )
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "already in use" in result.json["description"]
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+def test_partner_bibliography_create_series_sibling_does_not_conflict(
+    client, bibliography, user
+):
+    existing_entry = BibliographyEntryFactory.build(
+        id="Q30000000",
+        type="book",
+        title="Babylonian Provincial Officials Part One",
+        author=[{"given": "Mark", "family": "Smith"}],
+        issued={"date-parts": [[2010]]},
+        DOI="",
+        publisher="Eisenbrauns",
+        **{"collection-title": "Babylonian Provincial Officials"},
+    )
+    sibling_entry = {
+        **existing_entry,
+        "id": "Q30000001",
+        "title": "Babylonian Provincial Officials Part Two",
+    }
+    bibliography.create(existing_entry, user)
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(sibling_entry)
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert bibliography.find(existing_entry["id"]) == existing_entry
+    assert bibliography.find(result.json["id"]) == result.json

--- a/ebl/tests/bibliography/test_partner_bibliography_create_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_create_route.py
@@ -1,0 +1,227 @@
+import json
+import re
+from datetime import datetime, timedelta
+
+import falcon
+import pytest
+
+from ebl.bibliography.application.lookup_reservation import (
+    LookupReservationOperation,
+    LookupReservationState,
+)
+from ebl.tests.bibliography.bibliography_route_test_helpers import (
+    client_with_scope,
+    patch_duplicate_override_result,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+RESERVATIONS = "bibliography_lookup_reservations"
+
+
+def lookup_values(entry):
+    values = {entry["id"], entry["citationKey"]}
+    for alias in entry.get("aliases", []):
+        values.add(alias["value"])
+        values.add(alias["normalizedValue"])
+    return values
+
+
+def test_partner_bibliography_create(client, database):
+    bibliography_entry = {
+        key: value
+        for key, value in BibliographyEntryFactory.build().items()
+        if key != "id"
+    }
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert re.fullmatch(r"Q\d{8}", result.json["id"])
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
+    assert result.json["citationKey"] == "miccadei2002Synergistic"
+
+    get_result = client.simulate_get(f"/api/v1/bibliography/{result.json['id']}")
+
+    assert get_result.json["id"] == result.json["id"]
+    assert get_result.json["citationKey"] == "miccadei2002Synergistic"
+    assert get_result.json["bibliographyEntry"] == result.json
+    reservations = database[RESERVATIONS].find(
+        {"_id": {"$in": list(lookup_values(result.json))}}
+    )
+    assert {reservation["state"] for reservation in reservations} == {
+        LookupReservationState.COMMITTED.value
+    }
+
+
+def test_partner_bibliography_create_with_submitted_id_stores_alias(client, database):
+    submitted_id = "partner-legacy-123"
+    bibliography_entry = BibliographyEntryFactory.build(id=submitted_id)
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert result.json["id"] != submitted_id
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
+    assert result.json["citationKey"] == "miccadei2002Synergistic"
+    assert result.json["aliases"] == [
+        {
+            "value": submitted_id,
+            "normalizedValue": submitted_id,
+            "type": "partner_id",
+            "source": "partner_request",
+            "status": "redirect",
+        }
+    ]
+
+    canonical_result = client.simulate_get(f"/api/v1/bibliography/{result.json['id']}")
+    alias_result = client.simulate_get(f"/api/v1/bibliography/{submitted_id}")
+
+    assert canonical_result.json["bibliographyEntry"] == result.json
+    assert alias_result.json["id"] == result.json["id"]
+    assert alias_result.json["bibliographyEntry"] == result.json
+    values = lookup_values(result.json)
+    assert database[RESERVATIONS].count_documents(
+        {"_id": {"$in": list(values)}}
+    ) == len(values)
+
+
+def test_partner_bibliography_create_citation_key_collision_suffixes(
+    client, bibliography, user
+):
+    existing_entry = BibliographyEntryFactory.build(
+        id="Q30000000",
+        citationKey="miccadei2002Synergistic",
+    )
+    bibliography.create(existing_entry, user)
+    submitted_id = "partner-collision-123"
+    bibliography_entry = BibliographyEntryFactory.build(
+        id=submitted_id,
+        type="book",
+        DOI="10.1000/collision",
+        PMID="99999999",
+        title="Synergistic Tablets from Babylon",
+        publisher="Test Press",
+        volume="12",
+        issue="1",
+        page="1-20",
+    )
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert result.json["id"] != submitted_id
+    assert result.json["citationKey"] == "miccadei2002Synergistic-2"
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
+    assert result.json["aliases"][0]["value"] == submitted_id
+    assert bibliography.find(existing_entry["id"]) == existing_entry
+
+
+def test_partner_bibliography_create_citation_key_exhaustion_returns_conflict(
+    monkeypatch, client, bibliography_repository, database
+):
+    patch_duplicate_override_result(
+        monkeypatch, {"decision": "unique", "highestScore": 0, "candidates": []}
+    )
+    base_key = "miccadei2002Synergistic"
+    reserved_values = [base_key, *(f"{base_key}-{suffix}" for suffix in range(2, 101))]
+    bibliography_repository.claim_lookup_values(
+        LookupReservationOperation(
+            "owner", "Q99999999", datetime.utcnow() + timedelta(hours=1)
+        ),
+        reserved_values,
+    )
+    bibliography_entry = BibliographyEntryFactory.build(id="partner-exhausted-key")
+    before_bibliography_count = database["bibliography"].count_documents({})
+    before_changelog_count = database["changelog"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "Unable to generate a unique citation key" in result.json["description"]
+    assert database["bibliography"].count_documents({}) == before_bibliography_count
+    assert database[RESERVATIONS].count_documents({"state": "pending"}) == len(
+        reserved_values
+    )
+    assert database["changelog"].count_documents({}) == before_changelog_count
+
+
+def test_partner_bibliography_create_preserves_special_character_aliases(client):
+    submitted_id = "Von_Soden:Alte/Orient"
+    bibliography_entry = BibliographyEntryFactory.build(id=submitted_id)
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert result.json["aliases"][0]["value"] == submitted_id
+    assert result.json["aliases"][0]["normalizedValue"] == "von-soden-alte-orient"
+
+    alias_result = client.simulate_get("/api/v1/bibliography/Von Soden Alte Orient")
+
+    assert alias_result.status == falcon.HTTP_OK
+    assert alias_result.json["id"] == result.json["id"]
+
+
+def test_partner_bibliography_create_requires_write_scope(guest_client):
+    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
+    result = guest_client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN
+
+
+def test_partner_bibliography_create_rejects_export_only_scope(context):
+    client = client_with_scope(context, "export:bibliography")
+    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN
+
+
+def test_partner_bibliography_create_invalid(client):
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps({"title": "Missing type"})
+    )
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
+
+
+def test_partner_bibliography_create_rejects_unsafe_partner_id(client, database):
+    bibliography_entry = BibliographyEntryFactory.build(id="bad\u0000id")
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert "control characters" in result.json["description"]
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+@pytest.mark.parametrize("partner_id", ["", "   "])
+def test_partner_bibliography_create_rejects_empty_partner_id(
+    partner_id, client, database
+):
+    bibliography_entry = BibliographyEntryFactory.build(id=partner_id)
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
+    )
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert "must be a non-empty string" in result.json["description"]
+    assert database["bibliography"].count_documents({}) == before_count

--- a/ebl/tests/bibliography/test_partner_bibliography_export_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_export_route.py
@@ -1,12 +1,5 @@
-import json
-
 import falcon
 
-from ebl.tests.bibliography.bibliography_route_test_helpers import (
-    client_with_scope,
-    insufficient_data_duplicate_result,
-    patch_duplicate_override_result,
-)
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
 
 
@@ -34,6 +27,29 @@ def test_partner_bibliography_export_page(client, saved_entries):
     ]
 
 
+def test_partner_bibliography_export_excludes_deprecated_records(
+    client, bibliography, user
+):
+    canonical_entry = BibliographyEntryFactory.build(id="Q30000000")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="Q30000001", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    active_entry = BibliographyEntryFactory.build(id="Q30000002")
+    for entry in (canonical_entry, deprecated_entry, active_entry):
+        bibliography.create(entry, user)
+
+    first_page = client.simulate_get("/api/v1/bibliography", params={"limit": 1})
+    second_page = client.simulate_get(
+        "/api/v1/bibliography",
+        params={"limit": 1, "cursor": first_page.json["nextCursor"]},
+    )
+
+    assert [item["id"] for item in first_page.json["items"]] == [canonical_entry["id"]]
+    assert first_page.json["nextCursor"] == canonical_entry["id"]
+    assert [item["id"] for item in second_page.json["items"]] == [active_entry["id"]]
+    assert second_page.json["nextCursor"] is None
+
+
 def test_partner_bibliography_export_caps_limit(client, saved_entries):
     result = client.simulate_get("/api/v1/bibliography", params={"limit": 999})
 
@@ -50,6 +66,51 @@ def test_partner_bibliography_entry_by_id(client, saved_entry):
     assert result.json["bibliographyEntry"] == saved_entry
 
 
+def test_partner_bibliography_entry_by_deprecated_id_redirects(
+    client, bibliography, user
+):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    bibliography.create(canonical_entry, user)
+    bibliography.create(deprecated_entry, user)
+
+    result = client.simulate_get(f"/api/v1/bibliography/{deprecated_entry['id']}")
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == canonical_entry["id"]
+    assert result.json["bibliographyEntry"] == canonical_entry
+
+
+def test_partner_bibliography_entry_by_citation_key(client, bibliography, user):
+    bibliography_entry = BibliographyEntryFactory.build(citationKey="miccadei2002")
+    bibliography.create(bibliography_entry, user)
+
+    result = client.simulate_get(
+        f"/api/v1/bibliography/{bibliography_entry['citationKey']}"
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == bibliography_entry["id"]
+    assert result.json["citationKey"] == bibliography_entry["citationKey"]
+    assert result.json["bibliographyEntry"] == bibliography_entry
+
+
+def test_partner_bibliography_entry_by_alias(client, bibliography, user):
+    alias = "legacy-id"
+    bibliography_entry = BibliographyEntryFactory.build(
+        aliases=[{"value": alias, "normalizedValue": alias}]
+    )
+    bibliography.create(bibliography_entry, user)
+
+    result = client.simulate_get(f"/api/v1/bibliography/{alias}")
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == bibliography_entry["id"]
+    assert result.json["bibliographyEntry"] == bibliography_entry
+
+
 def test_partner_bibliography_entry_not_found(client):
     result = client.simulate_get("/api/v1/bibliography/not-found")
 
@@ -60,109 +121,3 @@ def test_partner_bibliography_export_requires_export_scope(guest_client):
     result = guest_client.simulate_get("/api/v1/bibliography")
 
     assert result.status == falcon.HTTP_FORBIDDEN
-
-
-def test_partner_bibliography_create(client):
-    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
-    result = client.simulate_post(
-        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
-    )
-
-    assert result.status == falcon.HTTP_CREATED
-    assert (
-        result.headers["Location"] == f"/api/v1/bibliography/{bibliography_entry['id']}"
-    )
-    assert result.json == bibliography_entry
-
-    get_result = client.simulate_get(f"/api/v1/bibliography/{bibliography_entry['id']}")
-
-    assert get_result.json["bibliographyEntry"] == bibliography_entry
-
-
-def test_partner_bibliography_create_requires_write_scope(guest_client):
-    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
-    result = guest_client.simulate_post(
-        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
-    )
-
-    assert result.status == falcon.HTTP_FORBIDDEN
-
-
-def test_partner_bibliography_create_rejects_export_only_scope(context):
-    client = client_with_scope(context, "export:bibliography")
-    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
-    result = client.simulate_post(
-        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
-    )
-
-    assert result.status == falcon.HTTP_FORBIDDEN
-
-
-def test_partner_bibliography_create_invalid(client):
-    result = client.simulate_post(
-        "/api/v1/bibliography", body=json.dumps({"title": "Missing type"})
-    )
-
-    assert result.status == falcon.HTTP_BAD_REQUEST
-
-
-def test_partner_bibliography_create_duplicate_conflict_does_not_mutate(
-    client, database, saved_entry
-):
-    duplicate_entry = {**saved_entry, "id": "Q30000001"}
-    before_count = database["bibliography"].count_documents({})
-
-    result = client.simulate_post(
-        "/api/v1/bibliography", body=json.dumps(duplicate_entry)
-    )
-
-    assert result.status == falcon.HTTP_CONFLICT
-    assert result.json["decision"] == "likely_duplicate"
-    assert result.json["candidates"][0]["id"] == saved_entry["id"]
-    assert database["bibliography"].count_documents({}) == before_count
-
-
-def test_partner_bibliography_create_insufficient_data_conflict_does_not_mutate(
-    monkeypatch, client, database
-):
-    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
-    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
-    before_count = database["bibliography"].count_documents({})
-
-    result = client.simulate_post(
-        "/api/v1/bibliography", body=json.dumps(bibliography_entry)
-    )
-
-    assert result.status == falcon.HTTP_CONFLICT
-    assert result.json["decision"] == "insufficient_data"
-    assert result.json["candidates"][0]["recommendation"] == "confirm_before_create"
-    assert database["bibliography"].count_documents({}) == before_count
-
-
-def test_partner_bibliography_create_series_sibling_does_not_conflict(
-    client, bibliography, user
-):
-    existing_entry = BibliographyEntryFactory.build(
-        id="Q30000000",
-        type="book",
-        title="Babylonian Provincial Officials Part One",
-        author=[{"given": "Mark", "family": "Smith"}],
-        issued={"date-parts": [[2010]]},
-        DOI="",
-        publisher="Eisenbrauns",
-        **{"collection-title": "Babylonian Provincial Officials"},
-    )
-    sibling_entry = {
-        **existing_entry,
-        "id": "Q30000001",
-        "title": "Babylonian Provincial Officials Part Two",
-    }
-    bibliography.create(existing_entry, user)
-
-    result = client.simulate_post(
-        "/api/v1/bibliography", body=json.dumps(sibling_entry)
-    )
-
-    assert result.status == falcon.HTTP_CREATED
-    assert bibliography.find(existing_entry["id"]) == existing_entry
-    assert bibliography.find(sibling_entry["id"]) == sibling_entry

--- a/ebl/tests/bibliography/test_partner_bibliography_override_additional_success_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_override_additional_success_route.py
@@ -1,0 +1,85 @@
+import json
+
+import falcon
+
+from ebl.tests.bibliography.bibliography_route_test_helpers import (
+    INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID,
+    duplicate_override_payload,
+    insufficient_data_duplicate_result,
+    patch_duplicate_override_result,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+def test_partner_bibliography_duplicate_override_creates_insufficient_data(
+    monkeypatch, client, database
+):
+    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
+    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(
+                bibliography_entry, [INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID]
+            )
+        ),
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert result.json["id"] != bibliography_entry["id"]
+    assert result.json["citationKey"] == "miccadei2002Synergistic"
+    assert database["bibliography"].count_documents({}) == before_count + 1
+
+
+def test_partner_bibliography_duplicate_override_reruns_duplicate_detection(
+    client, bibliography, user, database
+):
+    existing_entry = BibliographyEntryFactory.build(
+        id="Q30000000",
+        DOI="10.1210/MEND.16.4.0808",
+        title="The Synergistic Activity of Thyroid Transcription Factor 1",
+        author=[{"given": "Stefania", "family": "Miccadei"}],
+        issued={"date-parts": [[2002, 1, 1]]},
+        **{"container-title": "Molecular Endocrinology"},
+        volume="2",
+        issue="4",
+        page="837-846",
+    )
+    proposed_entry = {**existing_entry, "id": "Q30000001"}
+    bibliography.create(existing_entry, user)
+
+    preflight = client.simulate_post(
+        "/api/v1/bibliography/duplicate-candidates",
+        body=json.dumps(proposed_entry),
+    )
+
+    assert preflight.status == falcon.HTTP_OK
+    assert preflight.json["candidates"][0]["id"] == existing_entry["id"]
+
+    bibliography.update(
+        {
+            **existing_entry,
+            "type": "book",
+            "title": "Administrative Documents from Nippur",
+            "author": [{"given": "Mary", "family": "Jones"}],
+            "issued": {"date-parts": [[1971, 1, 1]]},
+            "DOI": "",
+            "ISBN": "9781575060727",
+            "page": "1-50",
+        },
+        user,
+    )
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(proposed_entry, [existing_entry["id"]])
+        ),
+    )
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
+    assert "Use POST /api/v1/bibliography instead." in result.json["description"]
+    assert database["bibliography"].count_documents({}) == before_count

--- a/ebl/tests/bibliography/test_partner_bibliography_override_scope_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_override_scope_route.py
@@ -1,0 +1,55 @@
+import json
+
+import falcon
+
+from ebl.tests.bibliography.bibliography_route_test_helpers import (
+    client_with_scope,
+    duplicate_override_payload,
+)
+
+
+def test_partner_bibliography_duplicate_override_requires_write_scope(
+    guest_client, saved_entry
+):
+    duplicate_entry = {**saved_entry, "id": "Q30000001"}
+
+    result = guest_client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(duplicate_entry, [saved_entry["id"]])
+        ),
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN
+
+
+def test_partner_bibliography_duplicate_override_rejects_duplicate_check_only_scope(
+    context, saved_entry
+):
+    client = client_with_scope(context, "check:bibliography_duplicates")
+    duplicate_entry = {**saved_entry, "id": "Q30000001"}
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(duplicate_entry, [saved_entry["id"]])
+        ),
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN
+
+
+def test_partner_bibliography_duplicate_override_rejects_export_only_scope(
+    context, saved_entry
+):
+    client = client_with_scope(context, "export:bibliography")
+    duplicate_entry = {**saved_entry, "id": "Q30000001"}
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(duplicate_entry, [saved_entry["id"]])
+        ),
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN

--- a/ebl/tests/bibliography/test_partner_bibliography_override_success_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_override_success_route.py
@@ -1,7 +1,9 @@
 import json
 
 import falcon
+import pydash
 
+from ebl.bibliography.application.lookup_reservation import LookupReservationState
 from ebl.tests.bibliography.bibliography_route_test_helpers import (
     BLOCKING_DUPLICATE_CANDIDATE_ID,
     INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID,
@@ -12,6 +14,8 @@ from ebl.tests.bibliography.bibliography_route_test_helpers import (
     patch_duplicate_override_result,
 )
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+RESERVATIONS = "bibliography_lookup_reservations"
 
 
 def test_partner_bibliography_duplicate_override_creates_likely_duplicate(
@@ -30,13 +34,26 @@ def test_partner_bibliography_duplicate_override_creates_likely_duplicate(
     )
 
     assert result.status == falcon.HTTP_CREATED
-    assert result.headers["Location"] == "/api/v1/bibliography/Q30000001"
-    assert result.json == duplicate_entry
+    assert result.json["id"] != duplicate_entry["id"]
+    assert result.json["citationKey"] == "miccadei2002Synergistic"
+    assert result.json["aliases"] == [
+        {
+            "value": duplicate_entry["id"],
+            "normalizedValue": duplicate_entry["id"].casefold(),
+            "type": "partner_id",
+            "source": "partner_request",
+            "status": "redirect",
+        }
+    ]
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
     assert database["bibliography"].count_documents({}) == before_count + 1
+    reservation = database[RESERVATIONS].find_one({"_id": duplicate_entry["id"]})
+    assert reservation["state"] == LookupReservationState.COMMITTED.value
 
-    get_result = client.simulate_get("/api/v1/bibliography/Q30000001")
+    get_result = client.simulate_get(f"/api/v1/bibliography/{duplicate_entry['id']}")
 
-    assert get_result.json["bibliographyEntry"] == duplicate_entry
+    assert get_result.json["id"] == result.json["id"]
+    assert get_result.json["bibliographyEntry"] == result.json
 
 
 def test_partner_bibliography_duplicate_override_creates_possible_duplicate(
@@ -67,8 +84,80 @@ def test_partner_bibliography_duplicate_override_creates_possible_duplicate(
     )
 
     assert result.status == falcon.HTTP_CREATED
-    assert result.headers["Location"] == "/api/v1/bibliography/Q30000001"
-    assert result.json == proposed_entry
+    assert result.json["id"] != proposed_entry["id"]
+    assert result.json["citationKey"] == "miccadei2002Synergistic"
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
+    assert database["bibliography"].count_documents({}) == before_count + 1
+
+
+def test_partner_bibliography_duplicate_override_citation_key_collision_suffixes(
+    monkeypatch, client, bibliography, user, database
+):
+    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
+    existing_entry = BibliographyEntryFactory.build(
+        id="Q30000000",
+        citationKey="miccadei2002Synergistic",
+    )
+    bibliography.create(existing_entry, user)
+    bibliography_entry = BibliographyEntryFactory.build(
+        id="partner-override-123",
+        type="book",
+        DOI="10.1000/override-collision",
+        PMID="99999998",
+        title="Synergistic Tablets from Babylon",
+        publisher="Test Press",
+        volume="12",
+        issue="1",
+        page="1-20",
+    )
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(
+                bibliography_entry, [INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID]
+            )
+        ),
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert result.json["id"] != bibliography_entry["id"]
+    assert result.json["citationKey"] == "miccadei2002Synergistic-2"
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
+    assert result.json["aliases"] == [
+        {
+            "value": "partner-override-123",
+            "normalizedValue": "partner-override-123",
+            "type": "partner_id",
+            "source": "partner_request",
+            "status": "redirect",
+        }
+    ]
+    assert database["bibliography"].count_documents({}) == before_count + 1
+    assert bibliography.find(existing_entry["id"]) == existing_entry
+
+
+def test_partner_bibliography_duplicate_override_without_id_generates_canonical_id(
+    monkeypatch, client, database
+):
+    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
+    bibliography_entry = pydash.omit(BibliographyEntryFactory.build(), "id")
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(
+                bibliography_entry, [INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID]
+            )
+        ),
+    )
+
+    assert result.status == falcon.HTTP_CREATED
+    assert result.json["id"].startswith("Q")
+    assert result.json["citationKey"] == "miccadei2002Synergistic"
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
     assert database["bibliography"].count_documents({}) == before_count + 1
 
 
@@ -89,8 +178,8 @@ def test_partner_bibliography_duplicate_override_accepts_blocking_candidate_id(
     )
 
     assert result.status == falcon.HTTP_CREATED
-    assert result.headers["Location"] == "/api/v1/bibliography/Q30000001"
-    assert result.json == bibliography_entry
+    assert result.json["id"] != bibliography_entry["id"]
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
     assert database["bibliography"].count_documents({}) == before_count + 1
 
 
@@ -115,79 +204,6 @@ def test_partner_bibliography_duplicate_override_accepts_blocking_with_non_block
     )
 
     assert result.status == falcon.HTTP_CREATED
-    assert result.headers["Location"] == "/api/v1/bibliography/Q30000001"
-    assert result.json == bibliography_entry
+    assert result.json["id"] != bibliography_entry["id"]
+    assert result.headers["Location"] == f"/api/v1/bibliography/{result.json['id']}"
     assert database["bibliography"].count_documents({}) == before_count + 1
-
-
-def test_partner_bibliography_duplicate_override_creates_insufficient_data(
-    monkeypatch, client, database
-):
-    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
-    bibliography_entry = BibliographyEntryFactory.build(id="Q30000001")
-    before_count = database["bibliography"].count_documents({})
-
-    result = client.simulate_post(
-        "/api/v1/bibliography/duplicate-override",
-        body=json.dumps(
-            duplicate_override_payload(
-                bibliography_entry, [INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID]
-            )
-        ),
-    )
-
-    assert result.status == falcon.HTTP_CREATED
-    assert result.json == bibliography_entry
-    assert database["bibliography"].count_documents({}) == before_count + 1
-
-
-def test_partner_bibliography_duplicate_override_reruns_duplicate_detection(
-    client, bibliography, user, database
-):
-    existing_entry = BibliographyEntryFactory.build(
-        id="Q30000000",
-        DOI="10.1210/MEND.16.4.0808",
-        title="The Synergistic Activity of Thyroid Transcription Factor 1",
-        author=[{"given": "Stefania", "family": "Miccadei"}],
-        issued={"date-parts": [[2002, 1, 1]]},
-        **{"container-title": "Molecular Endocrinology"},
-        volume="2",
-        issue="4",
-        page="837-846",
-    )
-    proposed_entry = {**existing_entry, "id": "Q30000001"}
-    bibliography.create(existing_entry, user)
-
-    preflight = client.simulate_post(
-        "/api/v1/bibliography/duplicate-candidates",
-        body=json.dumps(proposed_entry),
-    )
-
-    assert preflight.status == falcon.HTTP_OK
-    assert preflight.json["candidates"][0]["id"] == existing_entry["id"]
-
-    bibliography.update(
-        {
-            **existing_entry,
-            "type": "book",
-            "title": "Administrative Documents from Nippur",
-            "author": [{"given": "Mary", "family": "Jones"}],
-            "issued": {"date-parts": [[1971, 1, 1]]},
-            "DOI": "",
-            "ISBN": "9781575060727",
-            "page": "1-50",
-        },
-        user,
-    )
-    before_count = database["bibliography"].count_documents({})
-
-    result = client.simulate_post(
-        "/api/v1/bibliography/duplicate-override",
-        body=json.dumps(
-            duplicate_override_payload(proposed_entry, [existing_entry["id"]])
-        ),
-    )
-
-    assert result.status == falcon.HTTP_BAD_REQUEST
-    assert "Use POST /api/v1/bibliography instead." in result.json["description"]
-    assert database["bibliography"].count_documents({}) == before_count

--- a/ebl/tests/bibliography/test_partner_bibliography_override_validation_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_override_validation_route.py
@@ -4,12 +4,13 @@ import falcon
 import pytest
 
 from ebl.tests.bibliography.bibliography_route_test_helpers import (
+    INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID,
     NON_BLOCKING_DUPLICATE_CANDIDATE_ID,
     STALE_DUPLICATE_CANDIDATE_ID,
     assert_duplicate_override_bad_request,
     blocking_duplicate_override_result,
-    client_with_scope,
     duplicate_override_payload,
+    insufficient_data_duplicate_result,
     mixed_duplicate_override_result,
     patch_duplicate_override_result,
 )
@@ -147,48 +148,58 @@ def test_partner_bibliography_duplicate_override_invalid_csl_does_not_mutate(
     )
 
 
-def test_partner_bibliography_duplicate_override_requires_write_scope(
-    guest_client, saved_entry
+def test_partner_bibliography_duplicate_override_rejects_unsafe_partner_id(
+    monkeypatch, client, database
 ):
-    duplicate_entry = {**saved_entry, "id": "Q30000001"}
-
-    result = guest_client.simulate_post(
-        "/api/v1/bibliography/duplicate-override",
-        body=json.dumps(
-            duplicate_override_payload(duplicate_entry, [saved_entry["id"]])
-        ),
-    )
-
-    assert result.status == falcon.HTTP_FORBIDDEN
-
-
-def test_partner_bibliography_duplicate_override_rejects_duplicate_check_only_scope(
-    context, saved_entry
-):
-    client = client_with_scope(context, "check:bibliography_duplicates")
-    duplicate_entry = {**saved_entry, "id": "Q30000001"}
+    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
+    bibliography_entry = BibliographyEntryFactory.build(id="bad\u0000id")
+    before_count = database["bibliography"].count_documents({})
 
     result = client.simulate_post(
         "/api/v1/bibliography/duplicate-override",
         body=json.dumps(
-            duplicate_override_payload(duplicate_entry, [saved_entry["id"]])
+            duplicate_override_payload(
+                bibliography_entry, [INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID]
+            )
         ),
     )
 
-    assert result.status == falcon.HTTP_FORBIDDEN
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert "control characters" in result.json["description"]
+    assert database["bibliography"].count_documents({}) == before_count
 
 
-def test_partner_bibliography_duplicate_override_rejects_export_only_scope(
-    context, saved_entry
+def test_partner_bibliography_duplicate_override_alias_collision_does_not_mutate(
+    monkeypatch, client, bibliography, user, database
 ):
-    client = client_with_scope(context, "export:bibliography")
-    duplicate_entry = {**saved_entry, "id": "Q30000001"}
+    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
+    existing_entry = BibliographyEntryFactory.build(
+        id="Q30000000",
+        aliases=[
+            {
+                "value": "Leipzig/ABC 123",
+                "normalizedValue": "leipzig-abc-123",
+            }
+        ],
+    )
+    bibliography.create(existing_entry, user)
+    before_count = database["bibliography"].count_documents({})
+    bibliography_entry = BibliographyEntryFactory.build(
+        id="Leipzig ABC 123",
+        DOI="10.1000/two",
+        title="A Different Title",
+        issued={"date-parts": [[2005, 1, 1]]},
+    )
 
     result = client.simulate_post(
         "/api/v1/bibliography/duplicate-override",
         body=json.dumps(
-            duplicate_override_payload(duplicate_entry, [saved_entry["id"]])
+            duplicate_override_payload(
+                bibliography_entry, [INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID]
+            )
         ),
     )
 
-    assert result.status == falcon.HTTP_FORBIDDEN
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "already in use" in result.json["description"]
+    assert database["bibliography"].count_documents({}) == before_count

--- a/ebl/tests/bibliography/test_partner_bibliography_resolve_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_resolve_route.py
@@ -1,0 +1,214 @@
+import falcon
+import pytest
+
+from ebl.tests.bibliography.bibliography_route_test_helpers import client_with_scope
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+def insert_legacy_entry(database, create_mongo_bibliography_entry, entry):
+    database["bibliography"].insert_one(create_mongo_bibliography_entry(entry))
+
+
+def test_partner_bibliography_resolve_by_canonical_id(client, saved_entry):
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": saved_entry["id"]},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == saved_entry["id"]
+    assert result.json["bibliographyEntry"] == saved_entry
+
+
+def test_partner_bibliography_resolve_by_deprecated_id_redirects(
+    client, bibliography, user
+):
+    canonical_entry = BibliographyEntryFactory.build(id="CANONICAL_ID")
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    bibliography.create(canonical_entry, user)
+    bibliography.create(deprecated_entry, user)
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": deprecated_entry["id"]},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == canonical_entry["id"]
+    assert result.json["bibliographyEntry"] == canonical_entry
+
+
+def test_partner_bibliography_resolve_by_normalized_duplicate_alias(
+    client, database, create_mongo_bibliography_entry
+):
+    canonical_entry = BibliographyEntryFactory.build(
+        id="CANONICAL_ID",
+        aliases=[
+            {
+                "value": "DUPLICATE_ID",
+                "normalizedValue": "duplicate-id",
+                "type": "reviewed_duplicate_id",
+                "source": "possible_dedupes.xlsx",
+                "status": "redirect",
+            }
+        ],
+    )
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo=canonical_entry["id"]
+    )
+    insert_legacy_entry(database, create_mongo_bibliography_entry, canonical_entry)
+    insert_legacy_entry(database, create_mongo_bibliography_entry, deprecated_entry)
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve", params={"identifier": "duplicate id"}
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == canonical_entry["id"]
+    assert result.json["bibliographyEntry"] == canonical_entry
+
+
+def test_partner_bibliography_resolve_by_citation_key(client, bibliography, user):
+    bibliography_entry = BibliographyEntryFactory.build(citationKey="miccadei2002")
+    bibliography.create(bibliography_entry, user)
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": bibliography_entry["citationKey"]},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == bibliography_entry["id"]
+    assert result.json["citationKey"] == bibliography_entry["citationKey"]
+    assert result.json["bibliographyEntry"] == bibliography_entry
+
+
+@pytest.mark.parametrize(
+    "alias_case",
+    [
+        pytest.param(
+            ("Leipzig/ABC 123", "leipzig-abc-123"),
+            id="raw-slash",
+        ),
+        pytest.param(("D’Agostino", "d-agostino"), id="special-character"),
+    ],
+)
+def test_partner_bibliography_resolve_by_alias(alias_case, client, bibliography, user):
+    alias, normalized_value = alias_case
+    bibliography_entry = BibliographyEntryFactory.build(
+        aliases=[{"value": alias, "normalizedValue": normalized_value}]
+    )
+    bibliography.create(bibliography_entry, user)
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": alias},
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json["id"] == bibliography_entry["id"]
+    assert result.json["bibliographyEntry"] == bibliography_entry
+
+
+def test_partner_bibliography_resolve_missing_identifier(client):
+    result = client.simulate_get("/api/v1/bibliography/resolve")
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
+    assert "identifier" in result.json["description"]
+
+
+def test_resolve_path_segment_is_reserved_for_query_resolution(
+    client, bibliography, user
+):
+    bibliography_entry = BibliographyEntryFactory.build(citationKey="resolve")
+    bibliography.create(bibliography_entry, user)
+
+    dynamic_result = client.simulate_get("/api/v1/bibliography/resolve")
+    resolver_result = client.simulate_get(
+        "/api/v1/bibliography/resolve", params={"identifier": "resolve"}
+    )
+
+    assert dynamic_result.status == falcon.HTTP_BAD_REQUEST
+    assert resolver_result.status == falcon.HTTP_OK
+    assert resolver_result.json["id"] == bibliography_entry["id"]
+
+
+def test_partner_bibliography_resolve_not_found(client):
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": "not-found"},
+    )
+
+    assert result.status == falcon.HTTP_NOT_FOUND
+
+
+def test_partner_bibliography_resolve_missing_redirect_target_returns_not_found(
+    client, bibliography, user
+):
+    deprecated_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_ID", deprecated=True, redirectTo="MISSING_ID"
+    )
+    bibliography.create(deprecated_entry, user)
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": deprecated_entry["id"]},
+    )
+
+    assert result.status == falcon.HTTP_NOT_FOUND
+    assert "redirect target MISSING_ID not found" in result.json["description"]
+
+
+def test_partner_bibliography_resolve_redirect_loop_returns_conflict(
+    client, bibliography, user
+):
+    first_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_A", deprecated=True, redirectTo="DUPLICATE_B"
+    )
+    second_entry = BibliographyEntryFactory.build(
+        id="DUPLICATE_B", deprecated=True, redirectTo="DUPLICATE_A"
+    )
+    bibliography.create(first_entry, user)
+    bibliography.create(second_entry, user)
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve", params={"identifier": first_entry["id"]}
+    )
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "redirect loop" in result.json["description"]
+
+
+def test_partner_bibliography_resolve_ambiguous_alias_returns_conflict(
+    client, database, create_mongo_bibliography_entry
+):
+    alias = "legacy"
+    first_entry = BibliographyEntryFactory.build(
+        id="Q30000001", aliases=[{"value": alias, "normalizedValue": alias}]
+    )
+    second_entry = BibliographyEntryFactory.build(
+        id="Q30000002", aliases=[{"value": alias, "normalizedValue": alias}]
+    )
+    insert_legacy_entry(database, create_mongo_bibliography_entry, first_entry)
+    insert_legacy_entry(database, create_mongo_bibliography_entry, second_entry)
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": alias},
+    )
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "ambiguous" in result.json["description"]
+
+
+def test_partner_bibliography_resolve_requires_export_scope(context):
+    client = client_with_scope(context, "write:bibliography")
+
+    result = client.simulate_get(
+        "/api/v1/bibliography/resolve",
+        params={"identifier": "Q30000000"},
+    )
+
+    assert result.status == falcon.HTTP_FORBIDDEN

--- a/ebl/tests/bibliography/test_partner_bibliography_retry.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_retry.py
@@ -1,0 +1,86 @@
+import pytest
+
+from ebl.bibliography.application.bibliography_repository import (
+    LookupValueReservationError,
+)
+from ebl.bibliography.application.partner_bibliography import PartnerBibliography
+from ebl.errors import NotFoundError
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+class FakeRepository:
+    def __init__(self):
+        self.calls = 0
+
+    def list_all_bibliography(self):
+        self.calls += 1
+        return ["Q30000000"][: self.calls - 1]
+
+    def lookup_value_is_reserved(self, _value):
+        return False
+
+
+class FakeBibliography:
+    def __init__(self, errors=()):
+        self._errors = list(errors)
+        self.created_entries = []
+
+    def create(self, entry, _user):
+        if self._errors:
+            raise self._errors.pop(0)
+        self.created_entries.append(dict(entry))
+        return entry["id"]
+
+    def update(self, _entry, _user):
+        raise NotImplementedError
+
+    def find(self, id_):
+        raise NotFoundError(f"{id_} not found")
+
+    def find_duplicate_candidates(self, _entry, limit=10):
+        return {"decision": "unique", "candidates": []}
+
+
+def test_create_entry_retries_canonical_id_after_reservation_conflict(user):
+    bibliography = FakeBibliography([LookupValueReservationError("Q30000000")])
+    partner_bibliography = PartnerBibliography(bibliography, FakeRepository())
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    partner_bibliography.create_entry(entry, user)
+
+    assert entry["id"] == "Q30000001"
+    assert bibliography.created_entries == [entry]
+
+
+def test_create_entry_regenerates_citation_key_after_reservation_conflict(user):
+    bibliography = FakeBibliography(
+        [LookupValueReservationError("miccadei2002Synergistic")]
+    )
+    partner_bibliography = PartnerBibliography(bibliography, FakeRepository())
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    partner_bibliography.create_entry(entry, user)
+
+    assert entry["citationKey"] == "miccadei2002Synergistic-2"
+    assert bibliography.created_entries == [entry]
+
+
+def test_create_entry_raises_unrelated_lookup_reservation_conflict(user):
+    bibliography = FakeBibliography([LookupValueReservationError("other-value")])
+    partner_bibliography = PartnerBibliography(bibliography, FakeRepository())
+    entry = BibliographyEntryFactory.build(id="partner-id")
+
+    with pytest.raises(LookupValueReservationError):
+        partner_bibliography.create_entry(entry, user)
+
+    assert entry["id"] == "partner-id"
+    assert bibliography.created_entries == []
+
+
+def test_update_citation_key_removes_key_when_regeneration_has_no_source_data():
+    partner_bibliography = PartnerBibliography(FakeBibliography(), FakeRepository())
+    entry = {"id": "Q30000000", "type": "book", "citationKey": "oldKey"}
+
+    partner_bibliography._update_citation_key(entry, [])
+
+    assert "citationKey" not in entry

--- a/ebl/tests/bibliography/test_partner_bibliography_security.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_security.py
@@ -1,0 +1,78 @@
+import json
+
+import falcon
+import pytest
+
+from ebl.tests.bibliography.bibliography_route_test_helpers import (
+    INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID,
+    duplicate_override_payload,
+    insufficient_data_duplicate_result,
+    patch_duplicate_override_result,
+)
+from ebl.errors import DataError
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+SERVER_OWNED_FIELDS = ("aliases", "deprecated", "redirectTo", "citationKey")
+
+
+def payload_with_server_owned_field(entry: dict, field: str) -> dict:
+    values = {
+        "aliases": [{"value": "partner-controlled-alias"}],
+        "deprecated": True,
+        "redirectTo": "Q30000001",
+        "citationKey": "partnerControlledKey",
+    }
+    return {**entry, field: values[field]}
+
+
+@pytest.mark.parametrize("field", SERVER_OWNED_FIELDS)
+def test_partner_bibliography_create_rejects_server_owned_fields(
+    field, client, database
+):
+    entry = payload_with_server_owned_field(BibliographyEntryFactory.build(), field)
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post("/api/v1/bibliography", body=json.dumps(entry))
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+@pytest.mark.parametrize("field", SERVER_OWNED_FIELDS)
+def test_partner_bibliography_duplicate_override_rejects_server_owned_fields(
+    field, monkeypatch, client, database
+):
+    patch_duplicate_override_result(monkeypatch, insufficient_data_duplicate_result())
+    entry = payload_with_server_owned_field(BibliographyEntryFactory.build(), field)
+    before_count = database["bibliography"].count_documents({})
+
+    result = client.simulate_post(
+        "/api/v1/bibliography/duplicate-override",
+        body=json.dumps(
+            duplicate_override_payload(
+                entry, [INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID]
+            )
+        ),
+    )
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert database["bibliography"].count_documents({}) == before_count
+
+
+def test_create_partner_entry_rejects_server_owned_fields_when_schema_is_bypassed(
+    bibliography, user, database
+):
+    entry = BibliographyEntryFactory.build(
+        id="partner-controlled-id",
+        aliases=[{"value": "partner-controlled-alias"}],
+        citationKey="partnerControlledKey",
+        deprecated=True,
+        redirectTo="Q39999999",
+    )
+
+    before_count = database["bibliography"].count_documents({})
+
+    with pytest.raises(DataError):
+        bibliography.create_partner_entry(entry, user)
+
+    assert database["bibliography"].count_documents({}) == before_count

--- a/ebl/tests/bibliography/test_partner_bibliography_security.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_security.py
@@ -1,15 +1,19 @@
 import json
+from types import SimpleNamespace
 
 import falcon
 import pytest
 
+from ebl.bibliography.web.bibliography_entries import (
+    reject_server_owned_partner_fields,
+)
+from ebl.errors import DataError
 from ebl.tests.bibliography.bibliography_route_test_helpers import (
     INSUFFICIENT_DATA_DUPLICATE_CANDIDATE_ID,
     duplicate_override_payload,
     insufficient_data_duplicate_result,
     patch_duplicate_override_result,
 )
-from ebl.errors import DataError
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
 
 SERVER_OWNED_FIELDS = ("aliases", "deprecated", "redirectTo", "citationKey")
@@ -76,3 +80,9 @@ def test_create_partner_entry_rejects_server_owned_fields_when_schema_is_bypasse
         bibliography.create_partner_entry(entry, user)
 
     assert database["bibliography"].count_documents({}) == before_count
+
+
+def test_reject_server_owned_partner_fields_ignores_non_dict_media():
+    req = SimpleNamespace(media="not an object")
+
+    reject_server_owned_partner_fields(req, None, None, None)

--- a/ebl/tests/bibliography/test_partner_bibliography_update_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_update_route.py
@@ -2,6 +2,7 @@ import json
 
 import falcon
 import pydash
+import pytest
 
 from ebl.tests.bibliography.bibliography_route_test_helpers import (
     client_with_scope,
@@ -22,6 +23,55 @@ def test_partner_bibliography_update(client, saved_entry):
     get_result = client.simulate_get(f"/api/v1/bibliography/{saved_entry['id']}")
 
     assert get_result.json["bibliographyEntry"] == updated_entry
+
+
+def test_partner_bibliography_update_preserves_server_owned_fields(
+    client, bibliography, user
+):
+    stored_entry = BibliographyEntryFactory.build(
+        id="Q30000001",
+        citationKey="storedCitationKey",
+        aliases=[
+            {
+                "value": "partner-old-id",
+                "normalizedValue": "partner-old-id",
+                "type": "partner_id",
+                "source": "partner_request",
+                "status": "redirect",
+            }
+        ],
+    )
+    bibliography.create(stored_entry, user)
+    update_payload = pydash.omit(
+        {**stored_entry, "title": "New Partner Title"},
+        "aliases",
+        "citationKey",
+    )
+
+    result = client.simulate_post(
+        f"/api/v1/bibliography/{stored_entry['id']}", body=json.dumps(update_payload)
+    )
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert bibliography.find(stored_entry["id"]) == {
+        **update_payload,
+        "citationKey": stored_entry["citationKey"],
+        "aliases": stored_entry["aliases"],
+    }
+
+
+@pytest.mark.parametrize(
+    "field", ["aliases", "deprecated", "redirectTo", "citationKey"]
+)
+def test_partner_bibliography_update_rejects_server_owned_fields(
+    field, client, saved_entry
+):
+    result = client.simulate_post(
+        f"/api/v1/bibliography/{saved_entry['id']}",
+        body=json.dumps({**saved_entry, field: [] if field == "aliases" else "value"}),
+    )
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
 
 
 def test_partner_bibliography_update_requires_write_scope(guest_client, saved_entry):

--- a/ebl/tests/bibliography/test_partner_identity.py
+++ b/ebl/tests/bibliography/test_partner_identity.py
@@ -4,6 +4,7 @@ from ebl.bibliography.application.partner_identity import (
     MAX_CITATION_KEY_SUFFIX,
     create_partner_alias,
     generate_partner_citation_key,
+    select_canonical_bibliography_id,
 )
 from ebl.errors import DataError, DuplicateError
 
@@ -42,3 +43,16 @@ def test_generate_partner_citation_key_raises_duplicate_when_candidates_exhauste
     assert len(checked_values) == MAX_CITATION_KEY_SUFFIX
     assert checked_values[0] == base_key
     assert checked_values[-1] == f"{base_key}-{MAX_CITATION_KEY_SUFFIX}"
+
+
+def test_select_canonical_bibliography_id_raises_when_candidates_are_exhausted(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "ebl.bibliography.application.partner_identity."
+        "canonical_bibliography_id_candidates",
+        lambda _existing_ids: iter(()),
+    )
+
+    with pytest.raises(RuntimeError, match="Unable to generate bibliography id"):
+        select_canonical_bibliography_id([], lambda _value: False)

--- a/ebl/tests/bibliography/test_partner_identity.py
+++ b/ebl/tests/bibliography/test_partner_identity.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ebl.bibliography.application.partner_identity import (
+    MAX_CITATION_KEY_SUFFIX,
+    create_partner_alias,
+    generate_partner_citation_key,
+)
+from ebl.errors import DataError, DuplicateError
+
+
+def test_create_partner_alias_rejects_empty_normalized_id():
+    with pytest.raises(DataError, match="letter or digit"):
+        create_partner_alias("!!!")
+
+
+def test_generate_partner_citation_key_returns_none_without_meaningful_data():
+    entry = {"id": "Q30000000", "type": "book", "title": "Missing creator and year"}
+
+    assert generate_partner_citation_key(entry, lambda _value: False) is None
+
+
+def test_generate_partner_citation_key_raises_duplicate_when_candidates_exhausted():
+    base_key = "miccadei2002Synergistic"
+    unavailable = {base_key, *(f"{base_key}-{suffix}" for suffix in range(2, 101))}
+    entry = {
+        "type": "article-journal",
+        "title": "The Synergistic Activity of Thyroid Transcription Factor 1",
+        "author": [{"given": "Stefania", "family": "Miccadei"}],
+        "issued": {"date-parts": [[2002, 1, 1]]},
+    }
+    checked_values = []
+
+    def lookup_value_exists(value):
+        checked_values.append(value)
+        return value in unavailable
+
+    with pytest.raises(
+        DuplicateError, match="Unable to generate a unique citation key"
+    ):
+        generate_partner_citation_key(entry, lookup_value_exists)
+
+    assert len(checked_values) == MAX_CITATION_KEY_SUFFIX
+    assert checked_values[0] == base_key
+    assert checked_values[-1] == f"{base_key}-{MAX_CITATION_KEY_SUFFIX}"

--- a/ebl/tests/fragmentarium/test_fragment_updater.py
+++ b/ebl/tests/fragmentarium/test_fragment_updater.py
@@ -2,15 +2,13 @@ from ebl.common.domain.scopes import Scope
 from freezegun import freeze_time
 import pytest
 
-from ebl.errors import DataError, NotFoundError
+from ebl.errors import NotFoundError
 from ebl.fragmentarium.application.fragment_schema import FragmentSchema
 from ebl.fragmentarium.application.fragment_updater import FragmentUpdater
 from ebl.fragmentarium.domain.fragment import Fragment, Genre, NotLowestJoinError
 from ebl.fragmentarium.domain.joins import Join, Joins
 from ebl.transliteration.domain.museum_number import MuseumNumber
 from ebl.fragmentarium.domain.transliteration_update import TransliterationUpdate
-from ebl.lemmatization.domain.lemmatization import Lemmatization, LemmatizationToken
-from ebl.tests.factories.bibliography import ReferenceFactory
 from ebl.tests.factories.fragment import (
     FragmentFactory,
     TransliteratedFragmentFactory,
@@ -18,7 +16,6 @@ from ebl.tests.factories.fragment import (
 )
 from ebl.transliteration.domain.atf import Atf
 from ebl.transliteration.domain.atf_parsers.lark_parser import parse_atf_lark
-
 
 SCHEMA = FragmentSchema()
 FROZEN_TIME = "2018-09-07 15:41:24.032"
@@ -210,97 +207,6 @@ def test_update_dates_in_text(
     assert result == (injected_fragment, False)
 
 
-@freeze_time(FROZEN_TIME)
-def test_update_lemmatization(
-    fragment_updater, user, fragment_repository, parallel_line_injector, changelog, when
-):
-    transliterated_fragment = TransliteratedFragmentFactory.build()
-    number = transliterated_fragment.number
-    tokens = [list(line) for line in transliterated_fragment.text.lemmatization.tokens]
-    tokens[1][3] = LemmatizationToken(tokens[1][3].value, ("aklu I",))
-    lemmatization = Lemmatization(tokens)
-    lemmatized_fragment = transliterated_fragment.update_lemmatization(lemmatization)
-    (
-        when(fragment_repository)
-        .query_by_museum_number(number)
-        .thenReturn(transliterated_fragment)
-    )
-    injected_fragment = lemmatized_fragment.set_text(
-        parallel_line_injector.inject_transliteration(lemmatized_fragment.text)
-    )
-    when(changelog).create(
-        "fragments",
-        user.profile,
-        {"_id": str(number), **SCHEMA.dump(transliterated_fragment)},
-        {"_id": str(number), **SCHEMA.dump(lemmatized_fragment)},
-    ).thenReturn()
-    when(fragment_repository).update_field(
-        "lemmatization", lemmatized_fragment
-    ).thenReturn()
-
-    result = fragment_updater.update_lemmatization(number, lemmatization, user)
-    assert result == (injected_fragment, False)
-
-
-def test_update_update_lemmatization_not_found(
-    fragment_updater, user, fragment_repository, when
-):
-    number = "K.1"
-    (when(fragment_repository).query_by_museum_number(number).thenRaise(NotFoundError))
-
-    with pytest.raises(NotFoundError):
-        fragment_updater.update_lemmatization(
-            number, Lemmatization(((LemmatizationToken("1.", ()),),)), user
-        )
-
-
-def test_update_references(
-    fragment_updater,
-    bibliography,
-    user,
-    fragment_repository,
-    parallel_line_injector,
-    changelog,
-    when,
-):
-    fragment = FragmentFactory.build()
-    number = fragment.number
-    reference = ReferenceFactory.build()
-    references = (reference,)
-    updated_fragment = fragment.set_references(references)
-    injected_fragment = updated_fragment.set_text(
-        parallel_line_injector.inject_transliteration(updated_fragment.text)
-    )
-    when(bibliography).find(reference.id).thenReturn(reference)
-    when(fragment_repository).query_by_museum_number(number).thenReturn(
-        fragment
-    ).thenReturn(updated_fragment)
-    when(fragment_repository).update_field("references", updated_fragment).thenReturn()
-    when(changelog).create(
-        "fragments",
-        user.profile,
-        {"_id": str(number), **SCHEMA.dump(fragment)},
-        {"_id": str(number), **SCHEMA.dump(updated_fragment)},
-    ).thenReturn()
-
-    result = fragment_updater.update_references(number, references, user)
-    assert result == (injected_fragment, False)
-
-
-def test_update_references_invalid(
-    fragment_updater, bibliography, user, fragment_repository, when
-):
-    fragment = FragmentFactory.build()
-    number = fragment.number
-    reference = ReferenceFactory.build()
-    when(bibliography).find(reference.id).thenRaise(NotFoundError)
-    (when(fragment_repository).query_by_museum_number(number).thenReturn(fragment))
-    references = (reference,)
-
-    with pytest.raises(DataError):
-        fragment_updater.update_references(number, references, user)
-
-
 def test_update_introduction(
     fragment_updater: FragmentUpdater, user, fragment_repository, changelog, when
 ):
@@ -341,72 +247,3 @@ def test_update_notes(
 
     result = fragment_updater.update_edition(number, user, notes=notes)
     assert result == (updated_fragment, False)
-
-
-@freeze_time(FROZEN_TIME)
-def test_update_lemma_annotation(
-    fragment_updater, user, fragment_repository, parallel_line_injector, changelog, when
-):
-    transliterated_fragment = TransliteratedFragmentFactory.build()
-    number = transliterated_fragment.number
-
-    annotation = {1: {3: ["aklu I"]}}
-    lemmatized_fragment = transliterated_fragment.update_lemma_annotation(annotation)
-
-    (
-        when(fragment_repository)
-        .query_by_museum_number(number)
-        .thenReturn(transliterated_fragment)
-    )
-    injected_fragment = lemmatized_fragment.set_text(
-        parallel_line_injector.inject_transliteration(lemmatized_fragment.text)
-    )
-    when(changelog).create(
-        "fragments",
-        user.profile,
-        {"_id": str(number), **SCHEMA.dump(transliterated_fragment)},
-        {"_id": str(number), **SCHEMA.dump(lemmatized_fragment)},
-    ).thenReturn()
-    when(fragment_repository).update_field(
-        "lemmatization", lemmatized_fragment
-    ).thenReturn()
-
-    result = fragment_updater.update_lemma_annotation(number, annotation, user)
-    assert result == (injected_fragment, False)
-
-
-@freeze_time(FROZEN_TIME)
-def test_update_named_entities(
-    fragment_updater,
-    named_entity_spans,
-    user,
-    fragment_repository,
-    parallel_line_injector,
-    changelog,
-    when,
-):
-    transliterated_fragment: Fragment = TransliteratedFragmentFactory.build()
-    number = transliterated_fragment.number
-
-    annotated_fragment = transliterated_fragment.set_named_entities(named_entity_spans)
-
-    (
-        when(fragment_repository)
-        .query_by_museum_number(number)
-        .thenReturn(transliterated_fragment)
-    )
-    injected_fragment = annotated_fragment.set_text(
-        parallel_line_injector.inject_transliteration(annotated_fragment.text)
-    )
-    when(changelog).create(
-        "fragments",
-        user.profile,
-        {"_id": str(number), **SCHEMA.dump(transliterated_fragment)},
-        {"_id": str(number), **SCHEMA.dump(annotated_fragment)},
-    ).thenReturn()
-    when(fragment_repository).update_field(
-        "named_entities", annotated_fragment
-    ).thenReturn()
-
-    result = fragment_updater.update_named_entities(number, named_entity_spans, user)
-    assert result == (injected_fragment, False)

--- a/ebl/tests/fragmentarium/test_fragment_updater_annotations.py
+++ b/ebl/tests/fragmentarium/test_fragment_updater_annotations.py
@@ -1,0 +1,147 @@
+from dataclasses import dataclass
+
+from freezegun import freeze_time
+import pytest
+
+from ebl.errors import NotFoundError
+from ebl.fragmentarium.application.fragment_updater import FragmentUpdater
+from ebl.fragmentarium.application.fragment_schema import FragmentSchema
+from ebl.fragmentarium.domain.fragment import Fragment
+from ebl.lemmatization.domain.lemmatization import Lemmatization, LemmatizationToken
+from ebl.tests.factories.fragment import TransliteratedFragmentFactory
+from ebl.users.domain.user import User
+
+SCHEMA = FragmentSchema()
+FROZEN_TIME = "2018-09-07 15:41:24.032"
+
+
+@dataclass(frozen=True)
+class FragmentAnnotationContext:
+    fragment_updater: FragmentUpdater
+    user: User
+    fragment_repository: object
+    parallel_line_injector: object
+    changelog: object
+    when: object
+
+
+@pytest.fixture
+def fragment_annotation_context(request: pytest.FixtureRequest):
+    return FragmentAnnotationContext(
+        request.getfixturevalue("fragment_updater"),
+        request.getfixturevalue("user"),
+        request.getfixturevalue("fragment_repository"),
+        request.getfixturevalue("parallel_line_injector"),
+        request.getfixturevalue("changelog"),
+        request.getfixturevalue("when"),
+    )
+
+
+@freeze_time(FROZEN_TIME)
+def test_update_lemmatization(fragment_annotation_context):
+    context = fragment_annotation_context
+    transliterated_fragment = TransliteratedFragmentFactory.build()
+    number = transliterated_fragment.number
+    tokens = [list(line) for line in transliterated_fragment.text.lemmatization.tokens]
+    tokens[1][3] = LemmatizationToken(tokens[1][3].value, ("aklu I",))
+    lemmatization = Lemmatization(tokens)
+    lemmatized_fragment = transliterated_fragment.update_lemmatization(lemmatization)
+    (
+        context.when(context.fragment_repository)
+        .query_by_museum_number(number)
+        .thenReturn(transliterated_fragment)
+    )
+    injected_fragment = lemmatized_fragment.set_text(
+        context.parallel_line_injector.inject_transliteration(lemmatized_fragment.text)
+    )
+    context.when(context.changelog).create(
+        "fragments",
+        context.user.profile,
+        {"_id": str(number), **SCHEMA.dump(transliterated_fragment)},
+        {"_id": str(number), **SCHEMA.dump(lemmatized_fragment)},
+    ).thenReturn()
+    context.when(context.fragment_repository).update_field(
+        "lemmatization", lemmatized_fragment
+    ).thenReturn()
+
+    result = context.fragment_updater.update_lemmatization(
+        number, lemmatization, context.user
+    )
+    assert result == (injected_fragment, False)
+
+
+def test_update_update_lemmatization_not_found(
+    fragment_updater, user, fragment_repository, when
+):
+    number = "K.1"
+    (when(fragment_repository).query_by_museum_number(number).thenRaise(NotFoundError))
+
+    with pytest.raises(NotFoundError):
+        fragment_updater.update_lemmatization(
+            number, Lemmatization(((LemmatizationToken("1.", ()),),)), user
+        )
+
+
+@freeze_time(FROZEN_TIME)
+def test_update_lemma_annotation(fragment_annotation_context):
+    context = fragment_annotation_context
+    transliterated_fragment = TransliteratedFragmentFactory.build()
+    number = transliterated_fragment.number
+
+    annotation = {1: {3: ["aklu I"]}}
+    lemmatized_fragment = transliterated_fragment.update_lemma_annotation(annotation)
+
+    (
+        context.when(context.fragment_repository)
+        .query_by_museum_number(number)
+        .thenReturn(transliterated_fragment)
+    )
+    injected_fragment = lemmatized_fragment.set_text(
+        context.parallel_line_injector.inject_transliteration(lemmatized_fragment.text)
+    )
+    context.when(context.changelog).create(
+        "fragments",
+        context.user.profile,
+        {"_id": str(number), **SCHEMA.dump(transliterated_fragment)},
+        {"_id": str(number), **SCHEMA.dump(lemmatized_fragment)},
+    ).thenReturn()
+    context.when(context.fragment_repository).update_field(
+        "lemmatization", lemmatized_fragment
+    ).thenReturn()
+
+    result = context.fragment_updater.update_lemma_annotation(
+        number, annotation, context.user
+    )
+    assert result == (injected_fragment, False)
+
+
+@freeze_time(FROZEN_TIME)
+def test_update_named_entities(fragment_annotation_context, named_entity_spans):
+    context = fragment_annotation_context
+    transliterated_fragment: Fragment = TransliteratedFragmentFactory.build()
+    number = transliterated_fragment.number
+
+    annotated_fragment = transliterated_fragment.set_named_entities(named_entity_spans)
+
+    (
+        context.when(context.fragment_repository)
+        .query_by_museum_number(number)
+        .thenReturn(transliterated_fragment)
+    )
+    injected_fragment = annotated_fragment.set_text(
+        context.parallel_line_injector.inject_transliteration(annotated_fragment.text)
+    )
+    context.when(context.changelog).create(
+        "fragments",
+        context.user.profile,
+        {"_id": str(number), **SCHEMA.dump(transliterated_fragment)},
+        {"_id": str(number), **SCHEMA.dump(annotated_fragment)},
+    ).thenReturn()
+    context.when(context.fragment_repository).update_field(
+        "named_entities", annotated_fragment
+    ).thenReturn()
+
+    result = context.fragment_updater.update_named_entities(
+        number, named_entity_spans, context.user
+    )
+    assert result == (injected_fragment, False)

--- a/ebl/tests/fragmentarium/test_fragment_updater_references.py
+++ b/ebl/tests/fragmentarium/test_fragment_updater_references.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+
+import pytest
+
+from ebl.bibliography.application.bibliography import Bibliography
+from ebl.errors import DataError
+from ebl.fragmentarium.application.fragment_schema import FragmentSchema
+from ebl.fragmentarium.application.fragment_updater import FragmentUpdater
+from ebl.tests.factories.bibliography import ReferenceFactory
+from ebl.tests.factories.fragment import FragmentFactory
+from ebl.users.domain.user import User
+
+SCHEMA = FragmentSchema()
+
+
+@dataclass(frozen=True)
+class FragmentReferencesContext:
+    fragment_updater: FragmentUpdater
+    bibliography: Bibliography
+    user: User
+    fragment_repository: object
+    parallel_line_injector: object
+    changelog: object
+    when: object
+
+
+@pytest.fixture
+def fragment_references_context(request: pytest.FixtureRequest):
+    return FragmentReferencesContext(
+        request.getfixturevalue("fragment_updater"),
+        request.getfixturevalue("bibliography"),
+        request.getfixturevalue("user"),
+        request.getfixturevalue("fragment_repository"),
+        request.getfixturevalue("parallel_line_injector"),
+        request.getfixturevalue("changelog"),
+        request.getfixturevalue("when"),
+    )
+
+
+def test_update_references(fragment_references_context):
+    context = fragment_references_context
+    fragment = FragmentFactory.build()
+    number = fragment.number
+    reference = ReferenceFactory.build()
+    references = (reference,)
+    updated_fragment = fragment.set_references(references)
+    injected_fragment = updated_fragment.set_text(
+        context.parallel_line_injector.inject_transliteration(updated_fragment.text)
+    )
+    context.when(context.bibliography).canonicalize_references(references).thenReturn(
+        references
+    )
+    context.when(context.fragment_repository).query_by_museum_number(number).thenReturn(
+        fragment
+    ).thenReturn(updated_fragment)
+    context.when(context.fragment_repository).update_field(
+        "references", updated_fragment
+    ).thenReturn()
+    context.when(context.changelog).create(
+        "fragments",
+        context.user.profile,
+        {"_id": str(number), **SCHEMA.dump(fragment)},
+        {"_id": str(number), **SCHEMA.dump(updated_fragment)},
+    ).thenReturn()
+
+    result = context.fragment_updater.update_references(
+        number, references, context.user
+    )
+    assert result == (injected_fragment, False)
+
+
+def test_update_references_invalid(
+    fragment_updater, bibliography, user, fragment_repository, when
+):
+    fragment = FragmentFactory.build()
+    number = fragment.number
+    reference = ReferenceFactory.build()
+    references = (reference,)
+    when(bibliography).canonicalize_references(references).thenRaise(DataError)
+    (when(fragment_repository).query_by_museum_number(number).thenReturn(fragment))
+
+    with pytest.raises(DataError):
+        fragment_updater.update_references(number, references, user)

--- a/ebl/tests/fragmentarium/test_references_route.py
+++ b/ebl/tests/fragmentarium/test_references_route.py
@@ -1,8 +1,10 @@
 import json
 
+import attr
 import falcon
 import pytest
 
+from ebl.bibliography.domain.reference import BibliographyId
 from ebl.bibliography.application.reference_schema import ReferenceSchema
 from ebl.transliteration.domain.museum_number import MuseumNumber
 from ebl.fragmentarium.web.dtos import create_response_dto
@@ -27,6 +29,43 @@ def test_update_references(
 
     expected_json = create_response_dto(
         fragment.set_references((reference,)).set_text(
+            parallel_line_injector.inject_transliteration(fragment.text)
+        ),
+        user,
+        fragment.number == MuseumNumber("K", "1"),
+    )
+
+    assert post_result.status == falcon.HTTP_OK
+    assert post_result.json == expected_json
+
+    get_result = client.simulate_get(f"/fragments/{fragment.number}")
+    assert get_result.json == expected_json
+
+
+def test_update_references_canonicalizes_bibliography_alias(
+    client, fragmentarium, bibliography, parallel_line_injector, user
+):
+    fragment = FragmentFactory.build()
+    fragmentarium.create(fragment)
+    bibliography_entry = {
+        **ReferenceFactory.build(with_document=True).document,
+        "id": "Q30000001",
+        "aliases": [{"value": "OLD_ALIAS", "normalizedValue": "old-alias"}],
+    }
+    bibliography.create(bibliography_entry, ANY_USER)
+    submitted_reference = ReferenceFactory.build(id="OLD_ALIAS")
+    body = json.dumps({"references": [ReferenceSchema().dump(submitted_reference)]})
+    url = f"/fragments/{fragment.number}/references"
+
+    post_result = client.simulate_post(url, body=body)
+
+    canonical_reference = attr.evolve(
+        submitted_reference,
+        id=BibliographyId(bibliography_entry["id"]),
+        document=bibliography_entry,
+    )
+    expected_json = create_response_dto(
+        fragment.set_references((canonical_reference,)).set_text(
             parallel_line_injector.inject_transliteration(fragment.text)
         ),
         user,

--- a/ebl/tests/test_app_bootstrap.py
+++ b/ebl/tests/test_app_bootstrap.py
@@ -63,7 +63,7 @@ def test_create_context_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     with pytest.raises(FrozenInstanceError):
-        context.ebl_ai_client = EblAiClient("http://localhost:8001")
+        setattr(context, "ebl_ai_client", EblAiClient("http://localhost:8001"))
 
 
 def test_create_context_bootstraps_cache_indexes(

--- a/ebl/tests/test_app_bootstrap.py
+++ b/ebl/tests/test_app_bootstrap.py
@@ -89,25 +89,41 @@ def test_create_context_bootstraps_cache_indexes(
     assert calls["cache"] == 1
 
 
-def test_create_app_bootstraps_annotations_and_afo_indexes(
+def test_create_app_bootstraps_bibliography_annotations_and_afo_indexes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     key = RSA.generate(2048)
     configure_environment(monkeypatch, key.publickey().export_key())
     monkeypatch.setattr(ebl.app, "MongoClient", InMemoryMongoClient)
 
-    calls = {"annotations": 0, "afo": 0}
+    calls = {"bibliography": 0, "reconcile": 0, "annotations": 0, "afo": 0}
+
+    def bibliography_create_indexes(_self):
+        calls["bibliography"] += 1
 
     def annotations_create_indexes(_self):
         calls["annotations"] += 1
+
+    def bibliography_reconcile(_self, _now, limit=100):
+        calls["reconcile"] += limit
 
     def afo_create_indexes(_self):
         calls["afo"] += 1
 
     monkeypatch.setattr(
+        ebl.app.MongoBibliographyRepository,
+        "create_indexes",
+        bibliography_create_indexes,
+    )
+    monkeypatch.setattr(
         ebl.app.MongoAnnotationsRepository,
         "create_indexes",
         annotations_create_indexes,
+    )
+    monkeypatch.setattr(
+        ebl.app.MongoBibliographyRepository,
+        "reconcile_lookup_reservations",
+        bibliography_reconcile,
     )
     monkeypatch.setattr(
         ebl.app.MongoAfoRegisterRepository,
@@ -118,5 +134,7 @@ def test_create_app_bootstraps_annotations_and_afo_indexes(
     context = ebl.app.create_context()
     ebl.app.create_app(context)
 
+    assert calls["bibliography"] == 1
+    assert calls["reconcile"] == 100
     assert calls["annotations"] == 1
     assert calls["afo"] == 1

--- a/ebl/tests/test_app_bootstrap.py
+++ b/ebl/tests/test_app_bootstrap.py
@@ -63,7 +63,7 @@ def test_create_context_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     with pytest.raises(FrozenInstanceError):
-        setattr(context, "ebl_ai_client", EblAiClient("http://localhost:8001"))
+        context.ebl_ai_client = EblAiClient("http://localhost:8001")
 
 
 def test_create_context_bootstraps_cache_indexes(


### PR DESCRIPTION
This PR implements server-owned bibliography identity and alias-based compatibility for partner bibliography workflows.

Partner create and duplicate-override now generate canonical eBL bibliography IDs server-side. Any partner-submitted ID is preserved as a `partner_id` alias instead of becoming the canonical ID. Bibliography entries now support `citationKey` and embedded aliases, and lookup can resolve records by canonical ID, citationKey, alias, normalized alias, or the new read-only resolver endpoint for raw slash/special-character aliases.

The PR also adds citationKey generation/persistence for partner-created records, non-unique lookup indexes for citationKey and aliases, collision handling for generated IDs/citationKeys/aliases, and tests covering canonical ID ownership, alias preservation, special-character aliases, citationKey collision suffixing, duplicate override behavior, and resolver access.

No duplicate merge/deprecation workflow, citationKey backfill, production migration, reference rewriting, `@bib{...}` rewriting, or frontend changes are included.

Remaining Work:
- `citationKey` backfill --> basically update existing data
- citationKey apply-mode migration --> After the dry-run report is reviewed, a separate migration/apply mode can persist citationKeys to existing records. This should include safety flags, batching, collision handling, and manual-review support
- Unique indexes after audit -->Unique constraints should only be added after a dry-run audit confirms there are no existing citationKey or alias collisions.
- Partner-scoped alias uniqueness --> The current alias model preserves partner-submitted IDs, but future work should decide whether aliases are globally unique or scoped by partner/source. This matters if multiple partners use the same local ID.
- Duplicate merge/deprecation workflow --> Need to address duplicates
- Frontend citationKey work?
- Update docs if need be

## Summary by Sourcery

Introduce server-owned canonical bibliography IDs, citationKey support, and alias-based lookup for partner bibliography entries, including a new resolve endpoint and repository indexing.

New Features:
- Allow partner bibliography entries to be created with server-generated canonical IDs while preserving partner-submitted IDs as aliases.
- Add citationKey generation, storage, and lookup for bibliography entries, including collision-safe suffixing.
- Expose a /api/v1/bibliography/resolve endpoint to retrieve entries by canonical ID, citationKey, or raw alias with scope-based access control.

Bug Fixes:
- Ensure unsafe partner IDs containing control characters are rejected without mutating the database.
- Prevent ambiguous or colliding aliases from being created by returning conflict responses and leaving existing data unchanged.

Enhancements:
- Extend bibliography lookup to resolve entries by canonical ID, citationKey, or alias with precedence rules favoring canonical IDs.
- Add partner-specific CSL and duplicate-override schemas, including aliases, to validate incoming payloads.
- Introduce partner identity utilities for normalizing partner IDs, generating canonical bibliography IDs, and producing collision-resistant citation keys.
- Update duplicate override workflows so partner overrides create canonical IDs, store partner IDs as aliases, and handle citationKey collisions.

Tests:
- Add repository index tests for citationKey and alias fields.
- Add tests covering alias normalization, special-character handling, ambiguity detection, and resolve endpoint behavior.
- Expand partner create and duplicate-override tests to cover canonical ID generation, alias persistence, citationKey collisions, and permission checks.

Chores:
- Initialize bibliography repository indexes at app bootstrap alongside existing collections.