### PR TITLE
Add HARVEY_CUSHING_WHITNEY_MEDICAL_LIBRARY

### DIFF
--- a/ebl/fragmentarium/domain/museum.py
+++ b/ebl/fragmentarium/domain/museum.py
@@ -93,6 +93,12 @@ class Museum(Enum):
         "US",
         "https://harvardartmuseums.org/",
     )
+    HARVEY_CUSHING_WHITNEY_MEDICAL_LIBRARY = (
+        "Harvey Cushing/John Hay Whitney Medical Library, Yale University",
+        "New Haven",
+        "US",
+        "https://library.medicine.yale.edu/",
+    )
     HATAY_ARCHAEOLOGY_MUSEUM = (
         "Hatay Archaeology Museum",
         "Antakya",


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Support the Harvey Cushing/John Hay Whitney Medical Library as a recognized museum in the fragmentarium domain.