### PR TITLE
Add Sum as genre

### DIFF
--- a/docs/ebl-atf.md
+++ b/docs/ebl-atf.md
@@ -177,7 +177,7 @@ parallel-composition = '(',  { any-character }-, ' ', line-number,  ')';
 
 parallel-text = genre, ' ', category, '.', index, ' ',
                 [ stage, ' ',  [ version, ' ' ], chapter , ' ' ], line-number;
-genre = 'L' | 'D' | 'Lex' | 'Med' | 'Mag'
+genre = 'L' | 'D' | 'Lex' | 'Med' | 'Mag' | 'Šui' | 'Sum'
 category = { 'I' | 'V' | 'X' | 'L' | 'C' | 'D' | 'M' }-;
            (* Must be a valid numeral. *)
 stage = 'Ur3'  | 'OA'  | 'OB' | 'OElam' | 'PElam'  | 'MB' |

--- a/ebl/tests/corpus/test_text_id.py
+++ b/ebl/tests/corpus/test_text_id.py
@@ -12,6 +12,7 @@ from ebl.transliteration.domain.genre import Genre
         (TextId(Genre.MAGIC, 1, 2), "Mag I.2"),
         (TextId(Genre.MEDICINE, 1, 3), "Med I.3"),
         (TextId(Genre.SHUILA, 1, 8), "Šui I.8"),
+        (TextId(Genre.SUMERIAN, 1, 8), "Sum I.8"),
     ],
 )
 def test_str(text_id, expected) -> None:

--- a/ebl/transliteration/domain/atf_parsers/lark_parser/ebl_atf_parallel_line.lark
+++ b/ebl/transliteration/domain/atf_parsers/lark_parser/ebl_atf_parallel_line.lark
@@ -11,7 +11,7 @@ parallel_fragment: PARALLEL_LINE_PREFIX [CF] "F " museum_number " " [DUPLICATES 
 DUPLICATES: "&d"
 parallel_text: PARALLEL_LINE_PREFIX [CF] text_id " "  [chapter_name " "] line_number
 text_id: GENRE " " CATEGORY "." INT
-GENRE: "Lex" | "Med" | "L" | "D" | "Mag" | "Šui"
+GENRE: "Lex" | "Med" | "L" | "D" | "Mag" | "Sum" | "Šui"
 CATEGORY: "0" | CAPITAL_ROMAN_NUMERAL
 chapter_name: STAGE " " [quoted_string " "] quoted_string 
 quoted_string: "\"" /./+ "\""

--- a/ebl/transliteration/domain/genre.py
+++ b/ebl/transliteration/domain/genre.py
@@ -9,3 +9,4 @@ class Genre(Enum):
     MAGIC = "Mag"
     MEDICINE = "Med"
     SHUILA = "Šui"
+    SUMERIAN = "Sum"


### PR DESCRIPTION
## Summary by Sourcery

Add the Sumerian genre to the transliteration domain and parallel text grammar.

New Features:
- Introduce a new Sumerian genre value for text identifiers and transliteration genres.

Documentation:
- Update ATF documentation to include Šui and Sum as valid parallel-text genres.

Tests:
- Extend corpus text ID tests to cover the Sumerian genre string representation.