### PR TITLE
Add Type 1 and Type 2 to school tablet genre

### DIFF
--- a/ebl/fragmentarium/domain/genres.py
+++ b/ebl/fragmentarium/domain/genres.py
@@ -421,6 +421,8 @@ genres = (
     ("CANONICAL", "School Tablet"),
     ("CANONICAL", "School Tablet", "Model contract"),
     ("CANONICAL", "School Tablet", "Model letter"),
+    ("CANONICAL", "School Tablet", "Type 1"),
+    ("CANONICAL", "School Tablet", "Type 2"),
     ("CANONICAL", "Technical"),
     ("CANONICAL", "Technical", "Astronomy"),
     ("CANONICAL", "Technical", "Astronomy", "I.NAM.GIŠ.HUR.AN.KI.A"),


### PR DESCRIPTION
## Summary by Sourcery

Extend canonical school tablet genres with two new subtypes.