### PR TITLE
Add various museums in Turkey

### DIFF
--- a/ebl/fragmentarium/domain/museum.py
+++ b/ebl/fragmentarium/domain/museum.py
@@ -33,6 +33,12 @@ class Museum(Enum):
         "AU",
         "https://www.aiarch.org.au/",
     )
+    BATMAN_HASANKEYF_MUZESI = (
+        "Batman Hasankeyf Müzesi",
+        "Batman",
+        "TR",
+        "https://kvmgm.ktb.gov.tr/TR-281298/batman-muze-mudurlugu.html",
+    )
     BANQUE_NATIONALE_DE_BELGIQUE = (
         "Banque Nationale de Belgique",
         "Brussels",
@@ -160,6 +166,12 @@ class Museum(Enum):
         "https://www.khm.at/",
     )
     LOUVRE = ("Louvre", "Paris", "FR", "https://www.louvre.fr/")
+    MARDIN_MUZESI = (
+        "Mardin Müzesi",
+        "Mardin",
+        "TR",
+        "https://muze.gov.tr/muze-detay?sectionId=MRD01&distId=MRK",
+    )
     MOSUL_MUSEUM = (
         "Mosul Museum",
         "Mosul",
@@ -258,6 +270,11 @@ class Museum(Enum):
         "Private collection of W. Lamplough",
         "",
         "GB",
+    )
+    PRIVATE_COLLECTION_OF_Z_YILDIZ = (
+        "Private collection of Zeynel Yıldız",
+        "Elazığ",
+        "TR",
     )
     MCGILL_UNIVERSITY = (
         "McGill University Ethnological Collections",


### PR DESCRIPTION
## Summary by Sourcery

Add new Turkish museums and a private collection to the museum registry.

New Features:
- Register Batman Hasankeyf Museum in Batman, Turkey in the museum list.
- Register Mardin Museum in Mardin, Turkey in the museum list.
- Register the private collection of Zeynel Yıldız in Elazığ, Turkey in the museum list.