### PR TITLE
Add NATIONAL_MUSEUM_OF_ORIENTAL_ART

### DIFF
--- a/ebl/fragmentarium/domain/museum.py
+++ b/ebl/fragmentarium/domain/museum.py
@@ -191,6 +191,12 @@ class Museum(Enum):
         "https://muze.gov.tr/muze-detay?SectionId=AMM01&DistId=AMM",
     )
     NATIONALMUSEET = ("Nationalmuseet", "Copenhagen", "DK", "https://en.natmus.dk/")
+    NATIONAL_MUSEUM_OF_ORIENTAL_ART = (
+        'Museo Nazionale d\'Arte Orientale "Giuseppe Tucci"',
+        "Rome",
+        "IT",
+        "https://www.museodellecivilta.it/arte-orientale/",
+    )
     NATIONAL_MUSEUM_OF_WORLD_WRITING_SYSTEMS = (
         "National Museum of World Writing Systems",
         "Incheon",


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce NATIONAL_MUSEUM_OF_ORIENTAL_ART as a configurable museum with name, city, country, and website metadata.