### PR TITLE
fix: fix mongo not found errors

### DIFF
--- a/ebl/corpus/infrastructure/mongo_text_repository_get.py
+++ b/ebl/corpus/infrastructure/mongo_text_repository_get.py
@@ -3,22 +3,29 @@ from ebl.corpus.domain.chapter import ChapterId
 from ebl.corpus.infrastructure.queries import (
     chapter_id_query,
 )
-from ebl.corpus.infrastructure.mongo_text_repository_base import MongoTextRepositoryBase
+from ebl.corpus.infrastructure.mongo_text_repository_base import (
+    MongoTextRepositoryBase,
+    chapter_not_found,
+)
+from ebl.errors import NotFoundError
 
 
 class MongoTextRepositoryGet(MongoTextRepositoryBase):
     def get_sign_data(self, id_: ChapterId) -> dict:
-        return self._chapters.find_one(
-            chapter_id_query(id_),
-            projection={
-                "_id": False,
-                "signs": True,
-                "manuscripts": True,
-                "textId": True,
-                "stage": True,
-                "name": True,
-            },
-        )
+        try:
+            return self._chapters.find_one(
+                chapter_id_query(id_),
+                projection={
+                    "_id": False,
+                    "signs": True,
+                    "manuscripts": True,
+                    "textId": True,
+                    "stage": True,
+                    "name": True,
+                },
+            )
+        except NotFoundError as error:
+            raise chapter_not_found(id_) from error
 
     def get_all_sign_data(self) -> Sequence[dict]:
         return list(

--- a/ebl/dictionary/infrastructure/word_repository.py
+++ b/ebl/dictionary/infrastructure/word_repository.py
@@ -227,4 +227,4 @@ class MongoWordRepository(WordRepository):
         return self._collection.get_all_values("_id")
 
     def update(self, word) -> None:
-        self._collection.update_one({"_id": word["_id"]}, {"$set": word})
+        self._collection.update_one_by_id(word["_id"], {"$set": word})

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -405,17 +405,14 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
     def query_next_and_previous_fragment(
         self, museum_number: MuseumNumber
     ) -> FragmentPagerInfo:
-        try:
-            current = self._fragments.find_one(
-                {
-                    "museumNumber.prefix": museum_number.prefix,
-                    "museumNumber.number": museum_number.number,
-                    "museumNumber.suffix": museum_number.suffix,
-                },
-                projection={"_sortKey": True},
-            ).get("_sortKey")
-        except NotFoundError as error:
-            raise NotFoundError(f"Fragment {museum_number} not found.") from error
+        current = self._fragments.find_one(
+            {
+                "museumNumber.prefix": museum_number.prefix,
+                "museumNumber.number": museum_number.number,
+                "museumNumber.suffix": museum_number.suffix,
+            },
+            projection={"_sortKey": True},
+        ).get("_sortKey")
 
         if current is None:
             prev = next_ = museum_number

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get.py
@@ -405,14 +405,17 @@ class MongoFragmentRepositoryGetBase(MongoFragmentRepositoryBase):
     def query_next_and_previous_fragment(
         self, museum_number: MuseumNumber
     ) -> FragmentPagerInfo:
-        current = self._fragments.find_one(
-            {
-                "museumNumber.prefix": museum_number.prefix,
-                "museumNumber.number": museum_number.number,
-                "museumNumber.suffix": museum_number.suffix,
-            },
-            projection={"_sortKey": True},
-        ).get("_sortKey")
+        try:
+            current = self._fragments.find_one(
+                {
+                    "museumNumber.prefix": museum_number.prefix,
+                    "museumNumber.number": museum_number.number,
+                    "museumNumber.suffix": museum_number.suffix,
+                },
+                projection={"_sortKey": True},
+            ).get("_sortKey")
+        except NotFoundError as error:
+            raise NotFoundError(f"Fragment {museum_number} not found.") from error
 
         if current is None:
             prev = next_ = museum_number

--- a/ebl/mongo_collection.py
+++ b/ebl/mongo_collection.py
@@ -44,13 +44,18 @@ class MongoCollection:
         raise AssertionError("insert_one should return or raise")
 
     def find_one_by_id(self, id_):
-        return self.find_one({"_id": id_})
+        document = self.__get_collection().find_one({"_id": id_})
+
+        if document is None:
+            raise self.__id_not_found_error(id_)
+        else:
+            return document
 
     def find_one(self, query, *args, **kwargs) -> Any:
         document = self.__get_collection().find_one(query, *args, **kwargs)
 
         if document is None:
-            raise self.__not_found_error(query)
+            raise self.__not_found_error()
         else:
             return document
 
@@ -65,7 +70,7 @@ class MongoCollection:
             filter_ or {"_id": document["_id"]}, document, upsert
         )
         if result.matched_count == 0 and not upsert:
-            raise self.__not_found_error(document["_id"])
+            raise self.__id_not_found_error(document["_id"])
         else:
             return result
 
@@ -74,14 +79,14 @@ class MongoCollection:
             raise ValueError("Empty Query for delete one not allowed")
         result = self.__get_collection().delete_one(query)
         if result.deleted_count == 0:
-            raise self.__not_found_error(query)
+            raise self.__not_found_error()
 
     def delete_many(self, query: dict) -> None:
         if not bool(query):
             raise ValueError("Empty Query for delete many not allowed")
         result = self.__get_collection().delete_many(query)
         if result.deleted_count == 0:
-            raise self.__not_found_error(query)
+            raise self.__not_found_error()
 
     def update_one(self, query, update):
         for attempt in range(2):
@@ -92,7 +97,7 @@ class MongoCollection:
                     raise
                 continue
             if result.matched_count == 0:
-                raise self.__not_found_error(query)
+                raise self.__not_found_error()
             return result
         raise AssertionError("update_one should return or raise")
 
@@ -115,8 +120,11 @@ class MongoCollection:
         values = self.__get_collection().distinct(field, query or {})
         return [value for value in values if not isinstance(value, ObjectId)]
 
-    def __not_found_error(self, query):
-        return NotFoundError(f"{self.__resource_noun} {query} not found.")
+    def __not_found_error(self) -> NotFoundError:
+        return NotFoundError(f"{self.__resource_noun} not found.")
+
+    def __id_not_found_error(self, id_: object) -> NotFoundError:
+        return NotFoundError(f"{self.__resource_noun} {id_} not found.")
 
     def __get_collection(self) -> Collection:
         return self.__database[self.__collection]

--- a/ebl/mongo_collection.py
+++ b/ebl/mongo_collection.py
@@ -4,6 +4,7 @@ from bson import ObjectId
 from pymongo.collection import Collection
 from pymongo.database import Database
 from pymongo.errors import AutoReconnect, DuplicateKeyError
+from pymongo.results import UpdateResult
 from ebl.errors import DuplicateError, NotFoundError
 
 
@@ -43,7 +44,7 @@ class MongoCollection:
                     raise
         raise AssertionError("insert_one should return or raise")
 
-    def find_one_by_id(self, id_):
+    def find_one_by_id(self, id_: object) -> Any:
         document = self.__get_collection().find_one({"_id": id_})
 
         if document is None:
@@ -100,6 +101,12 @@ class MongoCollection:
                 raise self.__not_found_error()
             return result
         raise AssertionError("update_one should return or raise")
+
+    def update_one_by_id(self, id_: object, update) -> UpdateResult:
+        try:
+            return self.update_one({"_id": id_}, update)
+        except NotFoundError as error:
+            raise self.__id_not_found_error(id_) from error
 
     def update_many(self, query, update, **kwargs):
         return self.__get_collection().update_many(query, update, **kwargs)

--- a/ebl/tests/mongo/conftest.py
+++ b/ebl/tests/mongo/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from ebl.mongo_collection import MongoCollection
+
+
+@pytest.fixture
+def collection(database):
+    return MongoCollection(database, "collection")

--- a/ebl/tests/mongo/sanitization_helpers.py
+++ b/ebl/tests/mongo/sanitization_helpers.py
@@ -1,0 +1,6 @@
+QUERY_SYNTAX_FRAGMENTS = ["{", "}", "$", "_id"]
+
+
+def assert_no_query_details(message: str) -> None:
+    for fragment in QUERY_SYNTAX_FRAGMENTS:
+        assert fragment not in message

--- a/ebl/tests/mongo/test_domain_not_found_messages.py
+++ b/ebl/tests/mongo/test_domain_not_found_messages.py
@@ -1,0 +1,61 @@
+import pytest
+
+from ebl.corpus.domain.chapter import ChapterId
+from ebl.transliteration.domain.text_id import TextId
+from ebl.errors import NotFoundError
+from ebl.transliteration.domain.genre import Genre
+from ebl.common.domain.stage import Stage
+
+TEXT_ID = TextId(Genre.LITERATURE, 1, 99)
+CHAPTER_ID = ChapterId(TEXT_ID, Stage.OLD_BABYLONIAN, "missing")
+
+
+def test_corpus_text_keeps_domain_message(text_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        text_repository.find(TEXT_ID)
+
+    assert str(excinfo.value) == f"Text {TEXT_ID} not found."
+
+
+def test_corpus_chapter_keeps_domain_message(text_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        text_repository.find_chapter(CHAPTER_ID)
+
+    assert str(excinfo.value) == f"Chapter {CHAPTER_ID} not found."
+
+
+def test_corpus_manuscripts_keeps_domain_message(text_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        text_repository.query_manuscripts_by_chapter(CHAPTER_ID)
+
+    assert str(excinfo.value) == f"Chapter {CHAPTER_ID} not found."
+
+
+def test_realia_keeps_domain_message(realia_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        realia_repository.find_by_realia_id("missing")
+
+    assert str(excinfo.value) == "Realia entry with realiaId 'missing' not found."
+
+
+def test_bibliography_citation_key_keeps_domain_message(
+    bibliography_repository,
+) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography_repository.query_by_citation_key("missing")
+
+    assert str(excinfo.value) == "bibliography citation key missing not found."
+
+
+def test_bibliography_alias_keeps_domain_message(bibliography_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography_repository.query_by_alias("missing")
+
+    assert str(excinfo.value) == "bibliography alias missing not found."
+
+
+def test_file_repository_keeps_domain_message(file_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        file_repository.query_by_file_name("missing.jpg")
+
+    assert str(excinfo.value) == "File missing.jpg not found."

--- a/ebl/tests/mongo/test_domain_not_found_messages.py
+++ b/ebl/tests/mongo/test_domain_not_found_messages.py
@@ -5,9 +5,11 @@ from ebl.transliteration.domain.text_id import TextId
 from ebl.errors import NotFoundError
 from ebl.transliteration.domain.genre import Genre
 from ebl.common.domain.stage import Stage
+from ebl.transliteration.domain.museum_number import MuseumNumber
 
 TEXT_ID = TextId(Genre.LITERATURE, 1, 99)
 CHAPTER_ID = ChapterId(TEXT_ID, Stage.OLD_BABYLONIAN, "missing")
+MISSING_MUSEUM_NUMBER = MuseumNumber("X", "999")
 
 
 def test_corpus_text_keeps_domain_message(text_repository) -> None:
@@ -29,6 +31,20 @@ def test_corpus_manuscripts_keeps_domain_message(text_repository) -> None:
         text_repository.query_manuscripts_by_chapter(CHAPTER_ID)
 
     assert str(excinfo.value) == f"Chapter {CHAPTER_ID} not found."
+
+
+def test_corpus_sign_data_keeps_domain_message(text_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        text_repository.get_sign_data(CHAPTER_ID)
+
+    assert str(excinfo.value) == f"Chapter {CHAPTER_ID} not found."
+
+
+def test_fragment_pager_keeps_domain_message(fragment_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        fragment_repository.query_next_and_previous_fragment(MISSING_MUSEUM_NUMBER)
+
+    assert str(excinfo.value) == f"Fragment {MISSING_MUSEUM_NUMBER} not found."
 
 
 def test_realia_keeps_domain_message(realia_repository) -> None:

--- a/ebl/tests/mongo/test_domain_not_found_messages.py
+++ b/ebl/tests/mongo/test_domain_not_found_messages.py
@@ -5,11 +5,9 @@ from ebl.transliteration.domain.text_id import TextId
 from ebl.errors import NotFoundError
 from ebl.transliteration.domain.genre import Genre
 from ebl.common.domain.stage import Stage
-from ebl.transliteration.domain.museum_number import MuseumNumber
 
 TEXT_ID = TextId(Genre.LITERATURE, 1, 99)
 CHAPTER_ID = ChapterId(TEXT_ID, Stage.OLD_BABYLONIAN, "missing")
-MISSING_MUSEUM_NUMBER = MuseumNumber("X", "999")
 
 
 def test_corpus_text_keeps_domain_message(text_repository) -> None:
@@ -38,13 +36,6 @@ def test_corpus_sign_data_keeps_domain_message(text_repository) -> None:
         text_repository.get_sign_data(CHAPTER_ID)
 
     assert str(excinfo.value) == f"Chapter {CHAPTER_ID} not found."
-
-
-def test_fragment_pager_keeps_domain_message(fragment_repository) -> None:
-    with pytest.raises(NotFoundError) as excinfo:
-        fragment_repository.query_next_and_previous_fragment(MISSING_MUSEUM_NUMBER)
-
-    assert str(excinfo.value) == f"Fragment {MISSING_MUSEUM_NUMBER} not found."
 
 
 def test_realia_keeps_domain_message(realia_repository) -> None:

--- a/ebl/tests/mongo/test_mongo_collection_crud.py
+++ b/ebl/tests/mongo/test_mongo_collection_crud.py
@@ -1,17 +1,9 @@
 import datetime
-from unittest.mock import Mock
 
 import pytest
 from bson import ObjectId
-from pymongo.errors import AutoReconnect, DuplicateKeyError
 
 from ebl.errors import DuplicateError, NotFoundError
-from ebl.mongo_collection import MongoCollection
-
-
-@pytest.fixture
-def collection(database):
-    return MongoCollection(database, "collection")
 
 
 def test_create_many_and_find_by_id(collection):
@@ -178,86 +170,19 @@ def test_unicode_and_datetime_roundtrip(collection) -> None:
     assert stored == {"_id": insert_id, "data": "šà-ḫa", "created": timestamp}
 
 
-def test_insert_one_retries_once_on_auto_reconnect(collection) -> None:
-    document = {"data": "payload"}
-
-    insert_result = Mock()
-    insert_result.inserted_id = "inserted-id"
-
-    mocked_collection = Mock()
-    mocked_collection.insert_one.side_effect = [
-        AutoReconnect("operation cancelled"),
-        insert_result,
-    ]
-
-    collection._MongoCollection__get_collection = lambda: mocked_collection
-
-    assert collection.insert_one(document) == "inserted-id"
-    assert mocked_collection.insert_one.call_count == 2
+def test_delete_one_rejects_empty_query(collection):
+    with pytest.raises(ValueError, match="Empty Query for delete one not allowed"):
+        collection.delete_one({})
 
 
-def test_insert_one_reraises_auto_reconnect_after_last_attempt(collection) -> None:
-    document = {"data": "payload"}
-
-    mocked_collection = Mock()
-    mocked_collection.insert_one.side_effect = [
-        AutoReconnect("operation cancelled"),
-        AutoReconnect("operation cancelled"),
-    ]
-
-    collection._MongoCollection__get_collection = lambda: mocked_collection
-
-    with pytest.raises(AutoReconnect):
-        collection.insert_one(document)
-
-    assert mocked_collection.insert_one.call_count == 2
+def test_delete_many_rejects_empty_query(collection):
+    with pytest.raises(ValueError, match="Empty Query for delete many not allowed"):
+        collection.delete_many({})
 
 
-def test_insert_one_duplicate_after_auto_reconnect_returns_document_id(
-    collection,
-) -> None:
-    document = {"_id": "fixed-id", "data": "payload"}
+def test_create_and_drop_index(collection):
+    index_name = collection.create_index([("data", 1)])
+    assert index_name in collection.index_information()
 
-    mocked_collection = Mock()
-    mocked_collection.insert_one.side_effect = [
-        AutoReconnect("operation cancelled"),
-        DuplicateKeyError("duplicate"),
-    ]
-
-    collection._MongoCollection__get_collection = lambda: mocked_collection
-
-    assert collection.insert_one(document) == "fixed-id"
-    assert mocked_collection.insert_one.call_count == 2
-
-
-def test_update_one_retries_once_on_auto_reconnect(collection) -> None:
-    update_result = Mock()
-    update_result.matched_count = 1
-
-    mocked_collection = Mock()
-    mocked_collection.update_one.side_effect = [
-        AutoReconnect("operation cancelled"),
-        update_result,
-    ]
-
-    collection._MongoCollection__get_collection = lambda: mocked_collection
-
-    assert (
-        collection.update_one({"_id": "id"}, {"$set": {"data": "x"}}) is update_result
-    )
-    assert mocked_collection.update_one.call_count == 2
-
-
-def test_update_one_reraises_auto_reconnect_after_last_attempt(collection) -> None:
-    mocked_collection = Mock()
-    mocked_collection.update_one.side_effect = [
-        AutoReconnect("operation cancelled"),
-        AutoReconnect("operation cancelled"),
-    ]
-
-    collection._MongoCollection__get_collection = lambda: mocked_collection
-
-    with pytest.raises(AutoReconnect):
-        collection.update_one({"_id": "id"}, {"$set": {"data": "x"}})
-
-    assert mocked_collection.update_one.call_count == 2
+    collection.drop_index(index_name)
+    assert index_name not in collection.index_information()

--- a/ebl/tests/mongo/test_mongo_collection_crud.py
+++ b/ebl/tests/mongo/test_mongo_collection_crud.py
@@ -186,3 +186,11 @@ def test_create_and_drop_index(collection):
 
     collection.drop_index(index_name)
     assert index_name not in collection.index_information()
+
+
+def test_update_one_by_id(collection):
+    collection.insert_one({"_id": "ID", "data": "payload"})
+
+    collection.update_one_by_id("ID", {"$set": {"data": "updated"}})
+
+    assert collection.find_one_by_id("ID") == {"_id": "ID", "data": "updated"}

--- a/ebl/tests/mongo/test_mongo_collection_not_found.py
+++ b/ebl/tests/mongo/test_mongo_collection_not_found.py
@@ -1,0 +1,112 @@
+import pytest
+
+from ebl.errors import NotFoundError
+from ebl.mongo_collection import MongoCollection
+
+SECRET_VALUE = "secret-or-user-supplied-value"
+LEAKED_FRAGMENTS = ["{", "}", "$", "_id", "citationKey", "aliases.value"]
+
+COMPLEX_QUERIES = [
+    {"$or": [{"citationKey": "abc"}, {"aliases.value": "abc"}]},
+    {"citationKey": {"$in": ["abc", "def"]}},
+    {"aliases.value": {"$exists": True}},
+    {"deprecated": {"$ne": True}},
+    {"values": {"$elemMatch": {"value": "abc", "subIndex": {"$exists": False}}}},
+]
+
+
+def assert_no_query_details(message: str) -> None:
+    for fragment in LEAKED_FRAGMENTS:
+        assert fragment not in message
+    assert "abc" not in message
+
+
+@pytest.fixture
+def bibliography(database):
+    return MongoCollection(database, "bibliography")
+
+
+def test_find_one_by_id_reports_resource_and_identifier(bibliography) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.find_one_by_id(SECRET_VALUE)
+
+    assert str(excinfo.value) == f"bibliography {SECRET_VALUE} not found."
+    assert_no_query_details(str(excinfo.value))
+
+
+@pytest.mark.parametrize("query", COMPLEX_QUERIES)
+def test_find_one_hides_query(bibliography, query) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.find_one(query)
+
+    assert str(excinfo.value) == "bibliography not found."
+    assert_no_query_details(str(excinfo.value))
+
+
+@pytest.mark.parametrize("query", COMPLEX_QUERIES)
+def test_delete_one_hides_query(bibliography, query) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.delete_one(query)
+
+    assert str(excinfo.value) == "bibliography not found."
+    assert_no_query_details(str(excinfo.value))
+
+
+@pytest.mark.parametrize("query", COMPLEX_QUERIES)
+def test_delete_many_hides_query(bibliography, query) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.delete_many(query)
+
+    assert str(excinfo.value) == "bibliography not found."
+    assert_no_query_details(str(excinfo.value))
+
+
+@pytest.mark.parametrize("query", COMPLEX_QUERIES)
+def test_update_one_hides_query(bibliography, query) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.update_one(query, {"$set": {"title": "abc"}})
+
+    assert str(excinfo.value) == "bibliography not found."
+    assert_no_query_details(str(excinfo.value))
+
+
+def test_replace_one_reports_resource_and_identifier(bibliography) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.replace_one({"_id": SECRET_VALUE, "title": "abc"})
+
+    assert str(excinfo.value) == f"bibliography {SECRET_VALUE} not found."
+    assert_no_query_details(str(excinfo.value))
+
+
+def test_replace_one_with_filter_reports_document_identifier(bibliography) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.replace_one(
+            {"_id": SECRET_VALUE, "title": "abc"},
+            filter_={"citationKey": "abc"},
+        )
+
+    assert str(excinfo.value) == f"bibliography {SECRET_VALUE} not found."
+    assert_no_query_details(str(excinfo.value))
+
+
+@pytest.mark.parametrize(
+    "collection_name,expected",
+    [
+        ("bibliography", "bibliography not found."),
+        ("fragments", "fragment not found."),
+        ("words", "word not found."),
+        ("chapters", "chapter not found."),
+        ("signs", "sign not found."),
+        ("provenances", "provenance not found."),
+        ("dossiers", "dossier not found."),
+    ],
+)
+def test_resource_noun_is_singular_per_collection(
+    database, collection_name, expected
+) -> None:
+    collection = MongoCollection(database, collection_name)
+
+    with pytest.raises(NotFoundError) as excinfo:
+        collection.find_one({"$or": [{"citationKey": "abc"}]})
+
+    assert str(excinfo.value) == expected

--- a/ebl/tests/mongo/test_mongo_collection_not_found.py
+++ b/ebl/tests/mongo/test_mongo_collection_not_found.py
@@ -2,9 +2,10 @@ import pytest
 
 from ebl.errors import NotFoundError
 from ebl.mongo_collection import MongoCollection
+from ebl.tests.mongo.sanitization_helpers import assert_no_query_details
 
-SECRET_VALUE = "secret-or-user-supplied-value"
-LEAKED_FRAGMENTS = ["{", "}", "$", "_id", "citationKey", "aliases.value"]
+IDENTIFIER = "client-supplied-identifier"
+QUERY_FIELD_NAMES = ["citationKey", "aliases.value"]
 
 COMPLEX_QUERIES = [
     {"$or": [{"citationKey": "abc"}, {"aliases.value": "abc"}]},
@@ -15,9 +16,10 @@ COMPLEX_QUERIES = [
 ]
 
 
-def assert_no_query_details(message: str) -> None:
-    for fragment in LEAKED_FRAGMENTS:
-        assert fragment not in message
+def assert_hides_query(message: str) -> None:
+    assert_no_query_details(message)
+    for field_name in QUERY_FIELD_NAMES:
+        assert field_name not in message
     assert "abc" not in message
 
 
@@ -28,10 +30,10 @@ def bibliography(database):
 
 def test_find_one_by_id_reports_resource_and_identifier(bibliography) -> None:
     with pytest.raises(NotFoundError) as excinfo:
-        bibliography.find_one_by_id(SECRET_VALUE)
+        bibliography.find_one_by_id(IDENTIFIER)
 
-    assert str(excinfo.value) == f"bibliography {SECRET_VALUE} not found."
-    assert_no_query_details(str(excinfo.value))
+    assert str(excinfo.value) == f"bibliography {IDENTIFIER} not found."
+    assert_hides_query(str(excinfo.value))
 
 
 @pytest.mark.parametrize("query", COMPLEX_QUERIES)
@@ -40,7 +42,7 @@ def test_find_one_hides_query(bibliography, query) -> None:
         bibliography.find_one(query)
 
     assert str(excinfo.value) == "bibliography not found."
-    assert_no_query_details(str(excinfo.value))
+    assert_hides_query(str(excinfo.value))
 
 
 @pytest.mark.parametrize("query", COMPLEX_QUERIES)
@@ -49,7 +51,7 @@ def test_delete_one_hides_query(bibliography, query) -> None:
         bibliography.delete_one(query)
 
     assert str(excinfo.value) == "bibliography not found."
-    assert_no_query_details(str(excinfo.value))
+    assert_hides_query(str(excinfo.value))
 
 
 @pytest.mark.parametrize("query", COMPLEX_QUERIES)
@@ -58,7 +60,15 @@ def test_delete_many_hides_query(bibliography, query) -> None:
         bibliography.delete_many(query)
 
     assert str(excinfo.value) == "bibliography not found."
-    assert_no_query_details(str(excinfo.value))
+    assert_hides_query(str(excinfo.value))
+
+
+def test_update_one_by_id_reports_resource_and_identifier(bibliography) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography.update_one_by_id(IDENTIFIER, {"$set": {"title": "abc"}})
+
+    assert str(excinfo.value) == f"bibliography {IDENTIFIER} not found."
+    assert_hides_query(str(excinfo.value))
 
 
 @pytest.mark.parametrize("query", COMPLEX_QUERIES)
@@ -67,26 +77,26 @@ def test_update_one_hides_query(bibliography, query) -> None:
         bibliography.update_one(query, {"$set": {"title": "abc"}})
 
     assert str(excinfo.value) == "bibliography not found."
-    assert_no_query_details(str(excinfo.value))
+    assert_hides_query(str(excinfo.value))
 
 
 def test_replace_one_reports_resource_and_identifier(bibliography) -> None:
     with pytest.raises(NotFoundError) as excinfo:
-        bibliography.replace_one({"_id": SECRET_VALUE, "title": "abc"})
+        bibliography.replace_one({"_id": IDENTIFIER, "title": "abc"})
 
-    assert str(excinfo.value) == f"bibliography {SECRET_VALUE} not found."
-    assert_no_query_details(str(excinfo.value))
+    assert str(excinfo.value) == f"bibliography {IDENTIFIER} not found."
+    assert_hides_query(str(excinfo.value))
 
 
 def test_replace_one_with_filter_reports_document_identifier(bibliography) -> None:
     with pytest.raises(NotFoundError) as excinfo:
         bibliography.replace_one(
-            {"_id": SECRET_VALUE, "title": "abc"},
+            {"_id": IDENTIFIER, "title": "abc"},
             filter_={"citationKey": "abc"},
         )
 
-    assert str(excinfo.value) == f"bibliography {SECRET_VALUE} not found."
-    assert_no_query_details(str(excinfo.value))
+    assert str(excinfo.value) == f"bibliography {IDENTIFIER} not found."
+    assert_hides_query(str(excinfo.value))
 
 
 @pytest.mark.parametrize(

--- a/ebl/tests/mongo/test_mongo_collection_reconnect.py
+++ b/ebl/tests/mongo/test_mongo_collection_reconnect.py
@@ -1,0 +1,89 @@
+from unittest.mock import Mock
+
+import pytest
+from pymongo.errors import AutoReconnect, DuplicateKeyError
+
+
+def test_insert_one_retries_once_on_auto_reconnect(collection) -> None:
+    document = {"data": "payload"}
+
+    insert_result = Mock()
+    insert_result.inserted_id = "inserted-id"
+
+    mocked_collection = Mock()
+    mocked_collection.insert_one.side_effect = [
+        AutoReconnect("operation cancelled"),
+        insert_result,
+    ]
+
+    collection._MongoCollection__get_collection = lambda: mocked_collection
+
+    assert collection.insert_one(document) == "inserted-id"
+    assert mocked_collection.insert_one.call_count == 2
+
+
+def test_insert_one_reraises_auto_reconnect_after_last_attempt(collection) -> None:
+    document = {"data": "payload"}
+
+    mocked_collection = Mock()
+    mocked_collection.insert_one.side_effect = [
+        AutoReconnect("operation cancelled"),
+        AutoReconnect("operation cancelled"),
+    ]
+
+    collection._MongoCollection__get_collection = lambda: mocked_collection
+
+    with pytest.raises(AutoReconnect):
+        collection.insert_one(document)
+
+    assert mocked_collection.insert_one.call_count == 2
+
+
+def test_insert_one_duplicate_after_auto_reconnect_returns_document_id(
+    collection,
+) -> None:
+    document = {"_id": "fixed-id", "data": "payload"}
+
+    mocked_collection = Mock()
+    mocked_collection.insert_one.side_effect = [
+        AutoReconnect("operation cancelled"),
+        DuplicateKeyError("duplicate"),
+    ]
+
+    collection._MongoCollection__get_collection = lambda: mocked_collection
+
+    assert collection.insert_one(document) == "fixed-id"
+    assert mocked_collection.insert_one.call_count == 2
+
+
+def test_update_one_retries_once_on_auto_reconnect(collection) -> None:
+    update_result = Mock()
+    update_result.matched_count = 1
+
+    mocked_collection = Mock()
+    mocked_collection.update_one.side_effect = [
+        AutoReconnect("operation cancelled"),
+        update_result,
+    ]
+
+    collection._MongoCollection__get_collection = lambda: mocked_collection
+
+    assert (
+        collection.update_one({"_id": "id"}, {"$set": {"data": "x"}}) is update_result
+    )
+    assert mocked_collection.update_one.call_count == 2
+
+
+def test_update_one_reraises_auto_reconnect_after_last_attempt(collection) -> None:
+    mocked_collection = Mock()
+    mocked_collection.update_one.side_effect = [
+        AutoReconnect("operation cancelled"),
+        AutoReconnect("operation cancelled"),
+    ]
+
+    collection._MongoCollection__get_collection = lambda: mocked_collection
+
+    with pytest.raises(AutoReconnect):
+        collection.update_one({"_id": "id"}, {"$set": {"data": "x"}})
+
+    assert mocked_collection.update_one.call_count == 2

--- a/ebl/tests/mongo/test_not_found_routes.py
+++ b/ebl/tests/mongo/test_not_found_routes.py
@@ -1,0 +1,56 @@
+import json
+
+import falcon
+import pytest
+
+BIBLIOGRAPHY_ENTRY = {
+    "id": "clientChosenKey",
+    "type": "article-journal",
+    "title": "Title",
+    "issued": {"date-parts": [[2020]]},
+    "author": [{"family": "Family", "given": "Given"}],
+}
+
+
+def assert_sanitized(result, expected_description: str) -> None:
+    assert result.status == falcon.HTTP_NOT_FOUND
+    assert set(result.json) == {"title", "description"}
+    assert result.json["title"] == "404 Not Found"
+    assert result.json["description"] == expected_description
+    assert "{" not in result.json["description"]
+    assert "$" not in result.json["description"]
+    assert "_id" not in result.json["description"]
+
+
+def test_bibliography_update_of_missing_entry(client) -> None:
+    result = client.simulate_post(
+        "/bibliography/clientChosenKey",
+        body=json.dumps(BIBLIOGRAPHY_ENTRY),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert_sanitized(result, "bibliography clientChosenKey not found.")
+
+
+def test_bibliography_get_of_missing_entry_keeps_domain_message(client) -> None:
+    result = client.simulate_get("/bibliography/clientChosenKey")
+
+    assert_sanitized(result, "bibliography clientChosenKey not found.")
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("/words/missing-word", "word missing-word not found."),
+        ("/signs/MISSING", "sign MISSING not found."),
+        ("/provenances/MISSING", "provenance MISSING not found."),
+    ],
+)
+def test_routes_report_resource_and_identifier(client, url, expected) -> None:
+    assert_sanitized(client.simulate_get(url), expected)
+
+
+def test_fragment_route_keeps_domain_message(client) -> None:
+    assert_sanitized(
+        client.simulate_get("/fragments/X.999"), "Fragment X.999 not found."
+    )

--- a/ebl/tests/mongo/test_not_found_routes.py
+++ b/ebl/tests/mongo/test_not_found_routes.py
@@ -3,6 +3,8 @@ import json
 import falcon
 import pytest
 
+from ebl.tests.mongo.sanitization_helpers import assert_no_query_details
+
 BIBLIOGRAPHY_ENTRY = {
     "id": "clientChosenKey",
     "type": "article-journal",
@@ -17,9 +19,7 @@ def assert_sanitized(result, expected_description: str) -> None:
     assert set(result.json) == {"title", "description"}
     assert result.json["title"] == "404 Not Found"
     assert result.json["description"] == expected_description
-    assert "{" not in result.json["description"]
-    assert "$" not in result.json["description"]
-    assert "_id" not in result.json["description"]
+    assert_no_query_details(result.json["description"])
 
 
 def test_bibliography_update_of_missing_entry(client) -> None:
@@ -32,7 +32,9 @@ def test_bibliography_update_of_missing_entry(client) -> None:
     assert_sanitized(result, "bibliography clientChosenKey not found.")
 
 
-def test_bibliography_get_of_missing_entry_keeps_domain_message(client) -> None:
+def test_bibliography_get_of_missing_entry_reports_resource_and_identifier(
+    client,
+) -> None:
     result = client.simulate_get("/bibliography/clientChosenKey")
 
     assert_sanitized(result, "bibliography clientChosenKey not found.")

--- a/ebl/tests/mongo/test_repository_not_found.py
+++ b/ebl/tests/mongo/test_repository_not_found.py
@@ -1,0 +1,56 @@
+import pytest
+
+from ebl.errors import NotFoundError
+from ebl.transliteration.domain.sign_tokens import SignName
+
+MISSING_IDENTIFIER = "missing-identifier"
+
+
+def assert_message(excinfo, expected: str) -> None:
+    message = str(excinfo.value)
+    assert message == expected
+    assert "{" not in message
+    assert "$" not in message
+    assert "_id" not in message
+
+
+def test_word_repository_reports_identifier(word_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        word_repository.query_by_id(MISSING_IDENTIFIER)
+
+    assert_message(excinfo, f"word {MISSING_IDENTIFIER} not found.")
+
+
+def test_sign_repository_reports_identifier(sign_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        sign_repository.find(SignName(MISSING_IDENTIFIER))
+
+    assert_message(excinfo, f"sign {MISSING_IDENTIFIER} not found.")
+
+
+def test_bibliography_repository_reports_identifier(bibliography_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        bibliography_repository.query_by_id(MISSING_IDENTIFIER)
+
+    assert_message(excinfo, f"bibliography {MISSING_IDENTIFIER} not found.")
+
+
+def test_provenance_repository_reports_identifier(provenance_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        provenance_repository.query_by_id(MISSING_IDENTIFIER)
+
+    assert_message(excinfo, f"provenance {MISSING_IDENTIFIER} not found.")
+
+
+def test_provenance_repository_hides_query(provenance_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        provenance_repository.query_by_long_name(MISSING_IDENTIFIER)
+
+    assert_message(excinfo, "provenance not found.")
+
+
+def test_cache_repository_hides_query(mongo_cache_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        mongo_cache_repository.get(MISSING_IDENTIFIER)
+
+    assert_message(excinfo, "cache not found.")

--- a/ebl/tests/mongo/test_repository_not_found.py
+++ b/ebl/tests/mongo/test_repository_not_found.py
@@ -1,17 +1,24 @@
 import pytest
 
+from ebl.common.domain.stage import Stage
+from ebl.corpus.domain.chapter import ChapterId
 from ebl.errors import NotFoundError
+from ebl.tests.factories.corpus import ChapterFactory
+from ebl.tests.mongo.sanitization_helpers import assert_no_query_details
+from ebl.transliteration.domain.genre import Genre
 from ebl.transliteration.domain.sign_tokens import SignName
+from ebl.transliteration.domain.text_id import TextId
 
 MISSING_IDENTIFIER = "missing-identifier"
+MISSING_CHAPTER_ID = ChapterId(
+    TextId(Genre.LITERATURE, 1, 99), Stage.OLD_BABYLONIAN, "missing"
+)
 
 
 def assert_message(excinfo, expected: str) -> None:
     message = str(excinfo.value)
     assert message == expected
-    assert "{" not in message
-    assert "$" not in message
-    assert "_id" not in message
+    assert_no_query_details(message)
 
 
 def test_word_repository_reports_identifier(word_repository) -> None:
@@ -54,3 +61,17 @@ def test_cache_repository_hides_query(mongo_cache_repository) -> None:
         mongo_cache_repository.get(MISSING_IDENTIFIER)
 
     assert_message(excinfo, "cache not found.")
+
+
+def test_word_repository_update_reports_identifier(word_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        word_repository.update({"_id": MISSING_IDENTIFIER, "lemma": ["missing"]})
+
+    assert_message(excinfo, f"word {MISSING_IDENTIFIER} not found.")
+
+
+def test_corpus_chapter_update_hides_query(text_repository) -> None:
+    with pytest.raises(NotFoundError) as excinfo:
+        text_repository.update(MISSING_CHAPTER_ID, ChapterFactory.build())
+
+    assert_message(excinfo, "chapter not found.")


### PR DESCRIPTION
## fix: sanitize Mongo not-found errors

Generic `MongoCollection` not-found errors previously interpolated the raw Mongo query into the HTTP `404` description. This exposed internal field names and Mongo predicates such as `_id`, `$or`, `$exists`, `citationKey`, and `aliases.value` to API clients.

### What changed

`MongoCollection` now distinguishes between:

* **identifier-based lookups**, where the repository API explicitly knows a single safe identifier and returns messages such as `bibliography clientChosenKey not found.`;
* **arbitrary query-based lookups**, which now return only a resource-level message such as `bibliography not found.`.

Raw Mongo query dictionaries are never rendered into public error responses.

Application/domain-specific `NotFoundError` messages remain unchanged, so useful errors such as `Fragment X.999 not found.` continue to be returned where the application layer knows the semantic identifier.

### Compatibility

This does not change:

* HTTP status codes;
* the Falcon error response shape;
* successful Mongo operations;
* domain-specific not-found messages;
* partner APIs or bibliography identity behavior.

Only the generic `404` description changes.

No repository code or tests were found to parse or depend on the previous raw-query error text.

### Scope

The issue was discovered through bibliography updates but existed in shared `MongoCollection` infrastructure and affected multiple domains, including bibliography, dictionary, signs, provenance, cache, corpus, fragmentarium, and other repositories using the same abstraction.

The old behavior was a low-severity information-disclosure/API-hygiene issue: it exposed query structure and internal schema details, but no confirmed server-held secrets or privileged data.

### Tests

Added coverage for:

* exact-ID lookups;
* complex `$or` queries;
* `$in`, `$exists`, `$ne`, `$elemMatch`, and other Mongo predicates;
* repository behavior across representative domains;
* HTTP response serialization;
* preservation of existing domain-specific error messages.

The existing `MongoCollection` test module was split to remain under the repository's 250-line file limit without removing or weakening any existing tests.


No production data, bibliography identity behavior, partner APIs, or unrelated feature branches are changed by this PR.

## Summary by Sourcery

Prevent MongoDB query details from leaking through generic not-found responses while retaining meaningful identifier and domain-specific errors.

Bug Fixes:
- Sanitize generic MongoDB not-found errors so HTTP 404 responses no longer expose raw query structures or internal field names.
- Preserve safe identifier-based and domain-specific not-found messages across repositories and routes.

Enhancements:
- Add explicit identifier-based Mongo collection operations with resource-and-identifier error messages while using resource-level messages for arbitrary queries.

Tests:
- Add coverage for sanitized Mongo errors across CRUD operations, repositories, representative routes, and domain-specific message preservation.
- Reorganize Mongo collection tests into focused modules without reducing existing coverage.