### PR TITLE
Add Lunar Six Tablets as Genre

### DIFF
--- a/ebl/fragmentarium/domain/genres.py
+++ b/ebl/fragmentarium/domain/genres.py
@@ -435,6 +435,7 @@ genres = (
     ("CANONICAL", "Technical", "Astronomy", "Goal Year Texts"),
     ("CANONICAL", "Technical", "Astronomy", "Goal Year Procedure Texts"),
     ("CANONICAL", "Technical", "Astronomy", "GU-Text"),
+    ("CANONICAL", "Technical", "Astronomy", "Lunar Six Tablets"),
     ("CANONICAL", "Technical", "Astronomy", "MUL.APIN"),
     ("CANONICAL", "Technical", "Astronomy", "Time keeping texts"),
     ("CANONICAL", "Technical", "Astronomy", "Mathematical Astronomy"),


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce 'Lunar Six Tablets' as a canonical technical astronomy genre option in the fragmentarium domain model.