### PR TITLE
fix: fix internal overwrite

### DIFF
--- a/.devcontainer/sync-env.py
+++ b/.devcontainer/sync-env.py
@@ -10,19 +10,19 @@ def parse_env(content: str) -> dict[str, str]:
     result: dict[str, str] = {}
     for line in content.splitlines():
         stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
+        if not stripped or stripped.startswith("#"):
             continue
-        if '=' in stripped:
-            key, _, value = stripped.partition('=')
+        if "=" in stripped:
+            key, _, value = stripped.partition("=")
             result[key.strip()] = value
     return result
 
 
 def main() -> None:
-    example_content = read_file('.env.example')
+    example_content = read_file(".env.example")
     placeholders = parse_env(example_content)
 
-    env_content = read_file('.env')
+    env_content = read_file(".env")
     current = parse_env(env_content)
 
     modified = env_content
@@ -30,16 +30,16 @@ def main() -> None:
 
     for key, placeholder in placeholders.items():
         if key not in current:
-            modified = modified.rstrip('\n') + f'\n{key}={placeholder}\n'
+            modified = modified.rstrip("\n") + f"\n{key}={placeholder}\n"
             appended.append(key)
 
     if appended:
-        with open('.env', 'w') as f:
+        with open(".env", "w") as f:
             f.write(modified)
-        print('Added missing keys to .env: ' + ', '.join(appended))
+        print("Added missing keys to .env: " + ", ".join(appended))
     else:
-        print('.env already contains all keys from .env.example')
+        print(".env already contains all keys from .env.example")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.devcontainer/sync-env.py
+++ b/.devcontainer/sync-env.py
@@ -10,19 +10,19 @@ def parse_env(content: str) -> dict[str, str]:
     result: dict[str, str] = {}
     for line in content.splitlines():
         stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
+        if not stripped or stripped.startswith('#'):
             continue
-        if "=" in stripped:
-            key, _, value = stripped.partition("=")
+        if '=' in stripped:
+            key, _, value = stripped.partition('=')
             result[key.strip()] = value
     return result
 
 
 def main() -> None:
-    example_content = read_file(".env.example")
+    example_content = read_file('.env.example')
     placeholders = parse_env(example_content)
 
-    env_content = read_file(".env")
+    env_content = read_file('.env')
     current = parse_env(env_content)
 
     modified = env_content
@@ -30,16 +30,16 @@ def main() -> None:
 
     for key, placeholder in placeholders.items():
         if key not in current:
-            modified = modified.rstrip("\n") + f"\n{key}={placeholder}\n"
+            modified = modified.rstrip('\n') + f'\n{key}={placeholder}\n'
             appended.append(key)
 
     if appended:
-        with open(".env", "w") as f:
+        with open('.env', 'w') as f:
             f.write(modified)
-        print("Added missing keys to .env: " + ", ".join(appended))
+        print('Added missing keys to .env: ' + ', '.join(appended))
     else:
-        print(".env already contains all keys from .env.example")
+        print('.env already contains all keys from .env.example')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/.devcontainer/test_sync_env.py
+++ b/.devcontainer/test_sync_env.py
@@ -55,7 +55,9 @@ class TestParseEnv:
 
 
 class TestMain:
-    def test_appends_missing_keys(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    def test_appends_missing_keys(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
         example = tmp_path / ".env.example"
         example.write_text("EXISTING=placeholder\nMISSING=placeholder\n")
         env = tmp_path / ".env"
@@ -129,7 +131,9 @@ def _run_main_in(directory: Path) -> None:
 
 
 class TestEntryPoint:
-    def test_runs_as_script(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    def test_runs_as_script(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
         (tmp_path / ".env.example").write_text("KEY=placeholder\n")
         (tmp_path / ".env").write_text("KEY=value\n")
         script = str(Path(__file__).parent / "sync-env.py")

--- a/.devcontainer/test_sync_env.py
+++ b/.devcontainer/test_sync_env.py
@@ -55,9 +55,7 @@ class TestParseEnv:
 
 
 class TestMain:
-    def test_appends_missing_keys(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_appends_missing_keys(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         example = tmp_path / ".env.example"
         example.write_text("EXISTING=placeholder\nMISSING=placeholder\n")
         env = tmp_path / ".env"
@@ -131,9 +129,7 @@ def _run_main_in(directory: Path) -> None:
 
 
 class TestEntryPoint:
-    def test_runs_as_script(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_runs_as_script(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         (tmp_path / ".env.example").write_text("KEY=placeholder\n")
         (tmp_path / ".env").write_text("KEY=value\n")
         script = str(Path(__file__).parent / "sync-env.py")

--- a/ebl/app.py
+++ b/ebl/app.py
@@ -57,6 +57,7 @@ from ebl.dossiers.infrastructure.mongo_dossiers_repository import (
     MongoDossiersRepository,
 )
 from ebl.users.domain.user import Guest
+from ebl.users.web.user_request import UserRequest
 from ebl.users.infrastructure.auth0 import Auth0Backend
 from ebl.fragmentarium.infrastructure.mongo_findspot_repository import (
     MongoFindspotRepository,
@@ -127,7 +128,9 @@ def create_context():
 def create_api(context: Context) -> falcon.App:
     auth_middleware = FalconAuthMiddleware(context.auth_backend)
     api = falcon.App(
-        cors_enable=True, middleware=[auth_middleware, context.cache.middleware]
+        cors_enable=True,
+        middleware=[auth_middleware, context.cache.middleware],
+        request_type=UserRequest,
     )
     ebl.error_handler.set_up(api)
     return api

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -13,6 +13,9 @@ from ebl.bibliography.application.bibliography_identity import (
     update_with_identity_claims,
 )
 from ebl.bibliography.application.partner_bibliography import PartnerBibliography
+from ebl.bibliography.application.server_owned_fields import (
+    preserve_server_owned_fields,
+)
 from ebl.bibliography.domain.reference import BibliographyId, Reference
 from ebl.changelog import Changelog
 from ebl.errors import DataError, DuplicateError, NotFoundError
@@ -90,9 +93,18 @@ class Bibliography:
 
         return current
 
-    def update(self, entry, user: User):
+    def update(self, entry: dict, user: User) -> None:
         update_with_identity_claims(
-            self._repository, self._changelog, self.find, entry, user
+            self._repository,
+            self._changelog,
+            self.find,
+            self._with_preserved_server_owned_fields(entry),
+            user,
+        )
+
+    def _with_preserved_server_owned_fields(self, entry: dict) -> dict:
+        return preserve_server_owned_fields(
+            entry, self._repository.query_by_id(entry["id"])
         )
 
     def search(self, query: str) -> Sequence[dict]:

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -7,7 +7,10 @@ from pydash import uniq_with
 from ebl.bibliography.application.duplicate_detection import (
     BibliographyDuplicateDetector,
 )
-from ebl.bibliography.application.bibliography_repository import BibliographyRepository
+from ebl.bibliography.application.bibliography_repository import (
+    BibliographyRepository,
+    BibliographyUpdateConflictError,
+)
 from ebl.bibliography.application.bibliography_identity import (
     BibliographyIdentityContext,
     create_with_identity_claims,
@@ -65,10 +68,22 @@ class Bibliography:
         return follow_bibliography_redirect(entry, self._repository.query_by_id)
 
     def update(self, entry: dict, user: User) -> None:
+        """Edit the metadata of an entry, keeping its persisted identity state.
+
+        Trusted internal caller path: submitted server-owned fields are ignored
+        rather than rejected, because the caller (`PartnerBibliography`) has
+        already screened them out and rebuilt the entry from stored state.
+        """
         stored_entry = self._stored_entry_for_update(entry)
         self._persist_update(entry, stored_entry, user)
 
     def update_metadata(self, entry: dict, user: User) -> None:
+        """Edit the metadata of an entry on behalf of a client.
+
+        Same persistence as `update`, but a submitted server-owned field that
+        disagrees with stored state is reported as a conflict instead of being
+        silently dropped.
+        """
         stored_entry = self._stored_entry_for_update(entry)
         self._reject_changed_server_owned_fields(entry, stored_entry)
         self._persist_update(entry, stored_entry, user)
@@ -84,10 +99,7 @@ class Bibliography:
     @staticmethod
     def _reject_changed_server_owned_fields(entry: dict, stored_entry: dict) -> None:
         if changed_fields := changed_server_owned_fields(entry, stored_entry):
-            raise DataError(
-                "Bibliography metadata updates may not change server-owned fields: "
-                f"{', '.join(changed_fields)}. These are maintained by the server."
-            )
+            raise BibliographyUpdateConflictError(stored_entry["id"], changed_fields)
 
     def _stored_entry_for_update(self, entry: dict) -> dict:
         id_ = entry.get("id")

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -14,15 +14,16 @@ from ebl.bibliography.application.bibliography_identity import (
     update_with_identity_claims,
 )
 from ebl.bibliography.application.partner_bibliography import PartnerBibliography
+from ebl.bibliography.application.redirect_resolution import (
+    follow_bibliography_redirect,
+)
 from ebl.bibliography.application.server_owned_fields import (
-    preserve_server_owned_fields,
+    preserve_persisted_fields,
 )
 from ebl.bibliography.domain.reference import BibliographyId, Reference
 from ebl.changelog import Changelog
-from ebl.errors import DataError, DuplicateError, NotFoundError
+from ebl.errors import DataError, NotFoundError
 from ebl.users.domain.user import User
-
-MAX_REDIRECT_DEPTH = 5
 
 
 class Bibliography:
@@ -60,44 +61,13 @@ class Bibliography:
         return resolved_entries
 
     def _follow_redirect(self, entry: dict) -> dict:
-        current = entry
-        visited_ids: set[str] = set()
-        redirects_followed = 0
-
-        while current.get("deprecated", False):
-            current_id = current.get("id")
-            redirect_to = current.get("redirectTo")
-            if not isinstance(redirect_to, str) or not redirect_to:
-                raise NotFoundError(
-                    f"Deprecated bibliography {current_id} has no redirect target."
-                )
-            if current_id in visited_ids or redirect_to in visited_ids:
-                raise DuplicateError(
-                    f"Bibliography redirect loop detected at {current_id}."
-                )
-            if redirects_followed >= MAX_REDIRECT_DEPTH:
-                raise DuplicateError(
-                    f"Bibliography redirect from {entry.get('id')} exceeds "
-                    f"the maximum depth of {MAX_REDIRECT_DEPTH}."
-                )
-
-            if isinstance(current_id, str):
-                visited_ids.add(current_id)
-            try:
-                current = self._repository.query_by_id(redirect_to)
-            except NotFoundError as error:
-                raise NotFoundError(
-                    f"Bibliography redirect target {redirect_to} not found."
-                ) from error
-            redirects_followed += 1
-
-        return current
+        return follow_bibliography_redirect(entry, self._repository.query_by_id)
 
     def update(self, entry: dict, user: User) -> None:
         stored_entry = self._stored_entry_for_update(entry)
         update_with_identity_claims(
             self._identity,
-            preserve_server_owned_fields(entry, stored_entry),
+            preserve_persisted_fields(entry, stored_entry),
             user,
             stored_entry,
         )
@@ -106,7 +76,13 @@ class Bibliography:
         id_ = entry.get("id")
         if not isinstance(id_, str) or not id_:
             raise DataError("Bibliography entry id is required.")
-        return self._repository.query_by_id(id_)
+        stored_entry = self._repository.query_by_id(id_)
+        if stored_entry.get("deprecated"):
+            raise DataError(
+                f"Bibliography entry {id_} is deprecated; "
+                f"edit {stored_entry.get('redirectTo')} instead."
+            )
+        return stored_entry
 
     def search(self, query: str) -> Sequence[dict]:
         author_query_result: Sequence[dict] = []

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -94,18 +94,21 @@ class Bibliography:
         return current
 
     def update(self, entry: dict, user: User) -> None:
+        stored_entry = self._stored_entry_for_update(entry)
         update_with_identity_claims(
             self._repository,
             self._changelog,
             self.find,
-            self._with_preserved_server_owned_fields(entry),
+            preserve_server_owned_fields(entry, stored_entry),
             user,
+            stored_entry,
         )
 
-    def _with_preserved_server_owned_fields(self, entry: dict) -> dict:
-        return preserve_server_owned_fields(
-            entry, self._repository.query_by_id(entry["id"])
-        )
+    def _stored_entry_for_update(self, entry: dict) -> dict:
+        id_ = entry.get("id")
+        if not isinstance(id_, str) or not id_:
+            raise DataError("Bibliography entry id is required.")
+        return self._repository.query_by_id(id_)
 
     def search(self, query: str) -> Sequence[dict]:
         author_query_result: Sequence[dict] = []

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -9,6 +9,7 @@ from ebl.bibliography.application.duplicate_detection import (
 )
 from ebl.bibliography.application.bibliography_repository import BibliographyRepository
 from ebl.bibliography.application.bibliography_identity import (
+    BibliographyIdentityContext,
     create_with_identity_claims,
     update_with_identity_claims,
 )
@@ -29,11 +30,10 @@ class Bibliography:
         self._repository = repository
         self._changelog = changelog
         self._partner = PartnerBibliography(self, repository)
+        self._identity = BibliographyIdentityContext(repository, changelog, self.find)
 
     def create(self, entry, user: User) -> str:
-        return create_with_identity_claims(
-            self._repository, self._changelog, self.find, entry, user
-        )
+        return create_with_identity_claims(self._identity, entry, user)
 
     def find(self, id_: str):
         for query in (
@@ -96,9 +96,7 @@ class Bibliography:
     def update(self, entry: dict, user: User) -> None:
         stored_entry = self._stored_entry_for_update(entry)
         update_with_identity_claims(
-            self._repository,
-            self._changelog,
-            self.find,
+            self._identity,
             preserve_server_owned_fields(entry, stored_entry),
             user,
             stored_entry,

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -18,6 +18,7 @@ from ebl.bibliography.application.redirect_resolution import (
     follow_bibliography_redirect,
 )
 from ebl.bibliography.application.server_owned_fields import (
+    changed_server_owned_fields,
     preserve_persisted_fields,
 )
 from ebl.bibliography.domain.reference import BibliographyId, Reference
@@ -65,12 +66,28 @@ class Bibliography:
 
     def update(self, entry: dict, user: User) -> None:
         stored_entry = self._stored_entry_for_update(entry)
+        self._persist_update(entry, stored_entry, user)
+
+    def update_metadata(self, entry: dict, user: User) -> None:
+        stored_entry = self._stored_entry_for_update(entry)
+        self._reject_changed_server_owned_fields(entry, stored_entry)
+        self._persist_update(entry, stored_entry, user)
+
+    def _persist_update(self, entry: dict, stored_entry: dict, user: User) -> None:
         update_with_identity_claims(
             self._identity,
             preserve_persisted_fields(entry, stored_entry),
             user,
             stored_entry,
         )
+
+    @staticmethod
+    def _reject_changed_server_owned_fields(entry: dict, stored_entry: dict) -> None:
+        if changed_fields := changed_server_owned_fields(entry, stored_entry):
+            raise DataError(
+                "Bibliography metadata updates may not change server-owned fields: "
+                f"{', '.join(changed_fields)}. These are maintained by the server."
+            )
 
     def _stored_entry_for_update(self, entry: dict) -> dict:
         id_ = entry.get("id")

--- a/ebl/bibliography/application/bibliography.py
+++ b/ebl/bibliography/application/bibliography.py
@@ -24,6 +24,7 @@ from ebl.bibliography.application.server_owned_fields import (
     changed_server_owned_fields,
     preserve_persisted_fields,
 )
+from ebl.bibliography.application.update_target import stored_entry_for_update
 from ebl.bibliography.domain.reference import BibliographyId, Reference
 from ebl.changelog import Changelog
 from ebl.errors import DataError, NotFoundError
@@ -67,28 +68,24 @@ class Bibliography:
     def _follow_redirect(self, entry: dict) -> dict:
         return follow_bibliography_redirect(entry, self._repository.query_by_id)
 
-    def update(self, entry: dict, user: User) -> None:
+    def update_metadata(self, entry: dict, user: User) -> None:
         """Edit the metadata of an entry, keeping its persisted identity state.
 
-        Trusted internal caller path: submitted server-owned fields are ignored
-        rather than rejected, because the caller (`PartnerBibliography`) has
-        already screened them out and rebuilt the entry from stored state.
-        """
-        stored_entry = self._stored_entry_for_update(entry)
-        self._persist_update(entry, stored_entry, user)
+        The only way to write an existing entry, for clients and for trusted
+        internal callers alike. Client-editable CSL fields are replaced by the
+        submission; `aliases`, `citationKey`, `deprecated`, `redirectTo` and
+        every other persisted field the client does not own are carried over
+        from the stored record.
 
-    def update_metadata(self, entry: dict, user: User) -> None:
-        """Edit the metadata of an entry on behalf of a client.
-
-        Same persistence as `update`, but a submitted server-owned field that
-        disagrees with stored state is reported as a conflict instead of being
-        silently dropped.
+        A submitted server-owned field that disagrees with stored state is a
+        conflict: never a silent overwrite, and never a silent drop either, so a
+        caller holding a stale identity is told to reload rather than writing on
+        top of the newer state.
         """
-        stored_entry = self._stored_entry_for_update(entry)
+        stored_entry = stored_entry_for_update(
+            entry, self._repository.query_by_id, self.find
+        )
         self._reject_changed_server_owned_fields(entry, stored_entry)
-        self._persist_update(entry, stored_entry, user)
-
-    def _persist_update(self, entry: dict, stored_entry: dict, user: User) -> None:
         update_with_identity_claims(
             self._identity,
             preserve_persisted_fields(entry, stored_entry),
@@ -100,18 +97,6 @@ class Bibliography:
     def _reject_changed_server_owned_fields(entry: dict, stored_entry: dict) -> None:
         if changed_fields := changed_server_owned_fields(entry, stored_entry):
             raise BibliographyUpdateConflictError(stored_entry["id"], changed_fields)
-
-    def _stored_entry_for_update(self, entry: dict) -> dict:
-        id_ = entry.get("id")
-        if not isinstance(id_, str) or not id_:
-            raise DataError("Bibliography entry id is required.")
-        stored_entry = self._repository.query_by_id(id_)
-        if stored_entry.get("deprecated"):
-            raise DataError(
-                f"Bibliography entry {id_} is deprecated; "
-                f"edit {stored_entry.get('redirectTo')} instead."
-            )
-        return stored_entry
 
     def search(self, query: str) -> Sequence[dict]:
         author_query_result: Sequence[dict] = []

--- a/ebl/bibliography/application/bibliography_identity.py
+++ b/ebl/bibliography/application/bibliography_identity.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable
 
@@ -17,23 +18,29 @@ from ebl.users.domain.user import User
 COLLECTION = "bibliography"
 
 
+@dataclass(frozen=True)
+class BibliographyIdentityContext:
+    repository: BibliographyRepository
+    changelog: Changelog
+    find: Callable[[str], dict]
+
+
 def identity_values(entry: dict[str, Any]) -> set[str]:
     return set(bibliography_lookup_values(entry))
 
 
 def create_with_identity_claims(
-    repository: BibliographyRepository,
-    changelog: Changelog,
-    find: Callable[[str], dict],
+    context: BibliographyIdentityContext,
     entry: dict[str, Any],
     user: User,
 ) -> str:
+    repository = context.repository
     now = datetime.now(timezone.utc)
     operation = new_lookup_reservation_operation(entry["id"], now)
     created = False
     try:
         repository.claim_lookup_values(operation, bibliography_lookup_values(entry))
-        ensure_lookup_values_available(find, entry)
+        ensure_lookup_values_available(context.find, entry)
         created_id = repository.create(entry)
         created = True
         if created_id != entry["id"]:
@@ -41,7 +48,7 @@ def create_with_identity_claims(
                 f"Created bibliography id {created_id} does not match {entry['id']}."
             )
         repository.commit_lookup_values(operation, datetime.now(timezone.utc))
-        changelog.create(
+        context.changelog.create(
             COLLECTION, user.profile, {"_id": entry["id"]}, create_mongo_entry(entry)
         )
         return created_id
@@ -52,13 +59,12 @@ def create_with_identity_claims(
 
 
 def update_with_identity_claims(
-    repository: BibliographyRepository,
-    changelog: Changelog,
-    find: Callable[[str], dict],
+    context: BibliographyIdentityContext,
     entry: dict[str, Any],
     user: User,
     stored_entry: dict[str, Any] | None = None,
 ) -> None:
+    repository = context.repository
     old_entry = (
         repository.query_by_id(entry["id"]) if stored_entry is None else stored_entry
     )
@@ -71,14 +77,14 @@ def update_with_identity_claims(
     updated = False
     try:
         repository.claim_lookup_values(operation, values_to_claim)
-        ensure_lookup_values_available(find, entry, entry["id"])
+        ensure_lookup_values_available(context.find, entry, entry["id"])
         repository.update(entry)
         updated = True
         repository.commit_lookup_values(operation, datetime.now(timezone.utc))
         repository.retire_lookup_values(
             entry["id"], values_to_retire, datetime.now(timezone.utc)
         )
-        changelog.create(
+        context.changelog.create(
             COLLECTION,
             user.profile,
             create_mongo_entry(old_entry),

--- a/ebl/bibliography/application/bibliography_identity.py
+++ b/ebl/bibliography/application/bibliography_identity.py
@@ -57,8 +57,11 @@ def update_with_identity_claims(
     find: Callable[[str], dict],
     entry: dict[str, Any],
     user: User,
+    stored_entry: dict[str, Any] | None = None,
 ) -> None:
-    old_entry = repository.query_by_id(entry["id"])
+    old_entry = (
+        repository.query_by_id(entry["id"]) if stored_entry is None else stored_entry
+    )
     old_values = identity_values(old_entry)
     new_values = identity_values(entry)
     values_to_claim = sorted(new_values - old_values)

--- a/ebl/bibliography/application/bibliography_identity.py
+++ b/ebl/bibliography/application/bibliography_identity.py
@@ -1,6 +1,17 @@
+"""Trusted bibliography identity primitives.
+
+`update_with_identity_claims` is the only path allowed to change the
+server-owned identity of an entry: it diffs the lookup values, claims the added
+ones, retires the removed ones, and recovers reservations when persistence
+fails. `Bibliography.update` is the generic CSL metadata editor and deliberately
+calls this primitive with identity preserved, so a metadata edit never claims or
+retires anything. Callers that need to mutate identity must supply the new
+values themselves rather than routing through the metadata editor.
+"""
+
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from ebl.bibliography.application.bibliography_repository import (
     BibliographyRepository,
@@ -11,6 +22,7 @@ from ebl.bibliography.application.lookup_reservation import (
     new_lookup_reservation_operation,
 )
 from ebl.bibliography.application.serialization import create_mongo_entry
+from ebl.bibliography.application.server_owned_fields import stored_server_owned_fields
 from ebl.changelog import Changelog
 from ebl.errors import Defect, NotFoundError
 from ebl.users.domain.user import User
@@ -40,7 +52,7 @@ def create_with_identity_claims(
     created = False
     try:
         repository.claim_lookup_values(operation, bibliography_lookup_values(entry))
-        ensure_lookup_values_available(context.find, entry)
+        ensure_lookup_values_available(context.find, bibliography_lookup_values(entry))
         created_id = repository.create(entry)
         created = True
         if created_id != entry["id"]:
@@ -68,6 +80,12 @@ def update_with_identity_claims(
     old_entry = (
         repository.query_by_id(entry["id"]) if stored_entry is None else stored_entry
     )
+    if old_entry.get("id") != entry["id"]:
+        raise Defect(
+            f"Stored bibliography {old_entry.get('id')} does not match "
+            f"the entry being updated {entry['id']}."
+        )
+    expected_server_owned_fields = stored_server_owned_fields(old_entry)
     old_values = identity_values(old_entry)
     new_values = identity_values(entry)
     values_to_claim = sorted(new_values - old_values)
@@ -77,8 +95,8 @@ def update_with_identity_claims(
     updated = False
     try:
         repository.claim_lookup_values(operation, values_to_claim)
-        ensure_lookup_values_available(context.find, entry, entry["id"])
-        repository.update(entry)
+        ensure_lookup_values_available(context.find, values_to_claim, entry["id"])
+        repository.update(entry, expected_server_owned_fields)
         updated = True
         repository.commit_lookup_values(operation, datetime.now(timezone.utc))
         repository.retire_lookup_values(
@@ -97,9 +115,11 @@ def update_with_identity_claims(
 
 
 def ensure_lookup_values_available(
-    find: Callable[[str], dict], entry: dict[str, Any], allowed_id: str | None = None
+    find: Callable[[str], dict],
+    values: Sequence[str],
+    allowed_id: str | None = None,
 ) -> None:
-    for value in bibliography_lookup_values(entry):
+    for value in values:
         try:
             existing_entry = find(value)
         except NotFoundError:

--- a/ebl/bibliography/application/bibliography_identity.py
+++ b/ebl/bibliography/application/bibliography_identity.py
@@ -3,10 +3,14 @@
 `update_with_identity_claims` is the only path allowed to change the
 server-owned identity of an entry: it diffs the lookup values, claims the added
 ones, retires the removed ones, and recovers reservations when persistence
-fails. `Bibliography.update` is the generic CSL metadata editor and deliberately
-calls this primitive with identity preserved, so a metadata edit never claims or
-retires anything. Callers that need to mutate identity must supply the new
-values themselves rather than routing through the metadata editor.
+fails. `Bibliography.update_metadata` is the generic CSL metadata editor and
+deliberately calls this primitive with identity preserved, so a metadata edit
+never claims or retires anything.
+
+The claim/retire path itself is parked for a future identity-management
+endpoint (deprecate, redirect, repair identity) — no caller supplying new
+identity values exists yet. Such a caller would supply them directly rather
+than routing through the metadata editor.
 """
 
 from dataclasses import dataclass

--- a/ebl/bibliography/application/bibliography_repository.py
+++ b/ebl/bibliography/application/bibliography_repository.py
@@ -19,11 +19,23 @@ class LookupValueInUseError(DuplicateError):
 
 
 class BibliographyUpdateConflictError(DuplicateError):
-    def __init__(self, id_: str):
+    """The server-owned state the update was based on is no longer current.
+
+    Raised both when the submitted entry disagrees with the stored identity
+    state and when another operation changes it while the update runs. The
+    remedy is the same in either case: reload the entry and retry.
+    """
+
+    def __init__(self, id_: str, fields: Sequence[str] = ()):
         self.id_ = id_
+        self.fields = tuple(fields)
+        cause = (
+            f"does not match the stored server-owned state ({', '.join(self.fields)})"
+            if self.fields
+            else "was changed by another operation"
+        )
         super().__init__(
-            f"Bibliography entry {id_} was changed by another operation; "
-            "reload the entry and retry."
+            f"Bibliography entry {id_} {cause}; reload the entry and retry."
         )
 
 

--- a/ebl/bibliography/application/bibliography_repository.py
+++ b/ebl/bibliography/application/bibliography_repository.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
 from ebl.errors import DuplicateError
@@ -16,6 +16,15 @@ class LookupValueInUseError(DuplicateError):
     def __init__(self, value: str):
         self.value = value
         super().__init__(f"Bibliography lookup value {value} is in use.")
+
+
+class BibliographyUpdateConflictError(DuplicateError):
+    def __init__(self, id_: str):
+        self.id_ = id_
+        super().__init__(
+            f"Bibliography entry {id_} was changed by another operation; "
+            "reload the entry and retry."
+        )
 
 
 class BibliographyRepository(ABC):
@@ -74,7 +83,9 @@ class BibliographyRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def update(self, entry: Any) -> None:
+    def update(
+        self, entry: Any, expected_server_owned_fields: Mapping[str, Any]
+    ) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/ebl/bibliography/application/bibliography_repository.py
+++ b/ebl/bibliography/application/bibliography_repository.py
@@ -29,14 +29,15 @@ class BibliographyUpdateConflictError(DuplicateError):
     def __init__(self, id_: str, fields: Sequence[str] = ()):
         self.id_ = id_
         self.fields = tuple(fields)
+        super().__init__(id_, fields)
+
+    def __str__(self) -> str:
         cause = (
             f"does not match the stored server-owned state ({', '.join(self.fields)})"
             if self.fields
             else "was changed by another operation"
         )
-        super().__init__(
-            f"Bibliography entry {id_} {cause}; reload the entry and retry."
-        )
+        return f"Bibliography entry {self.id_} {cause}; reload the entry and retry."
 
 
 class BibliographyRepository(ABC):

--- a/ebl/bibliography/application/partner_bibliography.py
+++ b/ebl/bibliography/application/partner_bibliography.py
@@ -18,6 +18,9 @@ from ebl.bibliography.application.partner_identity import (
     generate_partner_citation_key,
     select_canonical_bibliography_id,
 )
+from ebl.bibliography.application.server_owned_fields import (
+    preserve_server_owned_fields,
+)
 from ebl.bibliography.domain.bibliography_entry import (
     CSL_JSON_SCHEMA,
     SERVER_OWNED_BIBLIOGRAPHY_FIELDS,
@@ -81,15 +84,9 @@ class PartnerBibliography:
     def update_entry(self, id_: str, entry: dict, user: User) -> Optional[dict]:
         self._reject_server_owned_fields(entry)
         stored_entry = self._bibliography.find(id_)
-        updated_entry = {
-            "id": stored_entry["id"],
-            **self._project_metadata(entry),
-            **{
-                field: stored_entry[field]
-                for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
-                if field in stored_entry
-            },
-        }
+        updated_entry = preserve_server_owned_fields(
+            {"id": stored_entry["id"], **self._project_metadata(entry)}, stored_entry
+        )
         self._validate_internal_entry(updated_entry)
         if duplicate_result := self._find_blocking_duplicate_candidates(updated_entry):
             return duplicate_result

--- a/ebl/bibliography/application/partner_bibliography.py
+++ b/ebl/bibliography/application/partner_bibliography.py
@@ -42,7 +42,7 @@ class BibliographyCore(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def update(self, entry: dict, user: User) -> None:
+    def update_metadata(self, entry: dict, user: User) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -90,7 +90,7 @@ class PartnerBibliography:
         self._validate_internal_entry(updated_entry)
         if duplicate_result := self._find_blocking_duplicate_candidates(updated_entry):
             return duplicate_result
-        self._bibliography.update(updated_entry, user)
+        self._bibliography.update_metadata(updated_entry, user)
         return None
 
     def export_page(

--- a/ebl/bibliography/application/redirect_resolution.py
+++ b/ebl/bibliography/application/redirect_resolution.py
@@ -1,0 +1,42 @@
+from typing import Callable
+
+from ebl.errors import DuplicateError, NotFoundError
+
+MAX_REDIRECT_DEPTH = 5
+
+
+def follow_bibliography_redirect(
+    entry: dict, query_by_id: Callable[[str], dict]
+) -> dict:
+    current = entry
+    visited_ids: set[str] = set()
+    redirects_followed = 0
+
+    while current.get("deprecated", False):
+        current_id = current.get("id")
+        redirect_to = current.get("redirectTo")
+        if not isinstance(redirect_to, str) or not redirect_to:
+            raise NotFoundError(
+                f"Deprecated bibliography {current_id} has no redirect target."
+            )
+        if current_id in visited_ids or redirect_to in visited_ids:
+            raise DuplicateError(
+                f"Bibliography redirect loop detected at {current_id}."
+            )
+        if redirects_followed >= MAX_REDIRECT_DEPTH:
+            raise DuplicateError(
+                f"Bibliography redirect from {entry.get('id')} exceeds "
+                f"the maximum depth of {MAX_REDIRECT_DEPTH}."
+            )
+
+        if isinstance(current_id, str):
+            visited_ids.add(current_id)
+        try:
+            current = query_by_id(redirect_to)
+        except NotFoundError as error:
+            raise NotFoundError(
+                f"Bibliography redirect target {redirect_to} not found."
+            ) from error
+        redirects_followed += 1
+
+    return current

--- a/ebl/bibliography/application/server_owned_fields.py
+++ b/ebl/bibliography/application/server_owned_fields.py
@@ -1,7 +1,14 @@
-from typing import Any, Mapping
+from copy import deepcopy
+from typing import Any, Mapping, cast
 
 from ebl.bibliography.domain.bibliography_entry import (
+    CSL_JSON_SCHEMA,
     SERVER_OWNED_BIBLIOGRAPHY_FIELDS,
+)
+
+CLIENT_EDITABLE_BIBLIOGRAPHY_FIELDS = (
+    frozenset(cast(dict[str, Any], CSL_JSON_SCHEMA["properties"]))
+    - SERVER_OWNED_BIBLIOGRAPHY_FIELDS
 )
 
 
@@ -13,12 +20,32 @@ def strip_server_owned_fields(entry: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-def stored_server_owned_fields(stored_entry: Mapping[str, Any]) -> dict[str, Any]:
+def client_editable_fields(entry: Mapping[str, Any]) -> dict[str, Any]:
     return {
-        field: stored_entry[field]
-        for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
-        if field in stored_entry
+        key: value
+        for key, value in entry.items()
+        if key in CLIENT_EDITABLE_BIBLIOGRAPHY_FIELDS
     }
+
+
+def stored_server_owned_fields(stored_entry: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(
+        {
+            field: stored_entry[field]
+            for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+            if field in stored_entry
+        }
+    )
+
+
+def stored_preserved_fields(stored_entry: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(
+        {
+            key: value
+            for key, value in stored_entry.items()
+            if key not in CLIENT_EDITABLE_BIBLIOGRAPHY_FIELDS
+        }
+    )
 
 
 def preserve_server_owned_fields(
@@ -27,4 +54,13 @@ def preserve_server_owned_fields(
     return {
         **strip_server_owned_fields(entry),
         **stored_server_owned_fields(stored_entry),
+    }
+
+
+def preserve_persisted_fields(
+    entry: Mapping[str, Any], stored_entry: Mapping[str, Any]
+) -> dict[str, Any]:
+    return {
+        **client_editable_fields(entry),
+        **stored_preserved_fields(stored_entry),
     }

--- a/ebl/bibliography/application/server_owned_fields.py
+++ b/ebl/bibliography/application/server_owned_fields.py
@@ -1,0 +1,30 @@
+from typing import Any, Mapping
+
+from ebl.bibliography.domain.bibliography_entry import (
+    SERVER_OWNED_BIBLIOGRAPHY_FIELDS,
+)
+
+
+def strip_server_owned_fields(entry: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in entry.items()
+        if key not in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+    }
+
+
+def stored_server_owned_fields(stored_entry: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        field: stored_entry[field]
+        for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+        if field in stored_entry
+    }
+
+
+def preserve_server_owned_fields(
+    entry: Mapping[str, Any], stored_entry: Mapping[str, Any]
+) -> dict[str, Any]:
+    return {
+        **strip_server_owned_fields(entry),
+        **stored_server_owned_fields(stored_entry),
+    }

--- a/ebl/bibliography/application/server_owned_fields.py
+++ b/ebl/bibliography/application/server_owned_fields.py
@@ -1,3 +1,17 @@
+"""Splitting a bibliography entry into client-owned and server-owned parts.
+
+Two helpers rebuild an entry from a submission plus stored state and are easy
+to confuse:
+
+* `preserve_server_owned_fields` keeps every submitted key except the
+  server-owned ones and overlays the stored server-owned values. Callers that
+  have already projected the submission to known metadata use it.
+* `preserve_persisted_fields` keeps only submitted keys that are client
+  editable and overlays everything else the stored document holds, including
+  keys outside the CSL schema. The generic update uses it so unknown persisted
+  fields survive an edit.
+"""
+
 from copy import deepcopy
 from typing import Any, Mapping, cast
 

--- a/ebl/bibliography/application/server_owned_fields.py
+++ b/ebl/bibliography/application/server_owned_fields.py
@@ -64,3 +64,13 @@ def preserve_persisted_fields(
         **client_editable_fields(entry),
         **stored_preserved_fields(stored_entry),
     }
+
+
+def changed_server_owned_fields(
+    entry: Mapping[str, Any], stored_entry: Mapping[str, Any]
+) -> list[str]:
+    return sorted(
+        field
+        for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+        if field in entry and entry[field] != stored_entry.get(field)
+    )

--- a/ebl/bibliography/application/server_owned_fields.py
+++ b/ebl/bibliography/application/server_owned_fields.py
@@ -10,10 +10,19 @@ to confuse:
   editable and overlays everything else the stored document holds, including
   keys outside the CSL schema. The generic update uses it so unknown persisted
   fields survive an edit.
+
+`changed_server_owned_fields` reports which of them a submission disagrees with.
+It compares `aliases` as an order-insensitive multiset, because no production
+code reads an alias by position: lookup values are collected into a set, and
+Mongo matches `aliases.normalizedValue` against the array as a whole. An editor
+that re-serialises the list in another order has not changed the identity, so it
+is not a conflict, while an alias added, removed, duplicated or edited still is.
+Only the comparison is canonicalised — the stored order is never rewritten.
 """
 
+import json
 from copy import deepcopy
-from typing import Any, Mapping, cast
+from typing import Any, Mapping, Sequence, cast
 
 from ebl.bibliography.domain.bibliography_entry import (
     CSL_JSON_SCHEMA,
@@ -80,11 +89,25 @@ def preserve_persisted_fields(
     }
 
 
+def canonical_aliases(aliases: Sequence[Any]) -> list[str]:
+    return sorted(json.dumps(alias, sort_keys=True, default=str) for alias in aliases)
+
+
+def comparable_server_owned_value(field: str, value: Any) -> Any:
+    return (
+        canonical_aliases(value)
+        if field == "aliases" and isinstance(value, list)
+        else value
+    )
+
+
 def changed_server_owned_fields(
     entry: Mapping[str, Any], stored_entry: Mapping[str, Any]
 ) -> list[str]:
     return sorted(
         field
         for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
-        if field in entry and entry[field] != stored_entry.get(field)
+        if field in entry
+        and comparable_server_owned_value(field, entry[field])
+        != comparable_server_owned_value(field, stored_entry.get(field))
     )

--- a/ebl/bibliography/application/update_target.py
+++ b/ebl/bibliography/application/update_target.py
@@ -1,0 +1,50 @@
+"""Choosing which stored record a metadata update is allowed to write to.
+
+`Bibliography.find` resolves a citation key, an alias or a redirect and answers
+with the canonical entry. An update deliberately does not: a write names one
+exact record, because a client that edited what it believed was one entry must
+never silently overwrite a different one that an identifier happened to resolve
+to. Reads may follow identity, writes may not.
+
+Both non-canonical identifiers are therefore refused, and each refusal names the
+record the caller should edit instead rather than leaving them with a bare
+`404`: a deprecated id points at its redirect target, and a citation key or
+alias points at the entry it belongs to. An identifier that resolves to nothing
+at all stays a `404`.
+"""
+
+from typing import Callable
+
+from ebl.errors import DataError, NotFoundError
+
+
+def stored_entry_for_update(
+    entry: dict,
+    query_by_id: Callable[[str], dict],
+    find: Callable[[str], dict],
+) -> dict:
+    id_ = entry.get("id")
+    if not isinstance(id_, str) or not id_:
+        raise DataError("Bibliography entry id is required.")
+    stored_entry = query_canonical_entry(id_, query_by_id, find)
+    if stored_entry.get("deprecated"):
+        raise DataError(
+            f"Bibliography entry {id_} is deprecated; "
+            f"edit {stored_entry.get('redirectTo')} instead."
+        )
+    return stored_entry
+
+
+def query_canonical_entry(
+    id_: str,
+    query_by_id: Callable[[str], dict],
+    find: Callable[[str], dict],
+) -> dict:
+    try:
+        return query_by_id(id_)
+    except NotFoundError as error:
+        canonical_entry = find(id_)
+        raise DataError(
+            f"Bibliography entry {id_} cannot be edited through a citation key "
+            f"or alias; edit {canonical_entry['id']} instead."
+        ) from error

--- a/ebl/bibliography/infrastructure/bibliography.py
+++ b/ebl/bibliography/infrastructure/bibliography.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 import pymongo
 
-from ebl.bibliography.application.bibliography_repository import BibliographyRepository
+from ebl.bibliography.application.bibliography_repository import (
+    BibliographyRepository,
+    BibliographyUpdateConflictError,
+)
 from ebl.bibliography.application.duplicate_audit import PROJECTION
 from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
 from ebl.bibliography.application.partner_identity import normalize_partner_id
@@ -11,9 +14,14 @@ from ebl.bibliography.application.serialization import (
     create_mongo_entry,
     create_object_entry,
 )
+from ebl.bibliography.infrastructure.bibliography_queries import (
+    ACTIVE_BIBLIOGRAPHY_FILTER,
+    author_year_title_match,
+    bibliography_query_pipeline,
+    server_owned_state_filter,
+)
 from ebl.bibliography.infrastructure.duplicate_candidate_queries import (
     duplicate_candidate_queries,
-    year_range,
 )
 from ebl.bibliography.infrastructure.lookup_reservations import MongoLookupReservations
 from ebl.bibliography.infrastructure.reference_documents import join_reference_documents
@@ -22,7 +30,6 @@ from ebl.mongo_collection import MongoCollection
 
 COLLECTION = "bibliography"
 DUPLICATE_CANDIDATE_QUERY_MAX_TIME_MS = 5000
-ACTIVE_BIBLIOGRAPHY_FILTER = {"deprecated": {"$ne": True}}
 ALIASES_VALUE_FIELD = "aliases.value"
 __all__ = ["MongoBibliographyRepository", "join_reference_documents"]
 
@@ -109,9 +116,18 @@ class MongoBibliographyRepository(BibliographyRepository):
         data = self._collection.find_many({"_id": {"$in": ids}})
         return [create_object_entry(item) for item in data]
 
-    def update(self, entry) -> None:
+    def update(self, entry, expected_server_owned_fields: Mapping[str, Any]) -> None:
         mongo_entry = create_mongo_entry(entry)
-        self._collection.replace_one(mongo_entry)
+        id_ = mongo_entry["_id"]
+        try:
+            self._collection.replace_one(
+                mongo_entry,
+                filter_=server_owned_state_filter(id_, expected_server_owned_fields),
+            )
+        except NotFoundError as error:
+            if not self._collection.exists({"_id": id_}):
+                raise
+            raise BibliographyUpdateConflictError(id_) from error
 
     def query_by_author_year_and_title(
         self, author: Optional[str], year: Optional[int], title: Optional[str]
@@ -186,37 +202,3 @@ class MongoBibliographyRepository(BibliographyRepository):
 
         matching_ids = self._collection.get_all_values("_id", lookup_query)
         return matching_ids == [entry_id]
-
-
-def author_year_title_match(
-    author: Optional[str], year: Optional[int], title: Optional[str]
-) -> Dict[str, Any]:
-    match: Dict[str, Any] = {}
-    if author:
-        match["author.0.family"] = author
-    if year:
-        match["issued.date-parts.0.0"] = year_range(year)
-    if title:
-        match["$expr"] = {"$eq": [{"$substrCP": ["$title", 0, len(title)]}, title]}
-    return match
-
-
-def bibliography_query_pipeline(
-    match: Dict[str, Any], trailing_sort_field: str
-) -> list[dict]:
-    return [
-        {"$match": {**match, **ACTIVE_BIBLIOGRAPHY_FILTER}},
-        {"$addFields": {"primaryYear": primary_year_expression()}},
-        {
-            "$sort": {
-                "author.0.family": 1,
-                "primaryYear": 1,
-                trailing_sort_field: 1,
-            }
-        },
-        {"$project": {"primaryYear": 0}},
-    ]
-
-
-def primary_year_expression() -> dict:
-    return {"$arrayElemAt": [{"$arrayElemAt": ["$issued.date-parts", 0]}, 0]}

--- a/ebl/bibliography/infrastructure/bibliography_queries.py
+++ b/ebl/bibliography/infrastructure/bibliography_queries.py
@@ -8,6 +8,15 @@ from ebl.bibliography.infrastructure.duplicate_candidate_queries import year_ran
 ACTIVE_BIBLIOGRAPHY_FILTER = {"deprecated": {"$ne": True}}
 
 
+def expected_field_match(value: Any) -> Any:
+    """Match exactly the stored value, distinguishing null from absent.
+
+    A bare ``None`` also matches documents where the field is missing, which
+    would let a concurrent removal slip past the compare-and-set.
+    """
+    return {"$type": "null"} if value is None else value
+
+
 def server_owned_state_filter(
     id_: str, expected_server_owned_fields: Mapping[str, Any]
 ) -> Dict[str, Any]:
@@ -15,7 +24,7 @@ def server_owned_state_filter(
         "_id": id_,
         **{
             field: (
-                expected_server_owned_fields[field]
+                expected_field_match(expected_server_owned_fields[field])
                 if field in expected_server_owned_fields
                 else {"$exists": False}
             )

--- a/ebl/bibliography/infrastructure/bibliography_queries.py
+++ b/ebl/bibliography/infrastructure/bibliography_queries.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, Mapping, Optional
+
+from ebl.bibliography.domain.bibliography_entry import (
+    SERVER_OWNED_BIBLIOGRAPHY_FIELDS,
+)
+from ebl.bibliography.infrastructure.duplicate_candidate_queries import year_range
+
+ACTIVE_BIBLIOGRAPHY_FILTER = {"deprecated": {"$ne": True}}
+
+
+def server_owned_state_filter(
+    id_: str, expected_server_owned_fields: Mapping[str, Any]
+) -> Dict[str, Any]:
+    return {
+        "_id": id_,
+        **{
+            field: (
+                expected_server_owned_fields[field]
+                if field in expected_server_owned_fields
+                else {"$exists": False}
+            )
+            for field in sorted(SERVER_OWNED_BIBLIOGRAPHY_FIELDS)
+        },
+    }
+
+
+def author_year_title_match(
+    author: Optional[str], year: Optional[int], title: Optional[str]
+) -> Dict[str, Any]:
+    match: Dict[str, Any] = {}
+    if author:
+        match["author.0.family"] = author
+    if year:
+        match["issued.date-parts.0.0"] = year_range(year)
+    if title:
+        match["$expr"] = {"$eq": [{"$substrCP": ["$title", 0, len(title)]}, title]}
+    return match
+
+
+def bibliography_query_pipeline(
+    match: Dict[str, Any], trailing_sort_field: str
+) -> list[dict]:
+    return [
+        {"$match": {**match, **ACTIVE_BIBLIOGRAPHY_FILTER}},
+        {"$addFields": {"primaryYear": primary_year_expression()}},
+        {
+            "$sort": {
+                "author.0.family": 1,
+                "primaryYear": 1,
+                trailing_sort_field: 1,
+            }
+        },
+        {"$project": {"primaryYear": 0}},
+    ]
+
+
+def primary_year_expression() -> dict:
+    return {"$arrayElemAt": [{"$arrayElemAt": ["$issued.date-parts", 0]}, 0]}

--- a/ebl/bibliography/web/bibliography_entries.py
+++ b/ebl/bibliography/web/bibliography_entries.py
@@ -15,11 +15,14 @@ from ebl.bibliography.domain.bibliography_entry import (
 )
 from ebl.errors import DataError
 from ebl.users.web.require_scope import require_scope
+from ebl.users.web.user_request import UserRequest
 from ebl.bibliography.application.bibliography import Bibliography
 from ebl.bibliography.application.duplicate_override import DuplicateOverrideError
 
 
-def submitted_server_owned_fields(candidate_entries: Sequence[Mapping]) -> list[str]:
+def submitted_server_owned_fields(
+    candidate_entries: Sequence[Mapping[str, object]],
+) -> list[str]:
     return sorted(
         {
             field
@@ -46,18 +49,6 @@ def reject_server_owned_partner_fields(req, _resp, _resource, _params) -> None:
         )
 
 
-def reject_server_owned_bibliography_fields(req, _resp, _resource, _params) -> None:
-    media = req.media
-    if not isinstance(media, dict):
-        return
-
-    if forbidden_fields := submitted_server_owned_fields([media]):
-        raise DataError(
-            "Bibliography metadata updates may not include server-owned fields: "
-            f"{', '.join(forbidden_fields)}. These are maintained by the server."
-        )
-
-
 class BibliographyResource:
     def __init__(self, bibliography: Bibliography):
         self._bibliography = bibliography
@@ -67,7 +58,7 @@ class BibliographyResource:
 
     @falcon.before(require_scope, "write:bibliography")
     @validate(CSL_JSON_SCHEMA)
-    def on_post(self, req: Request, resp: Response) -> None:
+    def on_post(self, req: UserRequest, resp: Response) -> None:
         bibliography_entry = req.media
         self._bibliography.create(bibliography_entry, req.context.user)
         resp.status = falcon.HTTP_CREATED
@@ -83,11 +74,10 @@ class BibliographyEntriesResource:
         resp.media = self._bibliography.find(id_)
 
     @falcon.before(require_scope, "write:bibliography")
-    @falcon.before(reject_server_owned_bibliography_fields)
     @validate(CSL_JSON_SCHEMA)
-    def on_post(self, req: Request, resp: Response, id_: str) -> None:
+    def on_post(self, req: UserRequest, resp: Response, id_: str) -> None:
         entry = {**req.media, "id": id_}
-        self._bibliography.update(entry, req.context.user)
+        self._bibliography.update_metadata(entry, req.context.user)
         resp.status = falcon.HTTP_NO_CONTENT
 
 
@@ -139,7 +129,7 @@ class PartnerBibliographyResource:
     @falcon.before(require_scope, "write:bibliography")
     @falcon.before(reject_server_owned_partner_fields)
     @validate(PARTNER_CSL_JSON_SCHEMA)
-    def on_post(self, req: Request, resp: Response) -> None:
+    def on_post(self, req: UserRequest, resp: Response) -> None:
         bibliography_entry = req.media
         if duplicate_result := self._bibliography.create_partner_entry(
             bibliography_entry, req.context.user
@@ -163,7 +153,9 @@ class PartnerBibliographyEntryResource:
     @falcon.before(require_scope, "write:bibliography")
     @falcon.before(reject_server_owned_partner_fields)
     @validate(PARTNER_CSL_JSON_SCHEMA)
-    def on_post(self, req: Request, resp: Response, id_or_citation_key: str) -> None:
+    def on_post(
+        self, req: UserRequest, resp: Response, id_or_citation_key: str
+    ) -> None:
         if duplicate_result := self._bibliography.update_partner_entry(
             id_or_citation_key, req.media, req.context.user
         ):
@@ -195,7 +187,7 @@ class PartnerBibliographyDuplicateOverrideResource:
     @falcon.before(require_scope, "write:bibliography")
     @falcon.before(reject_server_owned_partner_fields)
     @validate(PARTNER_DUPLICATE_OVERRIDE_JSON_SCHEMA)
-    def on_post(self, req: Request, resp: Response) -> None:
+    def on_post(self, req: UserRequest, resp: Response) -> None:
         bibliography_entry = req.media["bibliographyEntry"]
         override = req.media["override"]
 

--- a/ebl/bibliography/web/bibliography_entries.py
+++ b/ebl/bibliography/web/bibliography_entries.py
@@ -3,6 +3,7 @@ from falcon_caching import Cache
 from falcon import Request, Response
 from falcon.media.validators.jsonschema import validate
 import json
+from typing import Mapping, Sequence
 from ebl.cache.application.cache import DAILY_TIMEOUT
 
 from ebl.bibliography.domain.bibliography_entry import (
@@ -18,6 +19,17 @@ from ebl.bibliography.application.bibliography import Bibliography
 from ebl.bibliography.application.duplicate_override import DuplicateOverrideError
 
 
+def submitted_server_owned_fields(candidate_entries: Sequence[Mapping]) -> list[str]:
+    return sorted(
+        {
+            field
+            for entry in candidate_entries
+            for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
+            if field in entry
+        }
+    )
+
+
 def reject_server_owned_partner_fields(req, _resp, _resource, _params) -> None:
     media = req.media
     if not isinstance(media, dict):
@@ -27,18 +39,22 @@ def reject_server_owned_partner_fields(req, _resp, _resource, _params) -> None:
     if isinstance(media.get("bibliographyEntry"), dict):
         candidate_entries.append(media["bibliographyEntry"])
 
-    forbidden_fields = sorted(
-        {
-            field
-            for entry in candidate_entries
-            for field in SERVER_OWNED_BIBLIOGRAPHY_FIELDS
-            if field in entry
-        }
-    )
-    if forbidden_fields:
+    if forbidden_fields := submitted_server_owned_fields(candidate_entries):
         raise DataError(
             "Partner bibliography payload may not include server-owned fields: "
             f"{', '.join(forbidden_fields)}."
+        )
+
+
+def reject_server_owned_bibliography_fields(req, _resp, _resource, _params) -> None:
+    media = req.media
+    if not isinstance(media, dict):
+        return
+
+    if forbidden_fields := submitted_server_owned_fields([media]):
+        raise DataError(
+            "Bibliography metadata updates may not include server-owned fields: "
+            f"{', '.join(forbidden_fields)}. These are maintained by the server."
         )
 
 
@@ -67,6 +83,7 @@ class BibliographyEntriesResource:
         resp.media = self._bibliography.find(id_)
 
     @falcon.before(require_scope, "write:bibliography")
+    @falcon.before(reject_server_owned_bibliography_fields)
     @validate(CSL_JSON_SCHEMA)
     def on_post(self, req: Request, resp: Response, id_: str) -> None:
         entry = {**req.media, "id": id_}

--- a/ebl/bibliography/web/bibliography_entries.py
+++ b/ebl/bibliography/web/bibliography_entries.py
@@ -1,3 +1,16 @@
+"""Bibliography HTTP resources.
+
+`METADATA_UPDATE_JSON_SCHEMA` is `CSL_JSON_SCHEMA` without its lifecycle rule.
+The stored schema requires `redirectTo` whenever `deprecated` is true, which is
+an invariant of a *stored* entry. Applied to an update body it answered a client
+that submitted `deprecated` with `'redirectTo' is a required property` — a `400`
+about a field the client does not own, raised before the application could give
+the real answer, that the submitted state simply disagrees with what is stored.
+Dropping the rule from this one route lets that reach `update_metadata` and come
+back as a conflict. Every property keeps its shape, so an editor can still post
+back the whole entry it fetched, and `CSL_JSON_SCHEMA` itself is untouched.
+"""
+
 import falcon
 from falcon_caching import Cache
 from falcon import Request, Response
@@ -18,6 +31,11 @@ from ebl.users.web.require_scope import require_scope
 from ebl.users.web.user_request import UserRequest
 from ebl.bibliography.application.bibliography import Bibliography
 from ebl.bibliography.application.duplicate_override import DuplicateOverrideError
+
+
+METADATA_UPDATE_JSON_SCHEMA = {
+    key: value for key, value in CSL_JSON_SCHEMA.items() if key != "allOf"
+}
 
 
 def submitted_server_owned_fields(
@@ -74,7 +92,7 @@ class BibliographyEntriesResource:
         resp.media = self._bibliography.find(id_)
 
     @falcon.before(require_scope, "write:bibliography")
-    @validate(CSL_JSON_SCHEMA)
+    @validate(METADATA_UPDATE_JSON_SCHEMA)
     def on_post(self, req: UserRequest, resp: Response, id_: str) -> None:
         entry = {**req.media, "id": id_}
         self._bibliography.update_metadata(entry, req.context.user)

--- a/ebl/bibliography/web/bibliography_entries.py
+++ b/ebl/bibliography/web/bibliography_entries.py
@@ -7,8 +7,18 @@ that submitted `deprecated` with `'redirectTo' is a required property` — a `40
 about a field the client does not own, raised before the application could give
 the real answer, that the submitted state simply disagrees with what is stored.
 Dropping the rule from this one route lets that reach `update_metadata` and come
-back as a conflict. Every property keeps its shape, so an editor can still post
-back the whole entry it fetched, and `CSL_JSON_SCHEMA` itself is untouched.
+back as a conflict. Every property keeps its shape, and `CSL_JSON_SCHEMA` itself
+is untouched.
+
+It also allows additional properties, unlike the stored schema. GET serialises
+the whole stored document, and a persisted entry can carry keys outside
+`CSL_JSON_SCHEMA` that `preserve_persisted_fields` deliberately keeps across an
+edit instead of destroying them. Rejecting those keys here would mean an editor
+can fetch an entry and then fail to save it back unchanged. This does not open
+the door to a client inventing a new unknown field: `preserve_persisted_fields`
+only reads submitted keys that are already client-editable, so an unrecognised
+key in the request body is silently ignored either way — the schema accepting
+it only stops a spurious `400` on the legitimate round trip.
 """
 
 import falcon
@@ -34,7 +44,8 @@ from ebl.bibliography.application.duplicate_override import DuplicateOverrideErr
 
 
 METADATA_UPDATE_JSON_SCHEMA = {
-    key: value for key, value in CSL_JSON_SCHEMA.items() if key != "allOf"
+    **{key: value for key, value in CSL_JSON_SCHEMA.items() if key != "allOf"},
+    "additionalProperties": True,
 }
 
 

--- a/ebl/tests/bibliography/conftest.py
+++ b/ebl/tests/bibliography/conftest.py
@@ -1,6 +1,33 @@
 import pytest
 
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CITATION_KEY,
+    PARTNER_ALIAS,
+)
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+@pytest.fixture
+def aliased_entry(bibliography, user):
+    entry = BibliographyEntryFactory.build(
+        id="Q30000024",
+        title="Old title",
+        aliases=[PARTNER_ALIAS],
+        citationKey=CITATION_KEY,
+    )
+    bibliography.create(entry, user)
+    return entry
+
+
+@pytest.fixture
+def deprecated_entry(bibliography, user):
+    canonical_entry = BibliographyEntryFactory.build(id="rla_9_388", title="Canonical")
+    bibliography.create(canonical_entry, user)
+    entry = BibliographyEntryFactory.build(
+        id="RN2001", title="Loser", deprecated=True, redirectTo="rla_9_388"
+    )
+    bibliography.create(entry, user)
+    return entry
 
 
 @pytest.fixture

--- a/ebl/tests/bibliography/duplicate_detection_test_helpers.py
+++ b/ebl/tests/bibliography/duplicate_detection_test_helpers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from ebl.bibliography.application.bibliography_repository import BibliographyRepository
 from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
@@ -51,7 +51,9 @@ class FakeBibliographyRepository(BibliographyRepository):
     def query_by_ids(self, ids: Sequence[str]) -> Sequence[Any]:
         raise NotImplementedError
 
-    def update(self, entry: Any) -> None:
+    def update(
+        self, entry: Any, expected_server_owned_fields: Mapping[str, Any]
+    ) -> None:
         raise NotImplementedError
 
     def query_by_author_year_and_title(

--- a/ebl/tests/bibliography/identity_preservation_test_helpers.py
+++ b/ebl/tests/bibliography/identity_preservation_test_helpers.py
@@ -1,0 +1,33 @@
+import json
+
+import pydash
+from falcon import testing
+
+PARTNER_ALIAS = {
+    "value": "dossin1967archives",
+    "normalizedValue": "dossin1967archives",
+    "type": "partner_id",
+    "source": "partner_request",
+    "status": "redirect",
+}
+CITATION_KEY = "dossin1967La"
+CORRECTED_TITLE = "Corrected title"
+RESERVATIONS = "bibliography_lookup_reservations"
+
+
+def metadata_only_payload(entry: dict) -> dict:
+    return pydash.omit(
+        {**entry, "title": CORRECTED_TITLE},
+        "aliases",
+        "citationKey",
+        "deprecated",
+        "redirectTo",
+    )
+
+
+def post_entry(client, entry: dict) -> testing.Result:
+    return client.simulate_post(f"/bibliography/{entry['id']}", body=json.dumps(entry))
+
+
+def reservations(database) -> dict:
+    return {document["_id"]: document for document in database[RESERVATIONS].find({})}

--- a/ebl/tests/bibliography/test_alias_ordering_conflicts.py
+++ b/ebl/tests/bibliography/test_alias_ordering_conflicts.py
@@ -1,0 +1,116 @@
+"""Alias order is not identity.
+
+No production code reads an alias by position: lookup values are collected into
+a set, and Mongo matches `aliases.normalizedValue` against the array as a whole.
+An editor that re-serialises the list in another order has therefore changed
+nothing, and must not be told to reload. Anything that changes the multiset --
+an alias added, removed, duplicated or edited -- is still a conflict, and the
+stored order is never rewritten by a submission.
+"""
+
+import falcon
+import pytest
+
+from ebl.bibliography.application.server_owned_fields import (
+    canonical_aliases,
+    changed_server_owned_fields,
+)
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CORRECTED_TITLE,
+    post_entry,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+ALIAS_A = {
+    "value": "RN9001",
+    "normalizedValue": "rn9001",
+    "type": "legacy_id",
+    "source": "duplicate_merge_2026-08-04",
+    "status": "redirect",
+}
+ALIAS_B = {"value": "RN9002", "normalizedValue": "rn9002"}
+ALIAS_C = {"value": "RN9003", "normalizedValue": "rn9003"}
+STORED_ORDER = [ALIAS_A, ALIAS_B]
+EDITED_ALIAS_A = {**ALIAS_A, "status": "active"}
+
+
+@pytest.fixture
+def multi_alias_entry(bibliography, user):
+    entry = BibliographyEntryFactory.build(
+        id="Q30000501", title="Original", aliases=list(STORED_ORDER)
+    )
+    bibliography.create(entry, user)
+    return entry
+
+
+def submission(entry: dict, aliases: list) -> dict:
+    return {**entry, "title": CORRECTED_TITLE, "aliases": aliases}
+
+
+@pytest.mark.parametrize(
+    "aliases", [STORED_ORDER, list(reversed(STORED_ORDER))], ids=["same", "reversed"]
+)
+def test_the_same_aliases_in_any_order_are_accepted(
+    aliases, client, bibliography, multi_alias_entry
+):
+    result = post_entry(client, submission(multi_alias_entry, list(aliases)))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert bibliography.find(multi_alias_entry["id"])["title"] == CORRECTED_TITLE
+
+
+def test_a_reordered_submission_does_not_rewrite_the_stored_order(
+    client, bibliography, multi_alias_entry
+):
+    post_entry(client, submission(multi_alias_entry, list(reversed(STORED_ORDER))))
+
+    assert bibliography.find(multi_alias_entry["id"])["aliases"] == STORED_ORDER
+
+
+@pytest.mark.parametrize(
+    "aliases",
+    [
+        [*STORED_ORDER, ALIAS_C],
+        [ALIAS_A],
+        [EDITED_ALIAS_A, ALIAS_B],
+        [ALIAS_A, ALIAS_A],
+    ],
+    ids=["added", "removed", "edited", "duplicated"],
+)
+def test_a_changed_alias_multiset_is_still_a_conflict(
+    aliases, client, bibliography, multi_alias_entry
+):
+    result = post_entry(client, submission(multi_alias_entry, list(aliases)))
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "aliases" in result.text
+    assert bibliography.find(multi_alias_entry["id"])["aliases"] == STORED_ORDER
+
+
+def test_canonical_aliases_is_order_insensitive_but_keeps_duplicates():
+    assert canonical_aliases(STORED_ORDER) == canonical_aliases(
+        list(reversed(STORED_ORDER))
+    )
+    assert canonical_aliases([ALIAS_A, ALIAS_A]) != canonical_aliases([ALIAS_A])
+
+
+def test_changed_server_owned_fields_ignores_alias_order_only():
+    stored_entry = {"aliases": STORED_ORDER, "citationKey": "dossin1967La"}
+
+    assert (
+        changed_server_owned_fields(
+            {"aliases": list(reversed(STORED_ORDER))}, stored_entry
+        )
+        == []
+    )
+    assert changed_server_owned_fields({"aliases": [ALIAS_A]}, stored_entry) == [
+        "aliases"
+    ]
+    assert changed_server_owned_fields({"citationKey": "other"}, stored_entry) == [
+        "citationKey"
+    ]
+
+
+@pytest.mark.parametrize("value", [None, [], "not-a-list"])
+def test_a_non_list_alias_value_is_compared_unchanged(value):
+    assert changed_server_owned_fields({"aliases": value}, {"aliases": STORED_ORDER})

--- a/ebl/tests/bibliography/test_bibliography.py
+++ b/ebl/tests/bibliography/test_bibliography.py
@@ -199,7 +199,7 @@ def test_update(
         )
         .thenReturn()
     )
-    (when(bibliography_repository).update(bibliography_entry).thenReturn())
+    (when(bibliography_repository).update(bibliography_entry, {}).thenReturn())
     bibliography.update(bibliography_entry, user)
 
 

--- a/ebl/tests/bibliography/test_bibliography.py
+++ b/ebl/tests/bibliography/test_bibliography.py
@@ -200,7 +200,7 @@ def test_update(
         .thenReturn()
     )
     (when(bibliography_repository).update(bibliography_entry, {}).thenReturn())
-    bibliography.update(bibliography_entry, user)
+    bibliography.update_metadata(bibliography_entry, user)
 
 
 def test_update_not_found(bibliography_repository, bibliography, user, when):
@@ -211,7 +211,7 @@ def test_update_not_found(bibliography_repository, bibliography, user, when):
         .thenRaise(NotFoundError)
     )
     with pytest.raises(NotFoundError):
-        bibliography.update(bibliography_entry, user)
+        bibliography.update_metadata(bibliography_entry, user)
 
 
 def test_canonicalize_references(

--- a/ebl/tests/bibliography/test_bibliography_identity.py
+++ b/ebl/tests/bibliography/test_bibliography_identity.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 import pytest
 
 from ebl.bibliography.application.bibliography_identity import (
+    BibliographyIdentityContext,
     create_with_identity_claims,
     update_with_identity_claims,
 )
@@ -23,8 +26,13 @@ class ChangelogNoop:
 class RepositorySpy:
     def __init__(self, create_error=None):
         self.create_error = create_error
-        self.operation = None
-        self.released_owners = []
+        self.operation: Optional[LookupReservationOperation] = None
+        self.released_owners: list[str] = []
+
+    @property
+    def claimed_owner(self) -> str:
+        assert self.operation is not None
+        return self.operation.owner
 
     def claim_lookup_values(
         self, operation: LookupReservationOperation, _values
@@ -46,19 +54,23 @@ class RepositorySpy:
         self.released_owners.append(owner)
 
 
+def identity_context(repository, changelog, find):
+    return BibliographyIdentityContext(repository, changelog, find)
+
+
 def test_create_releases_claims_when_post_claim_lookup_finds_existing_entry(user):
     repository = RepositorySpy()
 
     with pytest.raises(LookupValueInUseError):
         create_with_identity_claims(
-            repository,
-            ChangelogSpy(),
-            lambda _value: {"id": "OTHER"},
+            identity_context(
+                repository, ChangelogSpy(), lambda _value: {"id": "OTHER"}
+            ),
             {"id": "Q30000000", "type": "book"},
             user,
         )
 
-    assert repository.released_owners == [repository.operation.owner]
+    assert repository.released_owners == [repository.claimed_owner]
 
 
 def test_lookup_values_skip_non_mapping_aliases():
@@ -112,7 +124,7 @@ def test_update_claims_added_alias_and_retires_removed_citation_key(user):
     repository = UpdateRepositorySpy(old_entry)
 
     update_with_identity_claims(
-        repository, ChangelogNoop(), missing_lookup, new_entry, user
+        identity_context(repository, ChangelogNoop(), missing_lookup), new_entry, user
     )
 
     assert repository.claimed_values == ["new-alias"]
@@ -126,7 +138,9 @@ def test_update_failure_releases_new_claims_without_retiring_old_claims(user):
 
     with pytest.raises(RuntimeError, match="update failed"):
         update_with_identity_claims(
-            repository, ChangelogSpy(), missing_lookup, new_entry, user
+            identity_context(repository, ChangelogSpy(), missing_lookup),
+            new_entry,
+            user,
         )
 
     assert repository.claimed_values == ["new-key"]
@@ -139,11 +153,13 @@ def test_create_releases_claims_when_repository_insert_fails(user):
 
     with pytest.raises(RuntimeError, match="insert failed"):
         create_with_identity_claims(
-            repository,
-            ChangelogSpy(),
-            lambda _value: (_ for _ in ()).throw(NotFoundError("missing")),
+            identity_context(
+                repository,
+                ChangelogSpy(),
+                lambda _value: (_ for _ in ()).throw(NotFoundError("missing")),
+            ),
             {"id": "Q30000000", "type": "book"},
             user,
         )
 
-    assert repository.released_owners == [repository.operation.owner]
+    assert repository.released_owners == [repository.claimed_owner]

--- a/ebl/tests/bibliography/test_bibliography_identity.py
+++ b/ebl/tests/bibliography/test_bibliography_identity.py
@@ -10,7 +10,7 @@ from ebl.bibliography.application.bibliography_identity import (
 from ebl.bibliography.application.bibliography_repository import LookupValueInUseError
 from ebl.bibliography.application.lookup_identity import bibliography_lookup_values
 from ebl.bibliography.application.lookup_reservation import LookupReservationOperation
-from ebl.errors import NotFoundError
+from ebl.errors import Defect, NotFoundError
 
 
 class ChangelogSpy:
@@ -96,7 +96,8 @@ class UpdateRepositorySpy:
     def claim_lookup_values(self, _operation, values):
         self.claimed_values = values
 
-    def update(self, _entry):
+    def update(self, _entry, expected_server_owned_fields):
+        self.expected_server_owned_fields = expected_server_owned_fields
         if self.update_error:
             raise self.update_error
 
@@ -163,3 +164,40 @@ def test_create_releases_claims_when_repository_insert_fails(user):
         )
 
     assert repository.released_owners == [repository.claimed_owner]
+
+
+def test_update_rejects_a_stored_entry_for_a_different_record(user):
+    repository = UpdateRepositorySpy({"id": "OTHER", "type": "book"})
+
+    with pytest.raises(Defect, match="does not match"):
+        update_with_identity_claims(
+            identity_context(repository, ChangelogSpy(), missing_lookup),
+            {"id": "Q30000000", "type": "book"},
+            user,
+            {"id": "OTHER", "type": "book"},
+        )
+
+    assert repository.claimed_values is None
+    assert repository.retired_values is None
+    assert repository.released_owners == []
+
+
+def test_update_passes_stored_server_owned_state_to_the_repository(user):
+    old_entry = {
+        "id": "Q30000000",
+        "type": "book",
+        "citationKey": "old-key",
+        "aliases": [{"value": "old-alias", "normalizedValue": "old-alias"}],
+    }
+    repository = UpdateRepositorySpy(old_entry)
+
+    update_with_identity_claims(
+        identity_context(repository, ChangelogNoop(), missing_lookup),
+        {"id": "Q30000000", "type": "book", "citationKey": "new-key"},
+        user,
+    )
+
+    assert repository.expected_server_owned_fields == {
+        "citationKey": "old-key",
+        "aliases": [{"value": "old-alias", "normalizedValue": "old-alias"}],
+    }

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation.py
@@ -1,46 +1,16 @@
-import json
-
 import falcon
 import pydash
 import pytest
-from falcon import testing
 
+from ebl.errors import DataError, NotFoundError
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CITATION_KEY,
+    CORRECTED_TITLE,
+    PARTNER_ALIAS,
+    metadata_only_payload,
+    post_entry,
+)
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
-
-PARTNER_ALIAS = {
-    "value": "dossin1967archives",
-    "normalizedValue": "dossin1967archives",
-    "type": "partner_id",
-    "source": "partner_request",
-    "status": "redirect",
-}
-CITATION_KEY = "dossin1967La"
-
-
-@pytest.fixture
-def aliased_entry(bibliography, user):
-    entry = BibliographyEntryFactory.build(
-        id="Q30000024",
-        title="Old title",
-        aliases=[PARTNER_ALIAS],
-        citationKey=CITATION_KEY,
-    )
-    bibliography.create(entry, user)
-    return entry
-
-
-def metadata_only_payload(entry: dict) -> dict:
-    return pydash.omit(
-        {**entry, "title": "Corrected title"},
-        "aliases",
-        "citationKey",
-        "deprecated",
-        "redirectTo",
-    )
-
-
-def post_entry(client, entry: dict) -> testing.Result:
-    return client.simulate_post(f"/bibliography/{entry['id']}", body=json.dumps(entry))
 
 
 def test_metadata_update_preserves_aliases_and_citation_key(
@@ -81,7 +51,7 @@ def test_metadata_update_keeps_record_active(client, bibliography, aliased_entry
 
     assert stored_entry.get("deprecated") is None
     assert stored_entry.get("redirectTo") is None
-    assert stored_entry["title"] == "Corrected title"
+    assert stored_entry["title"] == CORRECTED_TITLE
 
 
 def test_metadata_update_applies_requested_metadata(
@@ -165,3 +135,14 @@ def test_legacy_record_update_does_not_invent_identity_fields(
     assert "citationKey" not in stored_entry
     assert "deprecated" not in stored_entry
     assert "redirectTo" not in stored_entry
+
+
+@pytest.mark.parametrize("entry", [{}, {"id": ""}, {"id": None}, {"id": 47}])
+def test_update_without_a_usable_id_is_rejected(entry, bibliography, user):
+    with pytest.raises(DataError, match="id is required"):
+        bibliography.update({**entry, "type": "book"}, user)
+
+
+def test_update_of_unknown_id_is_not_found(bibliography, user):
+    with pytest.raises(NotFoundError):
+        bibliography.update({"id": "does-not-exist", "type": "book"}, user)

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation.py
@@ -1,5 +1,4 @@
 import falcon
-import pydash
 import pytest
 
 from ebl.errors import DataError, NotFoundError
@@ -9,8 +8,8 @@ from ebl.tests.bibliography.identity_preservation_test_helpers import (
     PARTNER_ALIAS,
     metadata_only_payload,
     post_entry,
+    reservations,
 )
-from ebl.tests.factories.bibliography import BibliographyEntryFactory
 
 
 def test_metadata_update_preserves_aliases_and_citation_key(
@@ -62,65 +61,6 @@ def test_metadata_update_applies_requested_metadata(
     post_entry(client, payload)
 
     assert bibliography.find(aliased_entry["id"])["volume"] == "99"
-
-
-SERVER_OWNED_PAYLOADS = {
-    "aliases": [{"value": "attacker-alias", "normalizedValue": "attacker-alias"}],
-    "citationKey": "different",
-    "deprecated": True,
-    "redirectTo": "other-record",
-}
-
-
-@pytest.mark.parametrize("field", sorted(SERVER_OWNED_PAYLOADS))
-def test_update_rejects_submitted_server_owned_field(
-    field, client, bibliography, aliased_entry
-):
-    payload = {
-        **metadata_only_payload(aliased_entry),
-        field: SERVER_OWNED_PAYLOADS[field],
-    }
-
-    result = post_entry(client, payload)
-
-    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
-    assert field in result.text
-
-
-@pytest.mark.parametrize("field", sorted(SERVER_OWNED_PAYLOADS))
-def test_rejected_server_owned_field_leaves_record_unchanged(
-    field, client, bibliography, aliased_entry
-):
-    payload = {
-        **metadata_only_payload(aliased_entry),
-        field: SERVER_OWNED_PAYLOADS[field],
-    }
-
-    post_entry(client, payload)
-    stored_entry = bibliography.find(aliased_entry["id"])
-
-    assert stored_entry["aliases"] == [PARTNER_ALIAS]
-    assert stored_entry["citationKey"] == CITATION_KEY
-    assert stored_entry["title"] == aliased_entry["title"]
-    assert stored_entry.get("deprecated") is None
-    assert stored_entry.get("redirectTo") is None
-
-
-def test_update_cannot_steal_an_alias_from_another_record(
-    client, bibliography, user, aliased_entry
-):
-    other_entry = BibliographyEntryFactory.build(id="Q30000099", title="Other")
-    bibliography.create(other_entry, user)
-    payload = {
-        **pydash.omit(other_entry, "aliases", "citationKey"),
-        "aliases": [PARTNER_ALIAS],
-    }
-
-    result = post_entry(client, payload)
-
-    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
-    assert bibliography.find(PARTNER_ALIAS["value"])["id"] == aliased_entry["id"]
-    assert "aliases" not in bibliography.find(other_entry["id"])
 
 
 def test_legacy_record_without_identity_fields_updates_normally(
@@ -180,3 +120,46 @@ def test_update_without_a_usable_id_is_rejected(entry, bibliography, user):
 def test_update_of_unknown_id_is_not_found(bibliography, user):
     with pytest.raises(NotFoundError):
         bibliography.update({"id": "does-not-exist", "type": "book"}, user)
+
+
+def test_get_returns_the_server_owned_fields_the_editor_round_trips(
+    client, aliased_entry
+):
+    fetched_entry = client.simulate_get(f"/bibliography/{aliased_entry['id']}").json
+
+    assert fetched_entry["aliases"] == [PARTNER_ALIAS]
+    assert fetched_entry["citationKey"] == CITATION_KEY
+
+
+def test_round_tripped_entry_is_accepted(client, bibliography, aliased_entry):
+    fetched_entry = client.simulate_get(f"/bibliography/{aliased_entry['id']}").json
+
+    result = post_entry(client, {**fetched_entry, "title": CORRECTED_TITLE})
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert bibliography.find(aliased_entry["id"]) == {
+        **fetched_entry,
+        "title": CORRECTED_TITLE,
+    }
+
+
+def test_round_tripped_entry_keeps_identity_resolvable(
+    client, bibliography, aliased_entry
+):
+    fetched_entry = client.simulate_get(f"/bibliography/{aliased_entry['id']}").json
+
+    post_entry(client, {**fetched_entry, "title": CORRECTED_TITLE})
+
+    assert bibliography.find(PARTNER_ALIAS["value"])["id"] == aliased_entry["id"]
+    assert bibliography.find(CITATION_KEY)["id"] == aliased_entry["id"]
+
+
+def test_round_tripped_entry_does_not_change_reservations(
+    client, database, aliased_entry
+):
+    fetched_entry = client.simulate_get(f"/bibliography/{aliased_entry['id']}").json
+    before = reservations(database)
+
+    post_entry(client, {**fetched_entry, "title": CORRECTED_TITLE})
+
+    assert reservations(database) == before

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation.py
@@ -64,35 +64,44 @@ def test_metadata_update_applies_requested_metadata(
     assert bibliography.find(aliased_entry["id"])["volume"] == "99"
 
 
-def test_update_ignores_submitted_aliases(client, bibliography, aliased_entry):
+SERVER_OWNED_PAYLOADS = {
+    "aliases": [{"value": "attacker-alias", "normalizedValue": "attacker-alias"}],
+    "citationKey": "different",
+    "deprecated": True,
+    "redirectTo": "other-record",
+}
+
+
+@pytest.mark.parametrize("field", sorted(SERVER_OWNED_PAYLOADS))
+def test_update_rejects_submitted_server_owned_field(
+    field, client, bibliography, aliased_entry
+):
     payload = {
         **metadata_only_payload(aliased_entry),
-        "aliases": [{"value": "attacker-alias", "normalizedValue": "attacker-alias"}],
+        field: SERVER_OWNED_PAYLOADS[field],
     }
 
-    post_entry(client, payload)
+    result = post_entry(client, payload)
 
-    assert bibliography.find(aliased_entry["id"])["aliases"] == [PARTNER_ALIAS]
-
-
-def test_update_ignores_submitted_citation_key(client, bibliography, aliased_entry):
-    payload = {**metadata_only_payload(aliased_entry), "citationKey": "different"}
-
-    post_entry(client, payload)
-
-    assert bibliography.find(aliased_entry["id"])["citationKey"] == CITATION_KEY
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert field in result.text
 
 
-def test_update_cannot_deprecate_an_active_record(client, bibliography, aliased_entry):
+@pytest.mark.parametrize("field", sorted(SERVER_OWNED_PAYLOADS))
+def test_rejected_server_owned_field_leaves_record_unchanged(
+    field, client, bibliography, aliased_entry
+):
     payload = {
         **metadata_only_payload(aliased_entry),
-        "deprecated": True,
-        "redirectTo": "other-record",
+        field: SERVER_OWNED_PAYLOADS[field],
     }
 
     post_entry(client, payload)
     stored_entry = bibliography.find(aliased_entry["id"])
 
+    assert stored_entry["aliases"] == [PARTNER_ALIAS]
+    assert stored_entry["citationKey"] == CITATION_KEY
+    assert stored_entry["title"] == aliased_entry["title"]
     assert stored_entry.get("deprecated") is None
     assert stored_entry.get("redirectTo") is None
 
@@ -107,8 +116,9 @@ def test_update_cannot_steal_an_alias_from_another_record(
         "aliases": [PARTNER_ALIAS],
     }
 
-    post_entry(client, payload)
+    result = post_entry(client, payload)
 
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
     assert bibliography.find(PARTNER_ALIAS["value"])["id"] == aliased_entry["id"]
     assert "aliases" not in bibliography.find(other_entry["id"])
 
@@ -135,6 +145,30 @@ def test_legacy_record_update_does_not_invent_identity_fields(
     assert "citationKey" not in stored_entry
     assert "deprecated" not in stored_entry
     assert "redirectTo" not in stored_entry
+
+
+@pytest.mark.parametrize(
+    "unknown_field,value", [("DPO", "10.1086/719864"), ("pages", "129-143")]
+)
+def test_update_preserves_unknown_persisted_fields(
+    unknown_field, value, client, database, saved_entry
+):
+    database["bibliography"].update_one(
+        {"_id": saved_entry["id"]}, {"$set": {unknown_field: value}}
+    )
+
+    result = post_entry(client, {**saved_entry, "title": "Legacy corrected"})
+    stored_entry = database["bibliography"].find_one({"_id": saved_entry["id"]})
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored_entry[unknown_field] == value
+    assert stored_entry["title"] == "Legacy corrected"
+
+
+def test_update_does_not_accept_unknown_fields_from_the_client(client, saved_entry):
+    result = post_entry(client, {**saved_entry, "DPO": "10.1086/719864"})
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
 
 
 @pytest.mark.parametrize("entry", [{}, {"id": ""}, {"id": None}, {"id": 47}])

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation.py
@@ -1,0 +1,167 @@
+import json
+
+import falcon
+import pydash
+import pytest
+from falcon import testing
+
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+PARTNER_ALIAS = {
+    "value": "dossin1967archives",
+    "normalizedValue": "dossin1967archives",
+    "type": "partner_id",
+    "source": "partner_request",
+    "status": "redirect",
+}
+CITATION_KEY = "dossin1967La"
+
+
+@pytest.fixture
+def aliased_entry(bibliography, user):
+    entry = BibliographyEntryFactory.build(
+        id="Q30000024",
+        title="Old title",
+        aliases=[PARTNER_ALIAS],
+        citationKey=CITATION_KEY,
+    )
+    bibliography.create(entry, user)
+    return entry
+
+
+def metadata_only_payload(entry: dict) -> dict:
+    return pydash.omit(
+        {**entry, "title": "Corrected title"},
+        "aliases",
+        "citationKey",
+        "deprecated",
+        "redirectTo",
+    )
+
+
+def post_entry(client, entry: dict) -> testing.Result:
+    return client.simulate_post(f"/bibliography/{entry['id']}", body=json.dumps(entry))
+
+
+def test_metadata_update_preserves_aliases_and_citation_key(
+    client, bibliography, aliased_entry
+):
+    payload = metadata_only_payload(aliased_entry)
+
+    result = post_entry(client, payload)
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert bibliography.find(aliased_entry["id"]) == {
+        **payload,
+        "aliases": [PARTNER_ALIAS],
+        "citationKey": CITATION_KEY,
+    }
+
+
+@pytest.mark.parametrize("alias_key", ["value", "normalizedValue"])
+def test_metadata_update_keeps_alias_resolvable(
+    alias_key, client, bibliography, aliased_entry
+):
+    post_entry(client, metadata_only_payload(aliased_entry))
+
+    assert bibliography.find(PARTNER_ALIAS[alias_key])["id"] == aliased_entry["id"]
+
+
+def test_metadata_update_keeps_citation_key_resolvable(
+    client, bibliography, aliased_entry
+):
+    post_entry(client, metadata_only_payload(aliased_entry))
+
+    assert bibliography.find(CITATION_KEY)["id"] == aliased_entry["id"]
+
+
+def test_metadata_update_keeps_record_active(client, bibliography, aliased_entry):
+    post_entry(client, metadata_only_payload(aliased_entry))
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert stored_entry.get("deprecated") is None
+    assert stored_entry.get("redirectTo") is None
+    assert stored_entry["title"] == "Corrected title"
+
+
+def test_metadata_update_applies_requested_metadata(
+    client, bibliography, aliased_entry
+):
+    payload = {**metadata_only_payload(aliased_entry), "volume": "99"}
+
+    post_entry(client, payload)
+
+    assert bibliography.find(aliased_entry["id"])["volume"] == "99"
+
+
+def test_update_ignores_submitted_aliases(client, bibliography, aliased_entry):
+    payload = {
+        **metadata_only_payload(aliased_entry),
+        "aliases": [{"value": "attacker-alias", "normalizedValue": "attacker-alias"}],
+    }
+
+    post_entry(client, payload)
+
+    assert bibliography.find(aliased_entry["id"])["aliases"] == [PARTNER_ALIAS]
+
+
+def test_update_ignores_submitted_citation_key(client, bibliography, aliased_entry):
+    payload = {**metadata_only_payload(aliased_entry), "citationKey": "different"}
+
+    post_entry(client, payload)
+
+    assert bibliography.find(aliased_entry["id"])["citationKey"] == CITATION_KEY
+
+
+def test_update_cannot_deprecate_an_active_record(client, bibliography, aliased_entry):
+    payload = {
+        **metadata_only_payload(aliased_entry),
+        "deprecated": True,
+        "redirectTo": "other-record",
+    }
+
+    post_entry(client, payload)
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert stored_entry.get("deprecated") is None
+    assert stored_entry.get("redirectTo") is None
+
+
+def test_update_cannot_steal_an_alias_from_another_record(
+    client, bibliography, user, aliased_entry
+):
+    other_entry = BibliographyEntryFactory.build(id="Q30000099", title="Other")
+    bibliography.create(other_entry, user)
+    payload = {
+        **pydash.omit(other_entry, "aliases", "citationKey"),
+        "aliases": [PARTNER_ALIAS],
+    }
+
+    post_entry(client, payload)
+
+    assert bibliography.find(PARTNER_ALIAS["value"])["id"] == aliased_entry["id"]
+    assert "aliases" not in bibliography.find(other_entry["id"])
+
+
+def test_legacy_record_without_identity_fields_updates_normally(
+    client, bibliography, saved_entry
+):
+    payload = {**saved_entry, "title": "Legacy corrected"}
+
+    result = post_entry(client, payload)
+    stored_entry = bibliography.find(saved_entry["id"])
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored_entry == payload
+
+
+def test_legacy_record_update_does_not_invent_identity_fields(
+    client, bibliography, saved_entry
+):
+    post_entry(client, {**saved_entry, "title": "Legacy corrected"})
+    stored_entry = bibliography.find(saved_entry["id"])
+
+    assert "aliases" not in stored_entry
+    assert "citationKey" not in stored_entry
+    assert "deprecated" not in stored_entry
+    assert "redirectTo" not in stored_entry

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation.py
@@ -105,10 +105,32 @@ def test_update_preserves_unknown_persisted_fields(
     assert stored_entry["title"] == "Legacy corrected"
 
 
-def test_update_does_not_accept_unknown_fields_from_the_client(client, saved_entry):
+@pytest.mark.parametrize(
+    "unknown_field,value", [("DPO", "10.1086/719864"), ("pages", "129-143")]
+)
+def test_round_tripped_entry_with_unknown_persisted_field_is_accepted(
+    unknown_field, value, client, database, saved_entry
+):
+    database["bibliography"].update_one(
+        {"_id": saved_entry["id"]}, {"$set": {unknown_field: value}}
+    )
+    fetched_entry = client.simulate_get(f"/bibliography/{saved_entry['id']}").json
+
+    result = post_entry(client, {**fetched_entry, "title": "Legacy corrected"})
+    stored_entry = database["bibliography"].find_one({"_id": saved_entry["id"]})
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored_entry[unknown_field] == value
+    assert stored_entry["title"] == "Legacy corrected"
+
+
+def test_update_ignores_an_unknown_field_the_client_invents(
+    client, bibliography, saved_entry
+):
     result = post_entry(client, {**saved_entry, "DPO": "10.1086/719864"})
 
-    assert result.status == falcon.HTTP_BAD_REQUEST
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert "DPO" not in bibliography.find(saved_entry["id"])
 
 
 @pytest.mark.parametrize("entry", [{}, {"id": ""}, {"id": None}, {"id": 47}])

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation.py
@@ -114,12 +114,12 @@ def test_update_does_not_accept_unknown_fields_from_the_client(client, saved_ent
 @pytest.mark.parametrize("entry", [{}, {"id": ""}, {"id": None}, {"id": 47}])
 def test_update_without_a_usable_id_is_rejected(entry, bibliography, user):
     with pytest.raises(DataError, match="id is required"):
-        bibliography.update({**entry, "type": "book"}, user)
+        bibliography.update_metadata({**entry, "type": "book"}, user)
 
 
 def test_update_of_unknown_id_is_not_found(bibliography, user):
     with pytest.raises(NotFoundError):
-        bibliography.update({"id": "does-not-exist", "type": "book"}, user)
+        bibliography.update_metadata({"id": "does-not-exist", "type": "book"}, user)
 
 
 def test_get_returns_the_server_owned_fields_the_editor_round_trips(

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
@@ -1,0 +1,151 @@
+import json
+
+import pydash
+import pytest
+from falcon import testing
+
+from ebl.bibliography.application.bibliography_repository import LookupValueInUseError
+from ebl.bibliography.application.lookup_reservation import LookupReservationState
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+RESERVATIONS = "bibliography_lookup_reservations"
+PARTNER_ALIAS = {
+    "value": "dossin1967archives",
+    "normalizedValue": "dossin1967archives",
+    "type": "partner_id",
+    "source": "partner_request",
+    "status": "redirect",
+}
+CITATION_KEY = "dossin1967La"
+
+
+@pytest.fixture
+def aliased_entry(bibliography, user):
+    entry = BibliographyEntryFactory.build(
+        id="Q30000024",
+        title="Old title",
+        aliases=[PARTNER_ALIAS],
+        citationKey=CITATION_KEY,
+    )
+    bibliography.create(entry, user)
+    return entry
+
+
+@pytest.fixture
+def deprecated_entry(bibliography, user):
+    canonical_entry = BibliographyEntryFactory.build(id="rla_9_388", title="Canonical")
+    bibliography.create(canonical_entry, user)
+    entry = BibliographyEntryFactory.build(
+        id="RN2001", title="Loser", deprecated=True, redirectTo="rla_9_388"
+    )
+    bibliography.create(entry, user)
+    return entry
+
+
+def reservations(database) -> dict:
+    return {document["_id"]: document for document in database[RESERVATIONS].find({})}
+
+
+def metadata_only_payload(entry: dict) -> dict:
+    return pydash.omit(
+        {**entry, "title": "Corrected title"},
+        "aliases",
+        "citationKey",
+        "deprecated",
+        "redirectTo",
+    )
+
+
+def post_entry(client, entry: dict) -> testing.Result:
+    return client.simulate_post(f"/bibliography/{entry['id']}", body=json.dumps(entry))
+
+
+def test_metadata_update_keeps_every_reservation(client, database, aliased_entry):
+    before = reservations(database)
+
+    post_entry(client, metadata_only_payload(aliased_entry))
+
+    assert set(reservations(database)) == set(before)
+    assert set(before) == {aliased_entry["id"], CITATION_KEY, PARTNER_ALIAS["value"]}
+
+
+def test_metadata_update_does_not_retire_reservations(client, database, aliased_entry):
+    post_entry(client, metadata_only_payload(aliased_entry))
+
+    assert [document["state"] for document in reservations(database).values()] == [
+        LookupReservationState.COMMITTED.value
+    ] * 3
+
+
+def test_metadata_update_keeps_reservation_owners(client, database, aliased_entry):
+    owners_before = {
+        value: document["owner"] for value, document in reservations(database).items()
+    }
+
+    post_entry(client, metadata_only_payload(aliased_entry))
+
+    assert {
+        value: document["owner"] for value, document in reservations(database).items()
+    } == owners_before
+
+
+def test_metadata_update_does_not_add_reservations(client, database, aliased_entry):
+    payload = {
+        **metadata_only_payload(aliased_entry),
+        "citationKey": "brand-new-key",
+        "aliases": [{"value": "brand-new", "normalizedValue": "brand-new"}],
+    }
+
+    post_entry(client, payload)
+
+    assert "brand-new-key" not in reservations(database)
+    assert "brand-new" not in reservations(database)
+
+
+def test_deprecated_record_update_is_rejected(bibliography, user, deprecated_entry):
+    with pytest.raises(LookupValueInUseError):
+        bibliography.update(
+            {**metadata_only_payload(deprecated_entry), "id": "RN2001"}, user
+        )
+
+
+def test_rejected_deprecated_update_keeps_tombstone(
+    bibliography, user, database, deprecated_entry
+):
+    with pytest.raises(LookupValueInUseError):
+        bibliography.update(
+            {**metadata_only_payload(deprecated_entry), "id": "RN2001"}, user
+        )
+    stored_entry = database["bibliography"].find_one({"_id": "RN2001"})
+
+    assert stored_entry["deprecated"] is True
+    assert stored_entry["redirectTo"] == "rla_9_388"
+
+
+def test_rejected_deprecated_update_keeps_redirect_working(
+    bibliography, user, deprecated_entry
+):
+    with pytest.raises(LookupValueInUseError):
+        bibliography.update(
+            {**metadata_only_payload(deprecated_entry), "id": "RN2001"}, user
+        )
+
+    assert bibliography.find("RN2001")["id"] == "rla_9_388"
+
+
+def test_deprecated_record_update_cannot_clear_tombstone_fields(
+    bibliography, user, database, deprecated_entry
+):
+    with pytest.raises(LookupValueInUseError):
+        bibliography.update(
+            {
+                **metadata_only_payload(deprecated_entry),
+                "id": "RN2001",
+                "deprecated": False,
+            },
+            user,
+        )
+    stored_entry = database["bibliography"].find_one({"_id": "RN2001"})
+
+    assert stored_entry["deprecated"] is True
+    assert stored_entry["redirectTo"] == "rla_9_388"

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
@@ -57,7 +57,7 @@ def test_rejected_identity_input_adds_no_reservations(client, database, aliased_
 
     result = post_entry(client, payload)
 
-    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert result.status == falcon.HTTP_CONFLICT
     assert "brand-new-key" not in reservations(database)
     assert "brand-new" not in reservations(database)
 

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
@@ -1,7 +1,8 @@
+import falcon
 import pytest
 
-from ebl.bibliography.application.bibliography_repository import LookupValueInUseError
 from ebl.bibliography.application.lookup_reservation import LookupReservationState
+from ebl.errors import DataError
 from ebl.tests.bibliography.identity_preservation_test_helpers import (
     CITATION_KEY,
     PARTNER_ALIAS,
@@ -9,6 +10,9 @@ from ebl.tests.bibliography.identity_preservation_test_helpers import (
     post_entry,
     reservations,
 )
+
+
+DEPRECATED_ERROR = "RN2001 is deprecated; edit rla_9_388 instead"
 
 
 def deprecated_payload(deprecated_entry: dict, **overrides) -> dict:
@@ -44,28 +48,29 @@ def test_metadata_update_keeps_reservation_owners(client, database, aliased_entr
     } == owners_before
 
 
-def test_metadata_update_does_not_add_reservations(client, database, aliased_entry):
+def test_rejected_identity_input_adds_no_reservations(client, database, aliased_entry):
     payload = {
         **metadata_only_payload(aliased_entry),
         "citationKey": "brand-new-key",
         "aliases": [{"value": "brand-new", "normalizedValue": "brand-new"}],
     }
 
-    post_entry(client, payload)
+    result = post_entry(client, payload)
 
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
     assert "brand-new-key" not in reservations(database)
     assert "brand-new" not in reservations(database)
 
 
 def test_deprecated_record_update_is_rejected(bibliography, user, deprecated_entry):
-    with pytest.raises(LookupValueInUseError):
+    with pytest.raises(DataError, match=DEPRECATED_ERROR):
         bibliography.update(deprecated_payload(deprecated_entry), user)
 
 
 def test_rejected_deprecated_update_keeps_tombstone(
     bibliography, user, database, deprecated_entry
 ):
-    with pytest.raises(LookupValueInUseError):
+    with pytest.raises(DataError, match=DEPRECATED_ERROR):
         bibliography.update(deprecated_payload(deprecated_entry), user)
     stored_entry = database["bibliography"].find_one({"_id": "RN2001"})
 
@@ -76,7 +81,7 @@ def test_rejected_deprecated_update_keeps_tombstone(
 def test_rejected_deprecated_update_keeps_redirect_working(
     bibliography, user, deprecated_entry
 ):
-    with pytest.raises(LookupValueInUseError):
+    with pytest.raises(DataError, match=DEPRECATED_ERROR):
         bibliography.update(deprecated_payload(deprecated_entry), user)
 
     assert bibliography.find("RN2001")["id"] == "rla_9_388"
@@ -85,7 +90,7 @@ def test_rejected_deprecated_update_keeps_redirect_working(
 def test_deprecated_record_update_cannot_clear_tombstone_fields(
     bibliography, user, database, deprecated_entry
 ):
-    with pytest.raises(LookupValueInUseError):
+    with pytest.raises(DataError, match=DEPRECATED_ERROR):
         bibliography.update(
             deprecated_payload(deprecated_entry, deprecated=False), user
         )

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
@@ -1,63 +1,18 @@
-import json
-
-import pydash
 import pytest
-from falcon import testing
 
 from ebl.bibliography.application.bibliography_repository import LookupValueInUseError
 from ebl.bibliography.application.lookup_reservation import LookupReservationState
-from ebl.tests.factories.bibliography import BibliographyEntryFactory
-
-RESERVATIONS = "bibliography_lookup_reservations"
-PARTNER_ALIAS = {
-    "value": "dossin1967archives",
-    "normalizedValue": "dossin1967archives",
-    "type": "partner_id",
-    "source": "partner_request",
-    "status": "redirect",
-}
-CITATION_KEY = "dossin1967La"
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CITATION_KEY,
+    PARTNER_ALIAS,
+    metadata_only_payload,
+    post_entry,
+    reservations,
+)
 
 
-@pytest.fixture
-def aliased_entry(bibliography, user):
-    entry = BibliographyEntryFactory.build(
-        id="Q30000024",
-        title="Old title",
-        aliases=[PARTNER_ALIAS],
-        citationKey=CITATION_KEY,
-    )
-    bibliography.create(entry, user)
-    return entry
-
-
-@pytest.fixture
-def deprecated_entry(bibliography, user):
-    canonical_entry = BibliographyEntryFactory.build(id="rla_9_388", title="Canonical")
-    bibliography.create(canonical_entry, user)
-    entry = BibliographyEntryFactory.build(
-        id="RN2001", title="Loser", deprecated=True, redirectTo="rla_9_388"
-    )
-    bibliography.create(entry, user)
-    return entry
-
-
-def reservations(database) -> dict:
-    return {document["_id"]: document for document in database[RESERVATIONS].find({})}
-
-
-def metadata_only_payload(entry: dict) -> dict:
-    return pydash.omit(
-        {**entry, "title": "Corrected title"},
-        "aliases",
-        "citationKey",
-        "deprecated",
-        "redirectTo",
-    )
-
-
-def post_entry(client, entry: dict) -> testing.Result:
-    return client.simulate_post(f"/bibliography/{entry['id']}", body=json.dumps(entry))
+def deprecated_payload(deprecated_entry: dict, **overrides) -> dict:
+    return {**metadata_only_payload(deprecated_entry), "id": "RN2001", **overrides}
 
 
 def test_metadata_update_keeps_every_reservation(client, database, aliased_entry):
@@ -104,18 +59,14 @@ def test_metadata_update_does_not_add_reservations(client, database, aliased_ent
 
 def test_deprecated_record_update_is_rejected(bibliography, user, deprecated_entry):
     with pytest.raises(LookupValueInUseError):
-        bibliography.update(
-            {**metadata_only_payload(deprecated_entry), "id": "RN2001"}, user
-        )
+        bibliography.update(deprecated_payload(deprecated_entry), user)
 
 
 def test_rejected_deprecated_update_keeps_tombstone(
     bibliography, user, database, deprecated_entry
 ):
     with pytest.raises(LookupValueInUseError):
-        bibliography.update(
-            {**metadata_only_payload(deprecated_entry), "id": "RN2001"}, user
-        )
+        bibliography.update(deprecated_payload(deprecated_entry), user)
     stored_entry = database["bibliography"].find_one({"_id": "RN2001"})
 
     assert stored_entry["deprecated"] is True
@@ -126,9 +77,7 @@ def test_rejected_deprecated_update_keeps_redirect_working(
     bibliography, user, deprecated_entry
 ):
     with pytest.raises(LookupValueInUseError):
-        bibliography.update(
-            {**metadata_only_payload(deprecated_entry), "id": "RN2001"}, user
-        )
+        bibliography.update(deprecated_payload(deprecated_entry), user)
 
     assert bibliography.find("RN2001")["id"] == "rla_9_388"
 
@@ -138,12 +87,7 @@ def test_deprecated_record_update_cannot_clear_tombstone_fields(
 ):
     with pytest.raises(LookupValueInUseError):
         bibliography.update(
-            {
-                **metadata_only_payload(deprecated_entry),
-                "id": "RN2001",
-                "deprecated": False,
-            },
-            user,
+            deprecated_payload(deprecated_entry, deprecated=False), user
         )
     stored_entry = database["bibliography"].find_one({"_id": "RN2001"})
 

--- a/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_preservation_state.py
@@ -64,14 +64,14 @@ def test_rejected_identity_input_adds_no_reservations(client, database, aliased_
 
 def test_deprecated_record_update_is_rejected(bibliography, user, deprecated_entry):
     with pytest.raises(DataError, match=DEPRECATED_ERROR):
-        bibliography.update(deprecated_payload(deprecated_entry), user)
+        bibliography.update_metadata(deprecated_payload(deprecated_entry), user)
 
 
 def test_rejected_deprecated_update_keeps_tombstone(
     bibliography, user, database, deprecated_entry
 ):
     with pytest.raises(DataError, match=DEPRECATED_ERROR):
-        bibliography.update(deprecated_payload(deprecated_entry), user)
+        bibliography.update_metadata(deprecated_payload(deprecated_entry), user)
     stored_entry = database["bibliography"].find_one({"_id": "RN2001"})
 
     assert stored_entry["deprecated"] is True
@@ -82,7 +82,7 @@ def test_rejected_deprecated_update_keeps_redirect_working(
     bibliography, user, deprecated_entry
 ):
     with pytest.raises(DataError, match=DEPRECATED_ERROR):
-        bibliography.update(deprecated_payload(deprecated_entry), user)
+        bibliography.update_metadata(deprecated_payload(deprecated_entry), user)
 
     assert bibliography.find("RN2001")["id"] == "rla_9_388"
 
@@ -91,7 +91,7 @@ def test_deprecated_record_update_cannot_clear_tombstone_fields(
     bibliography, user, database, deprecated_entry
 ):
     with pytest.raises(DataError, match=DEPRECATED_ERROR):
-        bibliography.update(
+        bibliography.update_metadata(
             deprecated_payload(deprecated_entry, deprecated=False), user
         )
     stored_entry = database["bibliography"].find_one({"_id": "RN2001"})

--- a/ebl/tests/bibliography/test_bibliography_identity_rejection.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_rejection.py
@@ -30,7 +30,7 @@ def test_update_rejects_submitted_server_owned_field(
 
     result = post_entry(client, payload)
 
-    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert result.status == falcon.HTTP_CONFLICT
     assert field in result.text
 
 
@@ -63,7 +63,7 @@ def test_update_cannot_tombstone_an_active_record(client, bibliography, aliased_
     result = post_entry(client, payload)
     stored_entry = bibliography.find(aliased_entry["id"])
 
-    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert result.status == falcon.HTTP_CONFLICT
     assert "deprecated" in result.text
     assert stored_entry.get("deprecated") is None
     assert stored_entry.get("redirectTo") is None
@@ -89,6 +89,6 @@ def test_update_cannot_steal_an_alias_from_another_record(
 
     result = post_entry(client, payload)
 
-    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert result.status == falcon.HTTP_CONFLICT
     assert bibliography.find(PARTNER_ALIAS["value"])["id"] == aliased_entry["id"]
     assert "aliases" not in bibliography.find(other_entry["id"])

--- a/ebl/tests/bibliography/test_bibliography_identity_rejection.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_rejection.py
@@ -1,0 +1,94 @@
+import falcon
+import pydash
+import pytest
+
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CITATION_KEY,
+    PARTNER_ALIAS,
+    metadata_only_payload,
+    post_entry,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+
+SERVER_OWNED_PAYLOADS = {
+    "aliases": [{"value": "attacker-alias", "normalizedValue": "attacker-alias"}],
+    "citationKey": "different",
+    "deprecated": False,
+    "redirectTo": "other-record",
+}
+
+
+@pytest.mark.parametrize("field", sorted(SERVER_OWNED_PAYLOADS))
+def test_update_rejects_submitted_server_owned_field(
+    field, client, bibliography, aliased_entry
+):
+    payload = {
+        **metadata_only_payload(aliased_entry),
+        field: SERVER_OWNED_PAYLOADS[field],
+    }
+
+    result = post_entry(client, payload)
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert field in result.text
+
+
+@pytest.mark.parametrize("field", sorted(SERVER_OWNED_PAYLOADS))
+def test_rejected_server_owned_field_leaves_record_unchanged(
+    field, client, bibliography, aliased_entry
+):
+    payload = {
+        **metadata_only_payload(aliased_entry),
+        field: SERVER_OWNED_PAYLOADS[field],
+    }
+
+    post_entry(client, payload)
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert stored_entry["aliases"] == [PARTNER_ALIAS]
+    assert stored_entry["citationKey"] == CITATION_KEY
+    assert stored_entry["title"] == aliased_entry["title"]
+    assert stored_entry.get("deprecated") is None
+    assert stored_entry.get("redirectTo") is None
+
+
+def test_update_cannot_tombstone_an_active_record(client, bibliography, aliased_entry):
+    payload = {
+        **metadata_only_payload(aliased_entry),
+        "deprecated": True,
+        "redirectTo": "other-record",
+    }
+
+    result = post_entry(client, payload)
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert "deprecated" in result.text
+    assert stored_entry.get("deprecated") is None
+    assert stored_entry.get("redirectTo") is None
+
+
+def test_update_rejects_deprecating_without_a_redirect_target(client, aliased_entry):
+    payload = {**metadata_only_payload(aliased_entry), "deprecated": True}
+
+    result = post_entry(client, payload)
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
+
+
+def test_update_cannot_steal_an_alias_from_another_record(
+    client, bibliography, user, aliased_entry
+):
+    other_entry = BibliographyEntryFactory.build(id="Q30000099", title="Other")
+    bibliography.create(other_entry, user)
+    payload = {
+        **pydash.omit(other_entry, "aliases", "citationKey"),
+        "aliases": [PARTNER_ALIAS],
+    }
+
+    result = post_entry(client, payload)
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert bibliography.find(PARTNER_ALIAS["value"])["id"] == aliased_entry["id"]
+    assert "aliases" not in bibliography.find(other_entry["id"])

--- a/ebl/tests/bibliography/test_bibliography_identity_rejection.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_rejection.py
@@ -69,12 +69,27 @@ def test_update_cannot_tombstone_an_active_record(client, bibliography, aliased_
     assert stored_entry.get("redirectTo") is None
 
 
-def test_update_rejects_deprecating_without_a_redirect_target(client, aliased_entry):
+def test_deprecating_without_a_redirect_target_is_a_conflict_not_a_schema_error(
+    client, bibliography, aliased_entry
+):
+    """`deprecated` is server-owned, so the answer is about state, not shape.
+
+    The stored schema requires `redirectTo` alongside `deprecated`, which used
+    to make this a `400` complaining about a property the client does not own.
+    The route contract drops that stored-entry rule so the request reaches the
+    application and gets the same answer every other server-owned mismatch
+    gets.
+    """
     payload = {**metadata_only_payload(aliased_entry), "deprecated": True}
 
     result = post_entry(client, payload)
+    stored_entry = bibliography.find(aliased_entry["id"])
 
-    assert result.status == falcon.HTTP_BAD_REQUEST
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "deprecated" in result.text
+    assert stored_entry.get("deprecated") is None
+    assert stored_entry.get("redirectTo") is None
+    assert stored_entry["title"] == aliased_entry["title"]
 
 
 def test_update_cannot_steal_an_alias_from_another_record(

--- a/ebl/tests/bibliography/test_bibliography_identity_update_recovery.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_update_recovery.py
@@ -6,6 +6,7 @@ from pymongo.database import Database
 
 from ebl.bibliography.application.bibliography import Bibliography
 from ebl.bibliography.application.bibliography_identity import (
+    BibliographyIdentityContext,
     update_with_identity_claims,
 )
 from ebl.bibliography.application.lookup_reservation import (
@@ -69,9 +70,11 @@ def reclaim(bibliography_repository, value: str):
 
 def update_identity(context: "BibliographyIdentityUpdateContext", entry: dict) -> None:
     update_with_identity_claims(
-        context.bibliography_repository,
-        context.changelog,
-        context.bibliography.find,
+        BibliographyIdentityContext(
+            context.bibliography_repository,
+            context.changelog,
+            context.bibliography.find,
+        ),
         entry,
         context.user,
     )

--- a/ebl/tests/bibliography/test_bibliography_identity_update_recovery.py
+++ b/ebl/tests/bibliography/test_bibliography_identity_update_recovery.py
@@ -5,6 +5,9 @@ import pytest
 from pymongo.database import Database
 
 from ebl.bibliography.application.bibliography import Bibliography
+from ebl.bibliography.application.bibliography_identity import (
+    update_with_identity_claims,
+)
 from ebl.bibliography.application.lookup_reservation import (
     LookupReservationOperation,
     LookupReservationState,
@@ -64,6 +67,16 @@ def reclaim(bibliography_repository, value: str):
     )
 
 
+def update_identity(context: "BibliographyIdentityUpdateContext", entry: dict) -> None:
+    update_with_identity_claims(
+        context.bibliography_repository,
+        context.changelog,
+        context.bibliography.find,
+        entry,
+        context.user,
+    )
+
+
 def fail_once(monkeypatch, target, name: str, message: str):
     original = getattr(target, name)
     calls = {"count": 0}
@@ -97,7 +110,7 @@ def test_update_commit_failure_recovers_new_claims_and_retires_old(
     )
 
     with pytest.raises(RuntimeError, match="commit failed"):
-        context.bibliography.update(new_entry, context.user)
+        update_identity(context, new_entry)
 
     assert context.bibliography_repository.query_by_id(old_entry["id"]) == new_entry
     assert (
@@ -122,7 +135,7 @@ def test_update_commit_failure_recovers_new_claims_and_retires_old(
         == LookupReservationState.ABANDONED.value
     )
     assert context.bibliography.find("new-update-alias") == new_entry
-    context.bibliography.update(new_entry, context.user)
+    update_identity(context, new_entry)
     assert (
         context.database["bibliography"].count_documents({"_id": old_entry["id"]}) == 1
     )
@@ -143,7 +156,7 @@ def test_update_retirement_failure_reconciles_stale_old_claim(
     )
 
     with pytest.raises(RuntimeError, match="retire failed"):
-        context.bibliography.update(new_entry, context.user)
+        update_identity(context, new_entry)
 
     assert context.bibliography.find(new_entry["citationKey"]) == new_entry
     assert (
@@ -176,7 +189,7 @@ def test_update_changelog_failure_keeps_persisted_update(
     fail_once(monkeypatch, context.changelog, "create", "changelog failed")
 
     with pytest.raises(RuntimeError, match="changelog failed"):
-        context.bibliography.update(new_entry, context.user)
+        update_identity(context, new_entry)
 
     assert context.bibliography_repository.query_by_id(old_entry["id"]) == new_entry
     assert (
@@ -188,7 +201,7 @@ def test_update_changelog_failure_keeps_persisted_update(
         == LookupReservationState.ABANDONED.value
     )
     context.bibliography_repository.reconcile_lookup_reservations(FUTURE)
-    context.bibliography.update(new_entry, context.user)
+    update_identity(context, new_entry)
 
     with pytest.raises(NotFoundError):
         context.bibliography.find(old_entry["citationKey"])

--- a/ebl/tests/bibliography/test_bibliography_legacy_identity_shape.py
+++ b/ebl/tests/bibliography/test_bibliography_legacy_identity_shape.py
@@ -1,0 +1,145 @@
+import falcon
+import pytest
+
+from ebl.bibliography.application.serialization import create_mongo_entry
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CORRECTED_TITLE,
+    metadata_only_payload,
+    post_entry,
+    reservations,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+CANONICAL_ID = "rla_9_388"
+LOSER_ID = "RN2001"
+MISSING_LOSER_ID = "RN9999"
+
+
+def legacy_alias(value: str, normalized_value: str) -> dict:
+    return {
+        "value": value,
+        "normalizedValue": normalized_value,
+        "type": "legacy_id",
+        "source": "duplicate_merge_2026-08-04",
+        "status": "redirect",
+    }
+
+
+def seed(database, id_: str, **fields) -> dict:
+    entry = BibliographyEntryFactory.build(id=id_)
+    database["bibliography"].insert_one({**create_mongo_entry(entry), **fields})
+    return entry
+
+
+def stored(database, id_: str) -> dict:
+    return database["bibliography"].find_one({"_id": id_})
+
+
+@pytest.fixture
+def merged_pair(database):
+    canonical = seed(
+        database,
+        CANONICAL_ID,
+        aliases=[legacy_alias(LOSER_ID, "rn2001")],
+    )
+    seed(database, LOSER_ID, deprecated=True, redirectTo=CANONICAL_ID)
+    return canonical
+
+
+@pytest.fixture
+def alias_only_canonical(database):
+    return seed(
+        database,
+        CANONICAL_ID,
+        aliases=[legacy_alias(MISSING_LOSER_ID, "rn9999")],
+    )
+
+
+def test_merged_canonical_metadata_update_succeeds(client, database, merged_pair):
+    result = post_entry(client, metadata_only_payload(merged_pair))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored(database, CANONICAL_ID)["title"] == CORRECTED_TITLE
+
+
+def test_merged_canonical_update_keeps_the_legacy_alias(client, database, merged_pair):
+    post_entry(client, metadata_only_payload(merged_pair))
+
+    assert stored(database, CANONICAL_ID)["aliases"] == [
+        legacy_alias(LOSER_ID, "rn2001")
+    ]
+
+
+@pytest.mark.parametrize("lookup_value", [LOSER_ID, "rn2001", CANONICAL_ID])
+def test_merged_canonical_update_keeps_lookup_resolvable(
+    lookup_value, client, bibliography, merged_pair
+):
+    post_entry(client, metadata_only_payload(merged_pair))
+
+    assert bibliography.find(lookup_value)["id"] == CANONICAL_ID
+
+
+def test_merged_canonical_update_keeps_the_tombstone(client, database, merged_pair):
+    post_entry(client, metadata_only_payload(merged_pair))
+    loser = stored(database, LOSER_ID)
+
+    assert loser["deprecated"] is True
+    assert loser["redirectTo"] == CANONICAL_ID
+
+
+def test_merged_canonical_update_claims_no_reservations(client, database, merged_pair):
+    post_entry(client, metadata_only_payload(merged_pair))
+
+    assert reservations(database) == {}
+
+
+def test_alias_only_canonical_metadata_update_succeeds(
+    client, database, alias_only_canonical
+):
+    result = post_entry(client, metadata_only_payload(alias_only_canonical))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored(database, CANONICAL_ID)["title"] == CORRECTED_TITLE
+
+
+@pytest.mark.parametrize("lookup_value", [MISSING_LOSER_ID, "rn9999"])
+def test_alias_only_canonical_keeps_alias_resolvable(
+    lookup_value, client, bibliography, alias_only_canonical
+):
+    post_entry(client, metadata_only_payload(alias_only_canonical))
+
+    assert bibliography.find(lookup_value)["id"] == CANONICAL_ID
+
+
+def test_alias_shadowing_an_active_record_does_not_block_metadata_update(
+    client, database
+):
+    canonical = seed(
+        database, CANONICAL_ID, aliases=[legacy_alias("SHADOWED", "shadowed")]
+    )
+    seed(database, "SHADOWED")
+
+    result = post_entry(client, metadata_only_payload(canonical))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored(database, CANONICAL_ID)["title"] == CORRECTED_TITLE
+
+
+def test_ambiguous_alias_does_not_block_metadata_update(client, database):
+    canonical = seed(database, CANONICAL_ID, aliases=[legacy_alias("SHARED", "shared")])
+    seed(database, "Q30000077", aliases=[legacy_alias("SHARED", "shared")])
+
+    result = post_entry(client, metadata_only_payload(canonical))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored(database, CANONICAL_ID)["title"] == CORRECTED_TITLE
+
+
+def test_duplicate_citation_key_does_not_block_metadata_update(client, database):
+    canonical = seed(database, CANONICAL_ID, citationKey="shared1967Key")
+    seed(database, "Q30000078", citationKey="shared1967Key")
+
+    result = post_entry(client, metadata_only_payload(canonical))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored(database, CANONICAL_ID)["title"] == CORRECTED_TITLE

--- a/ebl/tests/bibliography/test_bibliography_lookup.py
+++ b/ebl/tests/bibliography/test_bibliography_lookup.py
@@ -1,7 +1,7 @@
 import pytest
 from mockito import verify
 
-from ebl.bibliography.application.bibliography import MAX_REDIRECT_DEPTH
+from ebl.bibliography.application.redirect_resolution import MAX_REDIRECT_DEPTH
 from ebl.errors import DuplicateError, NotFoundError
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
 

--- a/ebl/tests/bibliography/test_bibliography_query_builders.py
+++ b/ebl/tests/bibliography/test_bibliography_query_builders.py
@@ -7,6 +7,9 @@ from ebl.bibliography.infrastructure.bibliography import (
     bibliography_query_pipeline,
     join_reference_documents,
 )
+from ebl.bibliography.infrastructure.bibliography_queries import (
+    server_owned_state_filter,
+)
 
 
 def test_join_reference_documents_pipeline() -> None:
@@ -43,3 +46,28 @@ def test_query_by_author_year_and_title_uses_title_sort(
         "result"
     ]
     assert seen["trailing_sort_field"] == "title"
+
+
+def test_server_owned_state_filter_requires_absent_fields_to_stay_absent() -> None:
+    assert server_owned_state_filter("Q30000024", {}) == {
+        "_id": "Q30000024",
+        "aliases": {"$exists": False},
+        "citationKey": {"$exists": False},
+        "deprecated": {"$exists": False},
+        "redirectTo": {"$exists": False},
+    }
+
+
+def test_server_owned_state_filter_matches_stored_values_exactly() -> None:
+    filter_ = server_owned_state_filter("Q30000024", {"citationKey": "dossin1967La"})
+
+    assert filter_["citationKey"] == "dossin1967La"
+    assert filter_["aliases"] == {"$exists": False}
+
+
+def test_server_owned_state_filter_separates_a_stored_null_from_an_absent_field() -> (
+    None
+):
+    filter_ = server_owned_state_filter("Q30000024", {"redirectTo": None})
+
+    assert filter_["redirectTo"] == {"$type": "null"}

--- a/ebl/tests/bibliography/test_bibliography_repository.py
+++ b/ebl/tests/bibliography/test_bibliography_repository.py
@@ -1,15 +1,8 @@
-import re
-
 import pydash
 import pytest
 
 from ebl.bibliography.application.bibliography_repository import (
     BibliographyUpdateConflictError,
-)
-from ebl.bibliography.infrastructure.duplicate_candidate_queries import (
-    doi_query,
-    duplicate_candidate_queries,
-    identifier_pattern,
 )
 from ebl.errors import DuplicateError, NotFoundError
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
@@ -242,41 +235,3 @@ def test_update_accepts_an_unchanged_null_redirect(bibliography_repository):
     assert (
         bibliography_repository.query_by_id(bibliography_entry["id"]) == updated_entry
     )
-
-
-def test_duplicate_candidate_queries_prioritize_strong_identifiers() -> None:
-    queries = duplicate_candidate_queries(
-        {
-            "type": "article-journal",
-            "title": "A Duplicate Candidate",
-            "author": [{"family": "George"}],
-            "issued": {"date-parts": [[2003]]},
-            "DOI": "10.123/abc",
-            "ISBN": "978-0-306-40615-7",
-            "ISSN": "1234-567X",
-            "container-title": "Journal of Cuneiform Studies",
-        }
-    )
-
-    assert "DOI" in queries[0]["$or"][0]
-    assert "ISBN" in queries[1]["$or"][0]
-    assert "ISSN" in queries[-1]["$or"][0]
-
-
-def test_identifier_pattern_matches_formatted_identifier_variants() -> None:
-    pattern = re.compile(identifier_pattern("9780306406157"))
-
-    assert pattern.fullmatch("9780306406157")
-    assert pattern.fullmatch("978-0-306-40615-7")
-    assert pattern.fullmatch("978 0 306 40615 7")
-    assert not pattern.fullmatch("978O306406157")
-
-
-def test_doi_query_matches_case_insensitive_variants() -> None:
-    query = doi_query(["10.123/abc"])
-    regex = query["$or"][1]["DOI"]
-    pattern = re.compile(regex["$regex"], re.IGNORECASE)
-
-    assert regex["$options"] == "i"
-    assert pattern.fullmatch("10.123/ABC")
-    assert not pattern.fullmatch("prefix 10.123/ABC")

--- a/ebl/tests/bibliography/test_bibliography_repository.py
+++ b/ebl/tests/bibliography/test_bibliography_repository.py
@@ -3,6 +3,9 @@ import re
 import pydash
 import pytest
 
+from ebl.bibliography.application.bibliography_repository import (
+    BibliographyUpdateConflictError,
+)
 from ebl.bibliography.infrastructure.duplicate_candidate_queries import (
     doi_query,
     duplicate_candidate_queries,
@@ -207,6 +210,38 @@ def test_update_not_found(bibliography_repository):
     bibliography_entry = BibliographyEntryFactory.build()
     with pytest.raises(NotFoundError):
         bibliography_repository.update(bibliography_entry, {})
+
+
+def test_update_detects_a_concurrently_removed_null_redirect(
+    bibliography_repository, database
+):
+    bibliography_entry = BibliographyEntryFactory.build(redirectTo=None)
+    bibliography_repository.create(bibliography_entry)
+    database[COLLECTION].update_one(
+        {"_id": bibliography_entry["id"]}, {"$unset": {"redirectTo": ""}}
+    )
+
+    with pytest.raises(BibliographyUpdateConflictError):
+        bibliography_repository.update(
+            {**bibliography_entry, "title": "New Title"}, {"redirectTo": None}
+        )
+
+    assert (
+        database[COLLECTION].find_one({"_id": bibliography_entry["id"]})["title"]
+        == bibliography_entry["title"]
+    )
+
+
+def test_update_accepts_an_unchanged_null_redirect(bibliography_repository):
+    bibliography_entry = BibliographyEntryFactory.build(redirectTo=None)
+    updated_entry = {**bibliography_entry, "title": "New Title"}
+    bibliography_repository.create(bibliography_entry)
+
+    bibliography_repository.update(updated_entry, {"redirectTo": None})
+
+    assert (
+        bibliography_repository.query_by_id(bibliography_entry["id"]) == updated_entry
+    )
 
 
 def test_duplicate_candidate_queries_prioritize_strong_identifiers() -> None:

--- a/ebl/tests/bibliography/test_bibliography_repository.py
+++ b/ebl/tests/bibliography/test_bibliography_repository.py
@@ -196,7 +196,7 @@ def test_update(bibliography_repository):
     bibliography_entry = BibliographyEntryFactory.build()
     updated_entry = pydash.omit({**bibliography_entry, "title": "New Title"}, "PMID")
     bibliography_repository.create(bibliography_entry)
-    bibliography_repository.update(updated_entry)
+    bibliography_repository.update(updated_entry, {})
 
     assert (
         bibliography_repository.query_by_id(bibliography_entry["id"]) == updated_entry
@@ -206,7 +206,7 @@ def test_update(bibliography_repository):
 def test_update_not_found(bibliography_repository):
     bibliography_entry = BibliographyEntryFactory.build()
     with pytest.raises(NotFoundError):
-        bibliography_repository.update(bibliography_entry)
+        bibliography_repository.update(bibliography_entry, {})
 
 
 def test_duplicate_candidate_queries_prioritize_strong_identifiers() -> None:

--- a/ebl/tests/bibliography/test_bibliography_route.py
+++ b/ebl/tests/bibliography/test_bibliography_route.py
@@ -195,3 +195,25 @@ def test_list_bibliography_deduplicates_redirected_canonical_entries(
 
     assert result.status == falcon.HTTP_OK
     assert result.json == [canonical_entry]
+
+
+def test_update_entry_rejects_a_non_object_body(client, saved_entry):
+    result = client.simulate_post(
+        f"/bibliography/{saved_entry['id']}", body=json.dumps([saved_entry])
+    )
+
+    assert result.status == falcon.HTTP_BAD_REQUEST
+
+
+def test_list_bibliography_serves_the_cached_response(
+    cached_client, bibliography, user
+):
+    entry = BibliographyEntryFactory.build(id="Q30000123")
+    bibliography.create(entry, user)
+    url = "/bibliography/list"
+
+    first_result = cached_client.simulate_get(url, params={"ids": entry["id"]})
+    second_result = cached_client.simulate_get(url, params={"ids": entry["id"]})
+
+    assert first_result.status == falcon.HTTP_OK
+    assert second_result.json == first_result.json

--- a/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
@@ -7,13 +7,20 @@ persists the submitted value, which keeps the remedy the same as for a write
 that races the request: reload the entry and retry.
 """
 
+from dataclasses import dataclass
+from typing import Callable
+
 import falcon
 import pytest
+from falcon import testing
+from pymongo.database import Database
 
+from ebl.bibliography.application.bibliography import Bibliography
 from ebl.bibliography.application.bibliography_identity import (
     BibliographyIdentityContext,
     update_with_identity_claims,
 )
+from ebl.users.domain.user import User
 from ebl.tests.bibliography.identity_preservation_test_helpers import (
     CITATION_KEY,
     CORRECTED_TITLE,
@@ -174,31 +181,57 @@ def test_an_invented_identity_value_is_also_a_conflict(
     assert stored_entry["title"] == aliased_entry["title"]
 
 
-def test_a_stale_body_cannot_resurrect_a_tombstoned_entry(
-    client,
-    bibliography,
-    database,
-    user,
-    aliased_entry,
-    fetched_entry,
-    identity_operation,
-):
-    bibliography.create(
-        BibliographyEntryFactory.build(id=CANONICAL_ID, title="Canonical"), user
-    )
-    identity_operation(
-        {**fetched_entry, "deprecated": True, "redirectTo": CANONICAL_ID}
+@dataclass(frozen=True)
+class StaleTombstoneResurrectionContext:
+    client: testing.TestClient
+    bibliography: Bibliography
+    database: Database
+    user: User
+    aliased_entry: dict
+    fetched_entry: dict
+    identity_operation: Callable[[dict], None]
+
+
+@pytest.fixture
+def stale_tombstone_resurrection_context(
+    request: pytest.FixtureRequest,
+) -> StaleTombstoneResurrectionContext:
+    return StaleTombstoneResurrectionContext(
+        request.getfixturevalue("client"),
+        request.getfixturevalue("bibliography"),
+        request.getfixturevalue("database"),
+        request.getfixturevalue("user"),
+        request.getfixturevalue("aliased_entry"),
+        request.getfixturevalue("fetched_entry"),
+        request.getfixturevalue("identity_operation"),
     )
 
-    result = post_entry(client, stale_payload(fetched_entry))
-    stored_entry = database["bibliography"].find_one({"_id": aliased_entry["id"]})
+
+def test_a_stale_body_cannot_resurrect_a_tombstoned_entry(
+    stale_tombstone_resurrection_context: StaleTombstoneResurrectionContext,
+) -> None:
+    context = stale_tombstone_resurrection_context
+    context.bibliography.create(
+        BibliographyEntryFactory.build(id=CANONICAL_ID, title="Canonical"),
+        context.user,
+    )
+    context.identity_operation(
+        {**context.fetched_entry, "deprecated": True, "redirectTo": CANONICAL_ID}
+    )
+
+    result = post_entry(context.client, stale_payload(context.fetched_entry))
+    stored_entry = context.database["bibliography"].find_one(
+        {"_id": context.aliased_entry["id"]}
+    )
 
     assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
     assert "is deprecated" in result.text
     assert stored_entry["deprecated"] is True
     assert stored_entry["redirectTo"] == CANONICAL_ID
-    assert stored_entry["title"] == aliased_entry["title"]
-    assert bibliography.find(aliased_entry["id"])["id"] == CANONICAL_ID
+    assert stored_entry["title"] == context.aliased_entry["title"]
+    assert (
+        context.bibliography.find(context.aliased_entry["id"])["id"] == CANONICAL_ID
+    )
 
 
 @pytest.mark.parametrize(

--- a/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
@@ -229,9 +229,7 @@ def test_a_stale_body_cannot_resurrect_a_tombstoned_entry(
     assert stored_entry["deprecated"] is True
     assert stored_entry["redirectTo"] == CANONICAL_ID
     assert stored_entry["title"] == context.aliased_entry["title"]
-    assert (
-        context.bibliography.find(context.aliased_entry["id"])["id"] == CANONICAL_ID
-    )
+    assert context.bibliography.find(context.aliased_entry["id"])["id"] == CANONICAL_ID
 
 
 @pytest.mark.parametrize(

--- a/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
@@ -1,0 +1,213 @@
+"""Cross-request conflict contract for the generic metadata update.
+
+A client can only submit server-owned state it fetched earlier, so when that
+state disagrees with what is stored the server cannot tell a stale editor from
+a client inventing an identity value. Both answer `409 Conflict` and neither
+persists the submitted value, which keeps the remedy the same as for a write
+that races the request: reload the entry and retry.
+"""
+
+import falcon
+import pytest
+
+from ebl.bibliography.application.bibliography_identity import (
+    BibliographyIdentityContext,
+    update_with_identity_claims,
+)
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CITATION_KEY,
+    CORRECTED_TITLE,
+    PARTNER_ALIAS,
+    metadata_only_payload,
+    post_entry,
+    reservations,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+CANONICAL_ID = "rla_9_388"
+NEW_CITATION_KEY = "dossin1967Lb"
+MERGED_ALIAS = {
+    "value": "RN9001",
+    "normalizedValue": "rn9001",
+    "type": "legacy_id",
+    "source": "duplicate_merge_2026-08-04",
+    "status": "redirect",
+}
+ADDED_ALIASES = [PARTNER_ALIAS, MERGED_ALIAS]
+
+
+@pytest.fixture
+def identity_operation(bibliography, bibliography_repository, changelog, user):
+    """Mutate identity the way a trusted operation would, bypassing the route."""
+
+    def operate(entry: dict) -> None:
+        update_with_identity_claims(
+            BibliographyIdentityContext(
+                bibliography_repository, changelog, bibliography.find
+            ),
+            entry,
+            user,
+        )
+
+    return operate
+
+
+@pytest.fixture
+def fetched_entry(client, aliased_entry) -> dict:
+    return client.simulate_get(f"/bibliography/{aliased_entry['id']}").json
+
+
+def stale_payload(fetched_entry: dict) -> dict:
+    return {**fetched_entry, "title": CORRECTED_TITLE}
+
+
+def changelog_count(database, id_: str) -> int:
+    return database["changelog"].count_documents({"resource_id": id_})
+
+
+def test_stale_aliases_are_a_conflict(client, fetched_entry, identity_operation):
+    identity_operation({**fetched_entry, "aliases": ADDED_ALIASES})
+
+    result = post_entry(client, stale_payload(fetched_entry))
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "aliases" in result.text
+    assert "reload" in result.text
+
+
+def test_stale_aliases_conflict_keeps_the_added_alias(
+    client, bibliography, aliased_entry, fetched_entry, identity_operation
+):
+    identity_operation({**fetched_entry, "aliases": ADDED_ALIASES})
+
+    post_entry(client, stale_payload(fetched_entry))
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert stored_entry["aliases"] == ADDED_ALIASES
+    assert stored_entry["title"] == aliased_entry["title"]
+
+
+def test_stale_citation_key_is_a_conflict(client, fetched_entry, identity_operation):
+    identity_operation({**fetched_entry, "citationKey": NEW_CITATION_KEY})
+
+    result = post_entry(client, stale_payload(fetched_entry))
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert "citationKey" in result.text
+
+
+def test_stale_citation_key_conflict_keeps_the_new_key(
+    client, bibliography, aliased_entry, fetched_entry, identity_operation
+):
+    identity_operation({**fetched_entry, "citationKey": NEW_CITATION_KEY})
+
+    post_entry(client, stale_payload(fetched_entry))
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert stored_entry["citationKey"] == NEW_CITATION_KEY
+    assert stored_entry["title"] == aliased_entry["title"]
+    assert bibliography.find(NEW_CITATION_KEY)["id"] == aliased_entry["id"]
+
+
+def test_stale_conflict_writes_no_changelog_entry(
+    client, database, aliased_entry, fetched_entry, identity_operation
+):
+    identity_operation({**fetched_entry, "aliases": ADDED_ALIASES})
+    before = changelog_count(database, aliased_entry["id"])
+
+    post_entry(client, stale_payload(fetched_entry))
+
+    assert changelog_count(database, aliased_entry["id"]) == before
+
+
+def test_stale_conflict_claims_no_reservations(
+    client, database, fetched_entry, identity_operation
+):
+    identity_operation({**fetched_entry, "citationKey": NEW_CITATION_KEY})
+    before = reservations(database)
+
+    post_entry(client, stale_payload(fetched_entry))
+
+    assert reservations(database) == before
+
+
+def test_reload_and_retry_after_a_stale_conflict_succeeds(
+    client, bibliography, aliased_entry, fetched_entry, identity_operation
+):
+    identity_operation({**fetched_entry, "aliases": ADDED_ALIASES})
+    conflict = post_entry(client, stale_payload(fetched_entry))
+
+    reloaded_entry = client.simulate_get(f"/bibliography/{aliased_entry['id']}").json
+    result = post_entry(client, stale_payload(reloaded_entry))
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert conflict.status == falcon.HTTP_CONFLICT
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored_entry["title"] == CORRECTED_TITLE
+    assert stored_entry["aliases"] == ADDED_ALIASES
+    assert stored_entry["citationKey"] == CITATION_KEY
+
+
+def test_metadata_only_update_succeeds_after_an_identity_change(
+    client, bibliography, aliased_entry, fetched_entry, identity_operation
+):
+    identity_operation({**fetched_entry, "aliases": ADDED_ALIASES})
+
+    result = post_entry(client, metadata_only_payload(aliased_entry))
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored_entry["title"] == CORRECTED_TITLE
+    assert stored_entry["aliases"] == ADDED_ALIASES
+
+
+def test_an_invented_identity_value_is_also_a_conflict(
+    client, bibliography, aliased_entry, fetched_entry
+):
+    payload = {**stale_payload(fetched_entry), "citationKey": "invented1999Key"}
+
+    result = post_entry(client, payload)
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert stored_entry["citationKey"] == CITATION_KEY
+    assert stored_entry["title"] == aliased_entry["title"]
+
+
+def test_a_stale_body_cannot_resurrect_a_tombstoned_entry(
+    client,
+    bibliography,
+    database,
+    user,
+    aliased_entry,
+    fetched_entry,
+    identity_operation,
+):
+    bibliography.create(
+        BibliographyEntryFactory.build(id=CANONICAL_ID, title="Canonical"), user
+    )
+    identity_operation(
+        {**fetched_entry, "deprecated": True, "redirectTo": CANONICAL_ID}
+    )
+
+    result = post_entry(client, stale_payload(fetched_entry))
+    stored_entry = database["bibliography"].find_one({"_id": aliased_entry["id"]})
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert "is deprecated" in result.text
+    assert stored_entry["deprecated"] is True
+    assert stored_entry["redirectTo"] == CANONICAL_ID
+    assert stored_entry["title"] == aliased_entry["title"]
+    assert bibliography.find(aliased_entry["id"])["id"] == CANONICAL_ID
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("aliases", "not-a-list"), ("citationKey", 7), ("deprecated", "yes")],
+)
+def test_a_malformed_server_owned_value_is_rejected_by_the_schema(
+    field, value, client, fetched_entry
+):
+    result = post_entry(client, {**stale_payload(fetched_entry), field: value})
+
+    assert result.status == falcon.HTTP_BAD_REQUEST

--- a/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_stale_identity_conflict.py
@@ -223,6 +223,7 @@ def test_a_stale_body_cannot_resurrect_a_tombstoned_entry(
     stored_entry = context.database["bibliography"].find_one(
         {"_id": context.aliased_entry["id"]}
     )
+    assert stored_entry is not None
 
     assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
     assert "is deprecated" in result.text

--- a/ebl/tests/bibliography/test_bibliography_update_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_update_conflict.py
@@ -1,0 +1,146 @@
+import falcon
+import pytest
+
+from ebl.bibliography.application.bibliography_repository import (
+    BibliographyUpdateConflictError,
+)
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CORRECTED_TITLE,
+    metadata_only_payload,
+    post_entry,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+CONCURRENT_ALIAS = {
+    "value": "RN9001",
+    "normalizedValue": "rn9001",
+    "type": "legacy_id",
+    "source": "duplicate_merge_2026-08-04",
+    "status": "redirect",
+}
+
+
+@pytest.fixture
+def active_entry(bibliography, user):
+    entry = BibliographyEntryFactory.build(id="Q30000042", title="Before")
+    bibliography.create(entry, user)
+    return entry
+
+
+def inject_concurrent_write(monkeypatch, bibliography_repository, database, update):
+    def claim_lookup_values(_operation, _values):
+        database["bibliography"].update_one({"_id": "Q30000042"}, update)
+
+    monkeypatch.setattr(
+        bibliography_repository, "claim_lookup_values", claim_lookup_values
+    )
+
+
+def stored(database):
+    return database["bibliography"].find_one({"_id": "Q30000042"})
+
+
+def test_metadata_update_succeeds_without_concurrent_write(
+    client, database, active_entry
+):
+    result = post_entry(client, metadata_only_payload(active_entry))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert stored(database)["title"] == CORRECTED_TITLE
+
+
+def test_concurrently_added_alias_makes_metadata_update_conflict(
+    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
+):
+    inject_concurrent_write(
+        monkeypatch,
+        bibliography_repository,
+        database,
+        {"$push": {"aliases": CONCURRENT_ALIAS}},
+    )
+
+    with pytest.raises(BibliographyUpdateConflictError):
+        bibliography.update(metadata_only_payload(active_entry), user)
+
+
+def test_concurrently_added_alias_survives_the_conflict(
+    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
+):
+    inject_concurrent_write(
+        monkeypatch,
+        bibliography_repository,
+        database,
+        {"$push": {"aliases": CONCURRENT_ALIAS}},
+    )
+
+    with pytest.raises(BibliographyUpdateConflictError):
+        bibliography.update(metadata_only_payload(active_entry), user)
+    stored_entry = stored(database)
+
+    assert stored_entry["aliases"] == [CONCURRENT_ALIAS]
+    assert stored_entry["title"] == active_entry["title"]
+
+
+def test_concurrent_deprecation_makes_metadata_update_conflict(
+    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
+):
+    inject_concurrent_write(
+        monkeypatch,
+        bibliography_repository,
+        database,
+        {"$set": {"deprecated": True, "redirectTo": "rla_9_388"}},
+    )
+
+    with pytest.raises(BibliographyUpdateConflictError):
+        bibliography.update(metadata_only_payload(active_entry), user)
+
+
+def test_concurrent_tombstone_survives_the_conflict(
+    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
+):
+    inject_concurrent_write(
+        monkeypatch,
+        bibliography_repository,
+        database,
+        {"$set": {"deprecated": True, "redirectTo": "rla_9_388"}},
+    )
+
+    with pytest.raises(BibliographyUpdateConflictError):
+        bibliography.update(metadata_only_payload(active_entry), user)
+    stored_entry = stored(database)
+
+    assert stored_entry["deprecated"] is True
+    assert stored_entry["redirectTo"] == "rla_9_388"
+    assert stored_entry["title"] == active_entry["title"]
+
+
+def test_conflict_writes_no_changelog_entry(
+    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
+):
+    before = database["changelog"].count_documents({"resource_id": "Q30000042"})
+    inject_concurrent_write(
+        monkeypatch,
+        bibliography_repository,
+        database,
+        {"$push": {"aliases": CONCURRENT_ALIAS}},
+    )
+
+    with pytest.raises(BibliographyUpdateConflictError):
+        bibliography.update(metadata_only_payload(active_entry), user)
+
+    assert database["changelog"].count_documents({"resource_id": "Q30000042"}) == before
+
+
+def test_conflict_is_reported_as_http_conflict(
+    monkeypatch, client, bibliography_repository, database, active_entry
+):
+    inject_concurrent_write(
+        monkeypatch,
+        bibliography_repository,
+        database,
+        {"$push": {"aliases": CONCURRENT_ALIAS}},
+    )
+
+    result = post_entry(client, metadata_only_payload(active_entry))
+
+    assert result.status == falcon.HTTP_CONFLICT

--- a/ebl/tests/bibliography/test_bibliography_update_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_update_conflict.py
@@ -1,16 +1,25 @@
+from dataclasses import dataclass
+
 import falcon
 import pytest
+from falcon import testing
+from pymongo.database import Database
 
+from ebl.bibliography.application.bibliography import Bibliography
 from ebl.bibliography.application.bibliography_repository import (
     BibliographyUpdateConflictError,
 )
+from ebl.bibliography.infrastructure.bibliography import MongoBibliographyRepository
 from ebl.tests.bibliography.identity_preservation_test_helpers import (
     CORRECTED_TITLE,
     metadata_only_payload,
     post_entry,
 )
 from ebl.tests.factories.bibliography import BibliographyEntryFactory
+from ebl.users.domain.user import User
 
+ENTRY_ID = "Q30000042"
+ORIGINAL_TITLE = "Before"
 CONCURRENT_ALIAS = {
     "value": "RN9001",
     "normalizedValue": "rn9001",
@@ -18,129 +27,126 @@ CONCURRENT_ALIAS = {
     "source": "duplicate_merge_2026-08-04",
     "status": "redirect",
 }
+ADD_ALIAS = {"$push": {"aliases": CONCURRENT_ALIAS}}
+DEPRECATE = {"$set": {"deprecated": True, "redirectTo": "rla_9_388"}}
+
+
+@dataclass(frozen=True)
+class UpdateConflictContext:
+    bibliography: Bibliography
+    bibliography_repository: MongoBibliographyRepository
+    database: Database
+    client: testing.TestClient
+    user: User
+    entry: dict
 
 
 @pytest.fixture
-def active_entry(bibliography, user):
-    entry = BibliographyEntryFactory.build(id="Q30000042", title="Before")
+def conflict_context(request: pytest.FixtureRequest) -> UpdateConflictContext:
+    bibliography = request.getfixturevalue("bibliography")
+    user = request.getfixturevalue("user")
+    entry = BibliographyEntryFactory.build(id=ENTRY_ID, title=ORIGINAL_TITLE)
     bibliography.create(entry, user)
-    return entry
-
-
-def inject_concurrent_write(monkeypatch, bibliography_repository, database, update):
-    def claim_lookup_values(_operation, _values):
-        database["bibliography"].update_one({"_id": "Q30000042"}, update)
-
-    monkeypatch.setattr(
-        bibliography_repository, "claim_lookup_values", claim_lookup_values
+    return UpdateConflictContext(
+        bibliography,
+        request.getfixturevalue("bibliography_repository"),
+        request.getfixturevalue("database"),
+        request.getfixturevalue("client"),
+        user,
+        entry,
     )
 
 
-def stored(database):
-    return database["bibliography"].find_one({"_id": "Q30000042"})
+def inject_concurrent_write(
+    monkeypatch: pytest.MonkeyPatch, context: UpdateConflictContext, update: dict
+) -> None:
+    def claim_lookup_values(_operation, _values) -> None:
+        context.database["bibliography"].update_one({"_id": ENTRY_ID}, update)
+
+    monkeypatch.setattr(
+        context.bibliography_repository, "claim_lookup_values", claim_lookup_values
+    )
 
 
-def test_metadata_update_succeeds_without_concurrent_write(
-    client, database, active_entry
-):
-    result = post_entry(client, metadata_only_payload(active_entry))
+def update_metadata(context: UpdateConflictContext) -> None:
+    context.bibliography.update(metadata_only_payload(context.entry), context.user)
+
+
+def stored(context: UpdateConflictContext) -> dict:
+    document = context.database["bibliography"].find_one({"_id": ENTRY_ID})
+    assert document is not None
+    return document
+
+
+def changelog_count(context: UpdateConflictContext) -> int:
+    return context.database["changelog"].count_documents({"resource_id": ENTRY_ID})
+
+
+def test_metadata_update_succeeds_without_concurrent_write(conflict_context):
+    result = post_entry(
+        conflict_context.client, metadata_only_payload(conflict_context.entry)
+    )
 
     assert result.status == falcon.HTTP_NO_CONTENT
-    assert stored(database)["title"] == CORRECTED_TITLE
+    assert stored(conflict_context)["title"] == CORRECTED_TITLE
 
 
 def test_concurrently_added_alias_makes_metadata_update_conflict(
-    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
+    monkeypatch, conflict_context
 ):
-    inject_concurrent_write(
-        monkeypatch,
-        bibliography_repository,
-        database,
-        {"$push": {"aliases": CONCURRENT_ALIAS}},
-    )
+    inject_concurrent_write(monkeypatch, conflict_context, ADD_ALIAS)
 
     with pytest.raises(BibliographyUpdateConflictError):
-        bibliography.update(metadata_only_payload(active_entry), user)
+        update_metadata(conflict_context)
 
 
-def test_concurrently_added_alias_survives_the_conflict(
-    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
-):
-    inject_concurrent_write(
-        monkeypatch,
-        bibliography_repository,
-        database,
-        {"$push": {"aliases": CONCURRENT_ALIAS}},
-    )
+def test_concurrently_added_alias_survives_the_conflict(monkeypatch, conflict_context):
+    inject_concurrent_write(monkeypatch, conflict_context, ADD_ALIAS)
 
     with pytest.raises(BibliographyUpdateConflictError):
-        bibliography.update(metadata_only_payload(active_entry), user)
-    stored_entry = stored(database)
+        update_metadata(conflict_context)
+    stored_entry = stored(conflict_context)
 
     assert stored_entry["aliases"] == [CONCURRENT_ALIAS]
-    assert stored_entry["title"] == active_entry["title"]
+    assert stored_entry["title"] == ORIGINAL_TITLE
 
 
 def test_concurrent_deprecation_makes_metadata_update_conflict(
-    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
+    monkeypatch, conflict_context
 ):
-    inject_concurrent_write(
-        monkeypatch,
-        bibliography_repository,
-        database,
-        {"$set": {"deprecated": True, "redirectTo": "rla_9_388"}},
-    )
+    inject_concurrent_write(monkeypatch, conflict_context, DEPRECATE)
 
     with pytest.raises(BibliographyUpdateConflictError):
-        bibliography.update(metadata_only_payload(active_entry), user)
+        update_metadata(conflict_context)
 
 
-def test_concurrent_tombstone_survives_the_conflict(
-    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
-):
-    inject_concurrent_write(
-        monkeypatch,
-        bibliography_repository,
-        database,
-        {"$set": {"deprecated": True, "redirectTo": "rla_9_388"}},
-    )
+def test_concurrent_tombstone_survives_the_conflict(monkeypatch, conflict_context):
+    inject_concurrent_write(monkeypatch, conflict_context, DEPRECATE)
 
     with pytest.raises(BibliographyUpdateConflictError):
-        bibliography.update(metadata_only_payload(active_entry), user)
-    stored_entry = stored(database)
+        update_metadata(conflict_context)
+    stored_entry = stored(conflict_context)
 
     assert stored_entry["deprecated"] is True
     assert stored_entry["redirectTo"] == "rla_9_388"
-    assert stored_entry["title"] == active_entry["title"]
+    assert stored_entry["title"] == ORIGINAL_TITLE
 
 
-def test_conflict_writes_no_changelog_entry(
-    monkeypatch, bibliography, bibliography_repository, database, user, active_entry
-):
-    before = database["changelog"].count_documents({"resource_id": "Q30000042"})
-    inject_concurrent_write(
-        monkeypatch,
-        bibliography_repository,
-        database,
-        {"$push": {"aliases": CONCURRENT_ALIAS}},
-    )
+def test_conflict_writes_no_changelog_entry(monkeypatch, conflict_context):
+    before = changelog_count(conflict_context)
+    inject_concurrent_write(monkeypatch, conflict_context, ADD_ALIAS)
 
     with pytest.raises(BibliographyUpdateConflictError):
-        bibliography.update(metadata_only_payload(active_entry), user)
+        update_metadata(conflict_context)
 
-    assert database["changelog"].count_documents({"resource_id": "Q30000042"}) == before
+    assert changelog_count(conflict_context) == before
 
 
-def test_conflict_is_reported_as_http_conflict(
-    monkeypatch, client, bibliography_repository, database, active_entry
-):
-    inject_concurrent_write(
-        monkeypatch,
-        bibliography_repository,
-        database,
-        {"$push": {"aliases": CONCURRENT_ALIAS}},
+def test_conflict_is_reported_as_http_conflict(monkeypatch, conflict_context):
+    inject_concurrent_write(monkeypatch, conflict_context, ADD_ALIAS)
+
+    result = post_entry(
+        conflict_context.client, metadata_only_payload(conflict_context.entry)
     )
-
-    result = post_entry(client, metadata_only_payload(active_entry))
 
     assert result.status == falcon.HTTP_CONFLICT

--- a/ebl/tests/bibliography/test_bibliography_update_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_update_conflict.py
@@ -69,7 +69,9 @@ def inject_concurrent_write(
 
 
 def update_metadata(context: UpdateConflictContext) -> None:
-    context.bibliography.update(metadata_only_payload(context.entry), context.user)
+    context.bibliography.update_metadata(
+        metadata_only_payload(context.entry), context.user
+    )
 
 
 def stored(context: UpdateConflictContext) -> dict:
@@ -150,6 +152,31 @@ def test_conflict_is_reported_as_http_conflict(monkeypatch, conflict_context):
     )
 
     assert result.status == falcon.HTTP_CONFLICT
+
+
+def test_tombstone_race_during_the_request_is_a_conflict_not_a_rejection(
+    monkeypatch, conflict_context
+):
+    """The entry is live when the route reads it and is deprecated mid-request.
+
+    This differs from posting to an already-deprecated id (422, the entry is
+    deprecated before the route ever reads it): the CAS write below the route
+    finds the stored state changed out from under it and reports 409, the same
+    remedy as any other in-request identity race.
+    """
+    inject_concurrent_write(monkeypatch, conflict_context, DEPRECATE)
+    before = changelog_count(conflict_context)
+
+    result = post_entry(
+        conflict_context.client, metadata_only_payload(conflict_context.entry)
+    )
+    stored_entry = stored(conflict_context)
+
+    assert result.status == falcon.HTTP_CONFLICT
+    assert stored_entry["deprecated"] is True
+    assert stored_entry["redirectTo"] == "rla_9_388"
+    assert stored_entry["title"] == ORIGINAL_TITLE
+    assert changelog_count(conflict_context) == before
 
 
 def test_conflict_error_names_the_mismatched_fields():

--- a/ebl/tests/bibliography/test_bibliography_update_conflict.py
+++ b/ebl/tests/bibliography/test_bibliography_update_conflict.py
@@ -150,3 +150,18 @@ def test_conflict_is_reported_as_http_conflict(monkeypatch, conflict_context):
     )
 
     assert result.status == falcon.HTTP_CONFLICT
+
+
+def test_conflict_error_names_the_mismatched_fields():
+    error = BibliographyUpdateConflictError(ENTRY_ID, ["aliases", "citationKey"])
+
+    assert error.fields == ("aliases", "citationKey")
+    assert "aliases, citationKey" in str(error)
+    assert "reload the entry and retry" in str(error)
+
+
+def test_conflict_error_without_fields_reports_a_concurrent_change():
+    error = BibliographyUpdateConflictError(ENTRY_ID)
+
+    assert error.fields == ()
+    assert "changed by another operation" in str(error)

--- a/ebl/tests/bibliography/test_bibliography_update_target.py
+++ b/ebl/tests/bibliography/test_bibliography_update_target.py
@@ -1,0 +1,102 @@
+"""Which record a metadata update is allowed to write to.
+
+Reads follow identity and writes do not. `GET /bibliography/{id}` resolves a
+citation key, an alias or a redirect and answers with the canonical entry, but
+the matching `POST` refuses every identifier except the entry's own id, so an
+edit can never land on a record the caller never looked at. The refusal names
+the record to edit instead, which is the part that used to be a bare `404`.
+"""
+
+import falcon
+import pytest
+
+from ebl.bibliography.application.bibliography_repository import (
+    BibliographyUpdateConflictError,
+)
+from ebl.tests.bibliography.identity_preservation_test_helpers import (
+    CITATION_KEY,
+    CORRECTED_TITLE,
+    PARTNER_ALIAS,
+    metadata_only_payload,
+    post_entry,
+)
+from ebl.tests.factories.bibliography import BibliographyEntryFactory
+
+NON_CANONICAL_IDENTIFIERS = [CITATION_KEY, PARTNER_ALIAS["value"]]
+
+
+def payload_for(entry: dict, id_: str) -> dict:
+    return {**metadata_only_payload(entry), "id": id_}
+
+
+@pytest.mark.parametrize("identifier", NON_CANONICAL_IDENTIFIERS)
+def test_update_through_a_citation_key_or_alias_is_refused(
+    identifier, client, aliased_entry
+):
+    result = post_entry(client, payload_for(aliased_entry, identifier))
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize("identifier", NON_CANONICAL_IDENTIFIERS)
+def test_refusal_names_the_record_to_edit_instead(identifier, client, aliased_entry):
+    result = post_entry(client, payload_for(aliased_entry, identifier))
+
+    assert aliased_entry["id"] in result.text
+
+
+@pytest.mark.parametrize("identifier", NON_CANONICAL_IDENTIFIERS)
+def test_a_refused_identifier_writes_nothing(
+    identifier, client, bibliography, aliased_entry
+):
+    post_entry(client, payload_for(aliased_entry, identifier))
+    stored_entry = bibliography.find(aliased_entry["id"])
+
+    assert stored_entry["title"] == aliased_entry["title"]
+    assert stored_entry["aliases"] == [PARTNER_ALIAS]
+    assert stored_entry["citationKey"] == CITATION_KEY
+
+
+def test_update_through_the_canonical_id_still_succeeds(
+    client, bibliography, aliased_entry
+):
+    result = post_entry(client, metadata_only_payload(aliased_entry))
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert bibliography.find(aliased_entry["id"])["title"] == CORRECTED_TITLE
+
+
+def test_update_through_a_deprecated_id_names_the_redirect_target(
+    client, deprecated_entry
+):
+    result = post_entry(client, metadata_only_payload(deprecated_entry))
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+    assert "is deprecated" in result.text
+    assert "rla_9_388" in result.text
+
+
+def test_an_identifier_that_resolves_to_nothing_is_still_not_found(client):
+    entry = BibliographyEntryFactory.build()
+
+    result = post_entry(client, entry)
+
+    assert result.status == falcon.HTTP_NOT_FOUND
+
+
+def test_a_direct_caller_supplying_stale_identity_fails_loudly(
+    bibliography, user, aliased_entry
+):
+    """The trusted path no longer drops server-owned fields in silence.
+
+    `Bibliography.update` used to ignore whatever identity a caller supplied,
+    so a stale one produced a successful write that quietly kept the stored
+    values. There is now one metadata editor and it reports the mismatch.
+    """
+    stale_entry = {**aliased_entry, "citationKey": "someoneElse1999Aa"}
+
+    with pytest.raises(BibliographyUpdateConflictError) as conflict:
+        bibliography.update_metadata(stale_entry, user)
+
+    assert conflict.value.fields == ("citationKey",)
+    assert bibliography.find(aliased_entry["id"])["citationKey"] == CITATION_KEY

--- a/ebl/tests/bibliography/test_duplicate_candidate_queries.py
+++ b/ebl/tests/bibliography/test_duplicate_candidate_queries.py
@@ -1,7 +1,12 @@
+import re
+
 from ebl.bibliography.infrastructure.duplicate_candidate_queries import (
     container_title_year_query,
     contributor_year_query,
+    doi_query,
+    duplicate_candidate_queries,
     first_contributor_family,
+    identifier_pattern,
     series_query_from_entry,
     year_title_query,
 )
@@ -19,3 +24,41 @@ def test_series_query_from_title_short_and_volume() -> None:
         "title-short": "BE",
         "volume": "1",
     }
+
+
+def test_duplicate_candidate_queries_prioritize_strong_identifiers() -> None:
+    queries = duplicate_candidate_queries(
+        {
+            "type": "article-journal",
+            "title": "A Duplicate Candidate",
+            "author": [{"family": "George"}],
+            "issued": {"date-parts": [[2003]]},
+            "DOI": "10.123/abc",
+            "ISBN": "978-0-306-40615-7",
+            "ISSN": "1234-567X",
+            "container-title": "Journal of Cuneiform Studies",
+        }
+    )
+
+    assert "DOI" in queries[0]["$or"][0]
+    assert "ISBN" in queries[1]["$or"][0]
+    assert "ISSN" in queries[-1]["$or"][0]
+
+
+def test_identifier_pattern_matches_formatted_identifier_variants() -> None:
+    pattern = re.compile(identifier_pattern("9780306406157"))
+
+    assert pattern.fullmatch("9780306406157")
+    assert pattern.fullmatch("978-0-306-40615-7")
+    assert pattern.fullmatch("978 0 306 40615 7")
+    assert not pattern.fullmatch("978O306406157")
+
+
+def test_doi_query_matches_case_insensitive_variants() -> None:
+    query = doi_query(["10.123/abc"])
+    regex = query["$or"][1]["DOI"]
+    pattern = re.compile(regex["$regex"], re.IGNORECASE)
+
+    assert regex["$options"] == "i"
+    assert pattern.fullmatch("10.123/ABC")
+    assert not pattern.fullmatch("prefix 10.123/ABC")

--- a/ebl/tests/bibliography/test_partner_bibliography_override_additional_success_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_override_additional_success_route.py
@@ -58,7 +58,7 @@ def test_partner_bibliography_duplicate_override_reruns_duplicate_detection(
     assert preflight.status == falcon.HTTP_OK
     assert preflight.json["candidates"][0]["id"] == existing_entry["id"]
 
-    bibliography.update(
+    bibliography.update_metadata(
         {
             **existing_entry,
             "type": "book",

--- a/ebl/tests/bibliography/test_partner_bibliography_update_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_update_route.py
@@ -155,60 +155,40 @@ def test_partner_bibliography_delete_not_supported(client, saved_entry):
     assert result.status == falcon.HTTP_METHOD_NOT_ALLOWED
 
 
-@pytest.fixture
-def identified_entry(bibliography, user):
-    entry = BibliographyEntryFactory.build(
-        id="Q30000024",
-        title="Old partner title",
-        citationKey="dossin1967La",
-        aliases=[
-            {
-                "value": "dossin1967archives",
-                "normalizedValue": "dossin1967archives",
-                "type": "partner_id",
-                "source": "partner_request",
-                "status": "redirect",
-            }
-        ],
+PARTNER_LOOKUP_VALUES = ["Q30000024", "dossin1967archives", "dossin1967La"]
+
+
+def partner_update_payload(entry: dict) -> dict:
+    return pydash.omit(
+        {**entry, "title": "New partner title"}, "aliases", "citationKey"
     )
-    bibliography.create(entry, user)
-    return entry
 
 
-@pytest.mark.parametrize(
-    "lookup_value", ["Q30000024", "dossin1967archives", "dossin1967La"]
-)
+@pytest.mark.parametrize("lookup_value", PARTNER_LOOKUP_VALUES)
 def test_partner_bibliography_update_by_any_identifier_preserves_identity(
-    lookup_value, client, bibliography, identified_entry
+    lookup_value, client, bibliography, aliased_entry
 ):
-    payload = pydash.omit(
-        {**identified_entry, "title": "New partner title"}, "aliases", "citationKey"
-    )
+    payload = partner_update_payload(aliased_entry)
 
     result = client.simulate_post(
         f"/api/v1/bibliography/{lookup_value}", body=json.dumps(payload)
     )
 
     assert result.status == falcon.HTTP_NO_CONTENT
-    assert bibliography.find(identified_entry["id"]) == {
+    assert bibliography.find(aliased_entry["id"]) == {
         **payload,
-        "citationKey": identified_entry["citationKey"],
-        "aliases": identified_entry["aliases"],
+        "citationKey": aliased_entry["citationKey"],
+        "aliases": aliased_entry["aliases"],
     }
 
 
-@pytest.mark.parametrize(
-    "lookup_value", ["Q30000024", "dossin1967archives", "dossin1967La"]
-)
+@pytest.mark.parametrize("lookup_value", PARTNER_LOOKUP_VALUES)
 def test_partner_bibliography_update_by_any_identifier_applies_metadata(
-    lookup_value, client, bibliography, identified_entry
+    lookup_value, client, bibliography, aliased_entry
 ):
-    payload = pydash.omit(
-        {**identified_entry, "title": "New partner title"}, "aliases", "citationKey"
-    )
-
     client.simulate_post(
-        f"/api/v1/bibliography/{lookup_value}", body=json.dumps(payload)
+        f"/api/v1/bibliography/{lookup_value}",
+        body=json.dumps(partner_update_payload(aliased_entry)),
     )
 
     assert bibliography.find(lookup_value)["title"] == "New partner title"

--- a/ebl/tests/bibliography/test_partner_bibliography_update_route.py
+++ b/ebl/tests/bibliography/test_partner_bibliography_update_route.py
@@ -153,3 +153,62 @@ def test_partner_bibliography_delete_not_supported(client, saved_entry):
     result = client.simulate_delete(f"/api/v1/bibliography/{saved_entry['id']}")
 
     assert result.status == falcon.HTTP_METHOD_NOT_ALLOWED
+
+
+@pytest.fixture
+def identified_entry(bibliography, user):
+    entry = BibliographyEntryFactory.build(
+        id="Q30000024",
+        title="Old partner title",
+        citationKey="dossin1967La",
+        aliases=[
+            {
+                "value": "dossin1967archives",
+                "normalizedValue": "dossin1967archives",
+                "type": "partner_id",
+                "source": "partner_request",
+                "status": "redirect",
+            }
+        ],
+    )
+    bibliography.create(entry, user)
+    return entry
+
+
+@pytest.mark.parametrize(
+    "lookup_value", ["Q30000024", "dossin1967archives", "dossin1967La"]
+)
+def test_partner_bibliography_update_by_any_identifier_preserves_identity(
+    lookup_value, client, bibliography, identified_entry
+):
+    payload = pydash.omit(
+        {**identified_entry, "title": "New partner title"}, "aliases", "citationKey"
+    )
+
+    result = client.simulate_post(
+        f"/api/v1/bibliography/{lookup_value}", body=json.dumps(payload)
+    )
+
+    assert result.status == falcon.HTTP_NO_CONTENT
+    assert bibliography.find(identified_entry["id"]) == {
+        **payload,
+        "citationKey": identified_entry["citationKey"],
+        "aliases": identified_entry["aliases"],
+    }
+
+
+@pytest.mark.parametrize(
+    "lookup_value", ["Q30000024", "dossin1967archives", "dossin1967La"]
+)
+def test_partner_bibliography_update_by_any_identifier_applies_metadata(
+    lookup_value, client, bibliography, identified_entry
+):
+    payload = pydash.omit(
+        {**identified_entry, "title": "New partner title"}, "aliases", "citationKey"
+    )
+
+    client.simulate_post(
+        f"/api/v1/bibliography/{lookup_value}", body=json.dumps(payload)
+    )
+
+    assert bibliography.find(lookup_value)["title"] == "New partner title"

--- a/ebl/tests/bibliography/test_server_owned_fields.py
+++ b/ebl/tests/bibliography/test_server_owned_fields.py
@@ -1,7 +1,9 @@
 import pytest
 
 from ebl.bibliography.application.server_owned_fields import (
+    preserve_persisted_fields,
     preserve_server_owned_fields,
+    stored_preserved_fields,
     stored_server_owned_fields,
     strip_server_owned_fields,
 )
@@ -79,6 +81,59 @@ def test_preserve_drops_submitted_fields_absent_from_stored():
     }
 
     assert preserve_server_owned_fields(entry, {"id": "RN1", "type": "book"}) == {
+        "id": "RN1",
+        "type": "book",
+    }
+
+
+def test_stored_server_owned_fields_are_deep_copied():
+    preserved = stored_server_owned_fields(STORED)
+
+    assert preserved["aliases"] == ALIASES
+    assert preserved["aliases"] is not ALIASES
+    assert preserved["aliases"][0] is not ALIASES[0]
+
+
+def test_preserve_does_not_alias_stored_mutable_values():
+    entry = {"id": "Q30000024", "type": "book", "title": "Corrected"}
+
+    preserved = preserve_server_owned_fields(entry, STORED)
+    preserved["aliases"].append({"value": "added"})
+
+    assert STORED["aliases"] == ALIASES
+
+
+def test_stored_preserved_fields_keeps_unknown_persisted_keys():
+    stored_entry = {"id": "RN1", "type": "book", "DPO": "10.1/x", "pages": "1-2"}
+
+    assert stored_preserved_fields(stored_entry) == {"DPO": "10.1/x", "pages": "1-2"}
+
+
+def test_stored_preserved_fields_excludes_client_editable_metadata():
+    assert stored_preserved_fields(STORED) == {
+        "aliases": ALIASES,
+        "citationKey": "stored-key",
+    }
+
+
+def test_preserve_persisted_restores_unknown_and_server_owned_fields():
+    stored_entry = {**STORED, "DPO": "10.1/x"}
+    entry = {"id": "Q30000024", "type": "book", "title": "Corrected"}
+
+    assert preserve_persisted_fields(entry, stored_entry) == {
+        "id": "Q30000024",
+        "type": "book",
+        "title": "Corrected",
+        "aliases": ALIASES,
+        "citationKey": "stored-key",
+        "DPO": "10.1/x",
+    }
+
+
+def test_preserve_persisted_drops_unknown_fields_supplied_by_the_client():
+    entry = {"id": "RN1", "type": "book", "DPO": "attacker"}
+
+    assert preserve_persisted_fields(entry, {"id": "RN1", "type": "book"}) == {
         "id": "RN1",
         "type": "book",
     }

--- a/ebl/tests/bibliography/test_server_owned_fields.py
+++ b/ebl/tests/bibliography/test_server_owned_fields.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ebl.bibliography.application.server_owned_fields import (
+    changed_server_owned_fields,
     preserve_persisted_fields,
     preserve_server_owned_fields,
     stored_preserved_fields,
@@ -152,3 +153,46 @@ def test_preserve_keeps_stored_tombstone_fields():
 
     assert preserved_entry["deprecated"] is True
     assert preserved_entry["redirectTo"] == "rla_9_388"
+
+
+def test_changed_server_owned_fields_accepts_round_tripped_values():
+    assert changed_server_owned_fields({**STORED, "title": "Corrected"}, STORED) == []
+
+
+def test_changed_server_owned_fields_accepts_omitted_fields():
+    entry = {"id": "Q30000024", "type": "book", "title": "Corrected"}
+
+    assert changed_server_owned_fields(entry, STORED) == []
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("aliases", [{"value": "attacker", "normalizedValue": "attacker"}]),
+        ("citationKey", "attacker-key"),
+        ("deprecated", True),
+        ("redirectTo", "other-record"),
+    ],
+)
+def test_changed_server_owned_fields_reports_a_changed_field(field, value):
+    assert changed_server_owned_fields({**STORED, field: value}, STORED) == [field]
+
+
+def test_changed_server_owned_fields_reports_every_changed_field():
+    entry = {**STORED, "aliases": [], "citationKey": "other"}
+
+    assert changed_server_owned_fields(entry, STORED) == ["aliases", "citationKey"]
+
+
+def test_changed_server_owned_fields_reports_a_field_absent_from_stored():
+    entry = {"id": "RN1", "type": "book", "deprecated": True}
+
+    assert changed_server_owned_fields(entry, {"id": "RN1", "type": "book"}) == [
+        "deprecated"
+    ]
+
+
+def test_changed_server_owned_fields_accepts_null_matching_absent_stored_field():
+    entry = {"id": "RN1", "type": "book", "redirectTo": None}
+
+    assert changed_server_owned_fields(entry, {"id": "RN1", "type": "book"}) == []

--- a/ebl/tests/bibliography/test_server_owned_fields.py
+++ b/ebl/tests/bibliography/test_server_owned_fields.py
@@ -1,0 +1,99 @@
+import pytest
+
+from ebl.bibliography.application.server_owned_fields import (
+    preserve_server_owned_fields,
+    stored_server_owned_fields,
+    strip_server_owned_fields,
+)
+
+ALIASES = [{"value": "legacy-id", "normalizedValue": "legacy-id"}]
+STORED = {
+    "id": "Q30000024",
+    "type": "book",
+    "title": "Stored title",
+    "aliases": ALIASES,
+    "citationKey": "stored-key",
+}
+
+
+@pytest.mark.parametrize(
+    "field", ["aliases", "citationKey", "deprecated", "redirectTo"]
+)
+def test_strip_removes_every_server_owned_field(field):
+    entry = {"id": "Q30000024", "type": "book", field: "value"}
+
+    assert strip_server_owned_fields(entry) == {"id": "Q30000024", "type": "book"}
+
+
+def test_strip_keeps_metadata():
+    assert strip_server_owned_fields(STORED) == {
+        "id": "Q30000024",
+        "type": "book",
+        "title": "Stored title",
+    }
+
+
+def test_stored_server_owned_fields_collects_present_fields():
+    assert stored_server_owned_fields(STORED) == {
+        "aliases": ALIASES,
+        "citationKey": "stored-key",
+    }
+
+
+def test_stored_server_owned_fields_omits_absent_fields():
+    assert stored_server_owned_fields({"id": "RN1", "type": "book"}) == {}
+
+
+def test_preserve_restores_omitted_fields():
+    entry = {"id": "Q30000024", "type": "book", "title": "Corrected"}
+
+    assert preserve_server_owned_fields(entry, STORED) == {
+        "id": "Q30000024",
+        "type": "book",
+        "title": "Corrected",
+        "aliases": ALIASES,
+        "citationKey": "stored-key",
+    }
+
+
+def test_preserve_overrides_submitted_server_owned_fields():
+    entry = {
+        "id": "Q30000024",
+        "type": "book",
+        "aliases": [{"value": "attacker", "normalizedValue": "attacker"}],
+        "citationKey": "attacker-key",
+    }
+
+    preserved_entry = preserve_server_owned_fields(entry, STORED)
+
+    assert preserved_entry["aliases"] == ALIASES
+    assert preserved_entry["citationKey"] == "stored-key"
+
+
+def test_preserve_drops_submitted_fields_absent_from_stored():
+    entry = {
+        "id": "RN1",
+        "type": "book",
+        "deprecated": True,
+        "redirectTo": "other-record",
+    }
+
+    assert preserve_server_owned_fields(entry, {"id": "RN1", "type": "book"}) == {
+        "id": "RN1",
+        "type": "book",
+    }
+
+
+def test_preserve_keeps_stored_tombstone_fields():
+    stored_entry: dict[str, object] = {
+        "id": "RN2001",
+        "type": "book",
+        "deprecated": True,
+        "redirectTo": "rla_9_388",
+    }
+    entry = {"id": "RN2001", "type": "book", "title": "Corrected"}
+
+    preserved_entry = preserve_server_owned_fields(entry, stored_entry)
+
+    assert preserved_entry["deprecated"] is True
+    assert preserved_entry["redirectTo"] == "rla_9_388"

--- a/ebl/users/web/user_request.py
+++ b/ebl/users/web/user_request.py
@@ -1,0 +1,13 @@
+from typing import Protocol
+
+import falcon
+
+from ebl.users.domain.user import User
+
+
+class UserContext(Protocol):
+    user: User
+
+
+class UserRequest(falcon.Request):
+    context: UserContext


### PR DESCRIPTION
This PR fixes the production issue where ordinary internal bibliography edits could silently remove persisted identity state. `POST /bibliography/{id}` is now intentionally a metadata-edit operation: existing `aliases`, `citationKey`, `deprecated`, `redirectTo`, and other non-client-owned persisted fields are preserved rather than replaced by whatever happens to be present in the submitted CSL payload.

Because the current frontend can round-trip the full bibliography entry during a no-op or metadata save, unchanged server-owned values are accepted. If submitted server-owned state differs from what is currently stored — including when the editor is holding a stale copy after identity changed elsewhere — the request now returns `409 Conflict` and requires reload/retry; the submitted identity state is never persisted. If the exact record targeted by the update is already deprecated when the request begins, the update is rejected with `422` and identifies the canonical record that should be edited instead.

The persistence layer also uses compare-and-set protection for the stored identity/tombstone fields, so an identity change that occurs during the update request cannot be silently overwritten. Ordinary CSL metadata remains last-write-wins as before; this PR does not add general optimistic concurrency for metadata fields.

Reads may resolve canonical IDs, citationKeys, aliases, and redirects, while ordinary internal metadata writes intentionally target an exact canonical `_id`. Trusted identity mutation is deliberately kept separate from this generic metadata-edit path: the underlying `update_with_identity_claims` primitive remains available for the dedicated identity-management follow-up rather than reopening identity mutation through `POST /bibliography/{id}`.

Internal `POST /bibliography` creation behavior is intentionally unchanged in this PR. Hardening that route and providing the replacement trusted identity-management API are handled in separate follow-up work so this fix remains narrowly focused on preventing the production overwrite bug without removing existing identity-management capability prematurely.


## Summary by Sourcery

Protect bibliography identity and persisted state during updates while adding conflict detection for concurrent changes.

Bug Fixes:
- Prevent bibliography metadata updates from overwriting server-owned identity and redirect fields.
- Detect concurrent bibliography updates and report conflicts without losing concurrent changes.

Enhancements:
- Preserve persisted server-owned and unknown fields during metadata edits while rejecting client attempts to modify protected fields.
- Centralize bibliography identity handling and redirect resolution, and retain lookup reservations during metadata-only updates.

Tests:
- Add coverage for identity preservation, legacy records, deprecated redirects, concurrent update conflicts, and reservation behavior.