### PR TITLE
Add KN (King Name) to named-entity codes in migration

### DIFF
--- a/ebl/dictionary/migrate_named_entity_tags.py
+++ b/ebl/dictionary/migrate_named_entity_tags.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 COLLECTION = "words"
 NAMED_ENTITY_CODES = frozenset(
-    "AN CN DN EN FN GN LN MN ON PN QN RN SN TN WN YN".split()
+    "AN CN DN EN FN GN KN LN MN ON PN QN RN SN TN WN YN".split()
 )
 
 

--- a/ebl/tests/dictionary/test_migrate_named_entity_tags.py
+++ b/ebl/tests/dictionary/test_migrate_named_entity_tags.py
@@ -22,6 +22,20 @@ def test_split_pos_separates_named_entities_from_grammatical():
     assert named == ["DN", "GN"]
 
 
+def test_king_name_code_is_a_named_entity():
+    assert "KN" in module.NAMED_ENTITY_CODES
+
+
+def test_run_migration_moves_king_name_code(database):
+    _insert(database, {"_id": "Samsu-iluna I", "pos": ["KN"]})
+
+    module.run_migration(database[COLLECTION])
+
+    document = database[COLLECTION].find_one({"_id": "Samsu-iluna I"})
+    assert document["pos"] == []
+    assert document["namedEntityTags"] == ["KN"]
+
+
 def test_run_migration_moves_named_entity_codes(database):
     _insert(database, {"_id": "Marduk I", "pos": ["N", "DN"]})
 


### PR DESCRIPTION
## Context

Follow-up to #731 (named-entity tags migration). Running the migration's
**dry-run against `ebldev`** and auditing the result surfaced an out-of-spec
named-entity code in the live data.

## Problem

Two `words` documents carry a `KN` ("King Name") code in `pos`:

| _id | lemma | pos |
|---|---|---|
| `Samsu-iluna I` | Samsu-iluna | `['KN']` |
| `Nazi-Maruttaš I` | Nazi-Maruttaš | `['KN']` |

Both are Babylonian kings, i.e. proper nouns. `KN` was **not** in the canonical
16-code set, so the migration would have left these documents with
`pos: ['KN']` and `namedEntityTags: []` — they would not be recognized as
proper nouns by the frontend's `namedEntityTags`-based filter, and a bogus
"grammatical" `KN` would remain in `pos`.

## Fix

Add `KN` to `NAMED_ENTITY_CODES` so it is moved like the other named-entity
codes. `KN` is **preserved** (not remapped to `RN`); a structural migration
should not make an irreversible semantic merge. Any `KN`→`RN` consolidation is
a separate data-cleaning decision for curators.

## Verification (dry-run on `ebldev`, read-only)

| | before fix | after fix |
|---|---|---|
| documents moved | 5,366 | 5,368 |
| documents backfilled | 15,462 | 15,460 |
| `XN`-style NE codes left uncovered in `pos` | `KN` (2) | none |

Totals still sum to 20,828; no writes were made.

- Migration module: 100% coverage; dictionary suite passes.
- `ruff check` / `ruff format --check` clean.

## Frontend note

If ebl-frontend enumerates NE codes for labels, it should learn about `KN`.
Proper-noun detection (`namedEntityTags.length > 0`) works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Include the KN (King Name) part-of-speech code in the named-entity migration and cover it with tests.

Bug Fixes:
- Ensure documents with KN codes are migrated from pos to namedEntityTags like other named-entity codes.

Tests:
- Add tests verifying KN is treated as a named-entity code and migrated correctly in the dictionary migration.