### PR TITLE
Map/backend 05 multisite artifacts

### DIFF
--- a/ebl/fragmentarium/data/map/kalhu_findspot_polygon_curation_report.md
+++ b/ebl/fragmentarium/data/map/kalhu_findspot_polygon_curation_report.md
@@ -1,0 +1,24 @@
+# Kalḫu Map Curation Report
+
+- Generated from immutable ODS and shapefile sources.
+- Verified mappings: 8
+- Unresolved rows: 10
+- Source conflicts: 0
+- Invalid source rows: 0
+
+## Deterministic rule used
+
+`normalize(ODS.area) == normalize(shapefile.Name without leading digits); when area is blank, fall back to normalize(ODS.building) == normalize(shapefile.Name without leading digits)`
+
+Normalization applies Unicode NFKC, trims whitespace, removes `?`, and case-folds both sides.
+
+## Human decision required
+
+The remaining rows need scholarly curation because no unique deterministic polygon match exists.
+
+Unresolved area/building values:
+
+- `<blank>`: 7
+- `C 50`: 1
+- `Upper fill of trench (d. 13) outside north-west corner of Governor's Palace`: 1
+- `ZT4`: 1

--- a/ebl/fragmentarium/data/map/kalhu_findspot_polygon_curation_template.json
+++ b/ebl/fragmentarium/data/map/kalhu_findspot_polygon_curation_template.json
@@ -1,0 +1,102 @@
+[
+  {
+    "findspotId": 348,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "",
+    "sector": "",
+    "map": "Russell2017Assyrian@437",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 777,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "C 50",
+    "sector": "",
+    "map": "?",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 817,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "",
+    "sector": "",
+    "map": "?",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 819,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "",
+    "sector": "",
+    "map": "?",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 1365,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "",
+    "sector": "",
+    "map": "RN2323@201",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 1378,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "",
+    "sector": "",
+    "map": "RN2323@232",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 1411,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "",
+    "sector": "",
+    "map": "?",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 1434,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "",
+    "sector": "",
+    "map": "Russell2017Assyrian@437",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4329,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "Upper fill of trench (d. 13) outside north-west corner of Governor's Palace",
+    "sector": "",
+    "map": "Russell2017Assyrian@437",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4374,
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "area": "ZT4",
+    "sector": "",
+    "map": "?",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  }
+]

--- a/ebl/fragmentarium/data/map/kalhu_findspot_polygon_mappings.json
+++ b/ebl/fragmentarium/data/map/kalhu_findspot_polygon_mappings.json
@@ -1,0 +1,82 @@
+[
+  {
+    "findspotId": 228,
+    "polygonIds": [
+      "kalhu-ekal-m-arti-fort-shalmaneser-d7b0dc777aa9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 300,
+    "polygonIds": [
+      "kalhu-ezida-118147b1d10a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 310,
+    "polygonIds": [
+      "kalhu-burnt-palace-89837a3195e9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 341,
+    "polygonIds": [
+      "kalhu-north-west-palace-a8934874262c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 360,
+    "polygonIds": [
+      "kalhu-d-xii-f1ec2958239a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 371,
+    "polygonIds": [
+      "kalhu-zt-654e87f7811b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 373,
+    "polygonIds": [
+      "kalhu-zte-25-e9fcf31fe8c3"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 474,
+    "polygonIds": [
+      "kalhu-ztw-4-2036effc54d9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Kalhu Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  }
+]

--- a/ebl/fragmentarium/data/map/kalhu_polygon_inventory.json
+++ b/ebl/fragmentarium/data/map/kalhu_polygon_inventory.json
@@ -1,0 +1,98 @@
+[
+  {
+    "polygonId": "kalhu-burnt-palace-89837a3195e9",
+    "name": "Burnt Palace",
+    "areaName": "Burnt Palace",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "89837a3195e9"
+  },
+  {
+    "polygonId": "kalhu-central-palace-5a32d4b3f1ac",
+    "name": "Central Palace",
+    "areaName": "Central Palace",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "5a32d4b3f1ac"
+  },
+  {
+    "polygonId": "kalhu-d-xii-f1ec2958239a",
+    "name": "D XII",
+    "areaName": "D XII",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "f1ec2958239a"
+  },
+  {
+    "polygonId": "kalhu-ekal-m-arti-fort-shalmaneser-d7b0dc777aa9",
+    "name": "ekal māšarti (Fort Shalmaneser)",
+    "areaName": "ekal māšarti (Fort Shalmaneser)",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "d7b0dc777aa9"
+  },
+  {
+    "polygonId": "kalhu-ezida-118147b1d10a",
+    "name": "Ezida",
+    "areaName": "Ezida",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "118147b1d10a"
+  },
+  {
+    "polygonId": "kalhu-governors-palace-875a12990aea",
+    "name": "Governors Palace",
+    "areaName": "Governors Palace",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "875a12990aea"
+  },
+  {
+    "polygonId": "kalhu-kalhu-17049d0f312c",
+    "name": "Kalhu",
+    "areaName": "Kalhu",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "17049d0f312c"
+  },
+  {
+    "polygonId": "kalhu-north-west-palace-a8934874262c",
+    "name": "North-West Palace",
+    "areaName": "North-West Palace",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "a8934874262c"
+  },
+  {
+    "polygonId": "kalhu-southwest-palace-37b77bce76e8",
+    "name": "Southwest Palace",
+    "areaName": "Southwest Palace",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "37b77bce76e8"
+  },
+  {
+    "polygonId": "kalhu-zt-654e87f7811b",
+    "name": "ZT",
+    "areaName": "ZT",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "654e87f7811b"
+  },
+  {
+    "polygonId": "kalhu-zte-25-e9fcf31fe8c3",
+    "name": "ZTE 25",
+    "areaName": "ZTE 25",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "e9fcf31fe8c3"
+  },
+  {
+    "polygonId": "kalhu-ztw-4-2036effc54d9",
+    "name": "ZTW 4",
+    "areaName": "ZTW 4",
+    "siteId": "KALHU",
+    "siteName": "Kalḫu",
+    "geometryChecksum": "2036effc54d9"
+  }
+]

--- a/ebl/fragmentarium/data/map/nippur_findspot_polygon_curation_report.md
+++ b/ebl/fragmentarium/data/map/nippur_findspot_polygon_curation_report.md
@@ -1,0 +1,26 @@
+# Nippur Map Curation Report
+
+- Generated from immutable ODS and shapefile sources.
+- Verified mappings: 20
+- Unresolved rows: 8
+- Source conflicts: 1
+- Invalid source rows: 0
+
+## Deterministic rule used
+
+`normalize(ODS.area) == normalize(shapefile.Name without leading digits); when area is blank, fall back to normalize(ODS.sector) == normalize(shapefile.Name without leading digits). Historical map plate references (the ODS `map` column) are never used as polygon identifiers.`
+
+Normalization applies Unicode NFKC, trims whitespace, removes `?`, and case-folds both sides.
+
+## Human decision required
+
+The remaining rows need scholarly curation because no unique deterministic polygon match exists.
+
+Unresolved area/sector values:
+
+- `<blank>`: 1
+- `EN`: 2
+- `EN gen.`: 1
+- `IT`: 1
+- `TA gen.`: 1
+- `ZB 4`: 1

--- a/ebl/fragmentarium/data/map/nippur_findspot_polygon_curation_template.json
+++ b/ebl/fragmentarium/data/map/nippur_findspot_polygon_curation_template.json
@@ -1,0 +1,82 @@
+[
+  {
+    "findspotId": 704,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "EN",
+    "sector": "",
+    "map": "heinrich1982die@234",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 940,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "TA gen.",
+    "sector": "",
+    "map": "RN2747@pl5",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 946,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "EN gen.",
+    "sector": "",
+    "map": "heinrich1982die@234",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 2518,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "EN",
+    "sector": "Religious Quarter",
+    "map": "heinrich1982die@234",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 2528,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "IT",
+    "sector": "Religious Quarter",
+    "map": "heinrich1982die@234",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 3176,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "",
+    "sector": "Religious Quarter",
+    "map": "heinrich1982die@234",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4263,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "WB",
+    "sector": "West Mound",
+    "map": "gibson1978excavations@fig49",
+    "status": "needs-human-curation",
+    "requiredDecision": "Resolve conflicting polygon matches across duplicate source rows."
+  },
+  {
+    "findspotId": 4305,
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "area": "ZB 4",
+    "sector": "",
+    "map": "-",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  }
+]

--- a/ebl/fragmentarium/data/map/nippur_findspot_polygon_mappings.json
+++ b/ebl/fragmentarium/data/map/nippur_findspot_polygon_mappings.json
@@ -1,0 +1,202 @@
+[
+  {
+    "findspotId": 625,
+    "polygonIds": [
+      "nippur-inanna-temple-65aa508e7862"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 641,
+    "polygonIds": [
+      "nippur-inanna-temple-65aa508e7862"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 901,
+    "polygonIds": [
+      "nippur-ta-a711959786ac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 945,
+    "polygonIds": [
+      "nippur-tb-beb0e6157cac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2530,
+    "polygonIds": [
+      "nippur-sa-6ece7116d8ca"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2531,
+    "polygonIds": [
+      "nippur-sb-04889d9160fd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2532,
+    "polygonIds": [
+      "nippur-sd-e3fd3f91b54b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2533,
+    "polygonIds": [
+      "nippur-se-d45d3339f015"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2537,
+    "polygonIds": [
+      "nippur-sk-412bf7d0598b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2538,
+    "polygonIds": [
+      "nippur-ta-a711959786ac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2544,
+    "polygonIds": [
+      "nippur-ta-a711959786ac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2548,
+    "polygonIds": [
+      "nippur-ta-a711959786ac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2564,
+    "polygonIds": [
+      "nippur-ta-a711959786ac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2652,
+    "polygonIds": [
+      "nippur-tb-beb0e6157cac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2680,
+    "polygonIds": [
+      "nippur-tb-beb0e6157cac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2729,
+    "polygonIds": [
+      "nippur-tb-beb0e6157cac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2746,
+    "polygonIds": [
+      "nippur-tb-beb0e6157cac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 2815,
+    "polygonIds": [
+      "nippur-tb-beb0e6157cac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 3148,
+    "polygonIds": [
+      "nippur-tb-beb0e6157cac"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4379,
+    "polygonIds": [
+      "nippur-wf-bab099415d47"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Nippur Tafeln.ods",
+    "sourceRevision": "2026-08-05"
+  }
+]

--- a/ebl/fragmentarium/data/map/nippur_polygon_inventory.json
+++ b/ebl/fragmentarium/data/map/nippur_polygon_inventory.json
@@ -1,0 +1,162 @@
+[
+  {
+    "polygonId": "nippur-enlil-temple-6d0422078951",
+    "name": "Enlil Temple",
+    "areaName": "Enlil Temple",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "6d0422078951"
+  },
+  {
+    "polygonId": "nippur-house-b-fa54c8fb4309",
+    "name": "House B",
+    "areaName": "House B",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "fa54c8fb4309"
+  },
+  {
+    "polygonId": "nippur-house-c-d166671e2914",
+    "name": "House C",
+    "areaName": "House C",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "d166671e2914"
+  },
+  {
+    "polygonId": "nippur-house-d-58cfaada3c2c",
+    "name": "House D",
+    "areaName": "House D",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "58cfaada3c2c"
+  },
+  {
+    "polygonId": "nippur-house-f-3c7002731e7f",
+    "name": "House F",
+    "areaName": "House F",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "3c7002731e7f"
+  },
+  {
+    "polygonId": "nippur-house-i-0519b761097e",
+    "name": "House I",
+    "areaName": "House I",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "0519b761097e"
+  },
+  {
+    "polygonId": "nippur-house-j-6bfbd6fd9957",
+    "name": "House J",
+    "areaName": "House J",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "6bfbd6fd9957"
+  },
+  {
+    "polygonId": "nippur-inanna-temple-65aa508e7862",
+    "name": "Inanna Temple",
+    "areaName": "Inanna Temple",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "65aa508e7862"
+  },
+  {
+    "polygonId": "nippur-north-temple-359552df33e1",
+    "name": "North Temple",
+    "areaName": "North Temple",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "359552df33e1"
+  },
+  {
+    "polygonId": "nippur-sa-6ece7116d8ca",
+    "name": "SA",
+    "areaName": "SA",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "6ece7116d8ca"
+  },
+  {
+    "polygonId": "nippur-sb-04889d9160fd",
+    "name": "SB",
+    "areaName": "SB",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "04889d9160fd"
+  },
+  {
+    "polygonId": "nippur-scribal-quarter-a566fe34fdbe",
+    "name": "Scribal Quarter",
+    "areaName": "Scribal Quarter",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "a566fe34fdbe"
+  },
+  {
+    "polygonId": "nippur-sd-e3fd3f91b54b",
+    "name": "SD",
+    "areaName": "SD",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "e3fd3f91b54b"
+  },
+  {
+    "polygonId": "nippur-se-d45d3339f015",
+    "name": "SE",
+    "areaName": "SE",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "d45d3339f015"
+  },
+  {
+    "polygonId": "nippur-sk-412bf7d0598b",
+    "name": "SK",
+    "areaName": "SK",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "412bf7d0598b"
+  },
+  {
+    "polygonId": "nippur-ta-a711959786ac",
+    "name": "TA",
+    "areaName": "TA",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "a711959786ac"
+  },
+  {
+    "polygonId": "nippur-tb-beb0e6157cac",
+    "name": "TB",
+    "areaName": "TB",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "beb0e6157cac"
+  },
+  {
+    "polygonId": "nippur-wb-589c63a46fb1",
+    "name": "WB",
+    "areaName": "WB",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "589c63a46fb1"
+  },
+  {
+    "polygonId": "nippur-west-mound-b014ce4004a4",
+    "name": "West Mound",
+    "areaName": "West Mound",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "b014ce4004a4"
+  },
+  {
+    "polygonId": "nippur-wf-bab099415d47",
+    "name": "WF",
+    "areaName": "WF",
+    "siteId": "NIPPUR",
+    "siteName": "Nippur",
+    "geometryChecksum": "bab099415d47"
+  }
+]

--- a/ebl/fragmentarium/data/map/uruk_findspot_polygon_curation_report.md
+++ b/ebl/fragmentarium/data/map/uruk_findspot_polygon_curation_report.md
@@ -1,0 +1,26 @@
+# Uruk Map Curation Report
+
+- Generated from immutable ODS and shapefile sources.
+- Verified mappings: 131
+- Unresolved rows: 12
+- Source conflicts: 0
+- Invalid source rows: 0
+
+## Deterministic rule used
+
+`normalize(ODS.area) == normalize(shapefile.Name without leading digits)`
+
+Normalization applies Unicode NFKC, trims whitespace, removes `?`, and case-folds both sides.
+
+## Human decision required
+
+The remaining rows need scholarly curation because no unique deterministic polygon match exists.
+
+Unresolved area labels:
+
+- `<blank>`: 7
+- `Oc`: 1
+- `Pd XVI/1`: 1
+- `Pd XVI/4`: 1
+- `Pe XV/5`: 1
+- `XVIII/1`: 1

--- a/ebl/fragmentarium/data/map/uruk_findspot_polygon_curation_template.json
+++ b/ebl/fragmentarium/data/map/uruk_findspot_polygon_curation_template.json
@@ -1,0 +1,122 @@
+[
+  {
+    "findspotId": 2,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "",
+    "sector": "",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 540,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "",
+    "sector": "",
+    "map": "LS220@Taf35",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 555,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "",
+    "sector": "",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 779,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "",
+    "sector": "",
+    "map": "LS220@Taf35",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 1336,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "XVIII/1",
+    "sector": "",
+    "map": "",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 1448,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "Pd XVI/4",
+    "sector": "",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4017,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "",
+    "sector": "Stadtgebiet",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4158,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "Oc",
+    "sector": "",
+    "map": "",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4259,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "",
+    "sector": "",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4313,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "",
+    "sector": "Eanna",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4333,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "Pe XV/5",
+    "sector": "",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4341,
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "area": "Pd XVI/1",
+    "sector": "",
+    "map": "eichmann1989uruk@Abb2",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  }
+]

--- a/ebl/fragmentarium/data/map/uruk_findspot_polygon_mappings.json
+++ b/ebl/fragmentarium/data/map/uruk_findspot_polygon_mappings.json
@@ -1,0 +1,1312 @@
+[
+  {
+    "findspotId": 1,
+    "polygonIds": [
+      "uruk-ue-xviii-1-4c5b1b215704"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 44,
+    "polygonIds": [
+      "uruk-ue-xviii-1-4c5b1b215704"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 57,
+    "polygonIds": [
+      "uruk-ub-xviii-4-1462df44fd82"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 60,
+    "polygonIds": [
+      "uruk-va-xviii-1-cd71a9c255f0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 70,
+    "polygonIds": [
+      "uruk-ue-xiii-1-078e015ee26e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 79,
+    "polygonIds": [
+      "uruk-ue-xviii-2-0dcddf1aedc1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 536,
+    "polygonIds": [
+      "uruk-pe-xiv-5-905a067ab399"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 538,
+    "polygonIds": [
+      "uruk-eb-xiv-4-d58a24dd9283"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 541,
+    "polygonIds": [
+      "uruk-nd-xvi-4-5-ne-xvi-3-5-ca3ee571ba37"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 542,
+    "polygonIds": [
+      "uruk-pa-xvi-2-29df82537bea"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 543,
+    "polygonIds": [
+      "uruk-la-xii-5-519b74458172"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 544,
+    "polygonIds": [
+      "uruk-nd-xvi-5-67f28c6d8386"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 546,
+    "polygonIds": [
+      "uruk-ob-xv-3-fed96c8009d5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 550,
+    "polygonIds": [
+      "uruk-qe-xvi-fcbd869640e4"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 551,
+    "polygonIds": [
+      "uruk-eb-xiv-2-28590548f8cd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 553,
+    "polygonIds": [
+      "uruk-nd-xxiii-08a9658955dd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 554,
+    "polygonIds": [
+      "uruk-oe-pa-xvii-2-5e18c19f28b3"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 557,
+    "polygonIds": [
+      "uruk-dd-xiv-3-96468f51be24"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 563,
+    "polygonIds": [
+      "uruk-dc-xiv-3-3e0172c0f4cf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 565,
+    "polygonIds": [
+      "uruk-dc-xiv-2-55d0546c4ba6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 566,
+    "polygonIds": [
+      "uruk-dd-xiv-5-295337b2e084"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 570,
+    "polygonIds": [
+      "uruk-de-ea-xiv-5-01c349b5750a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 573,
+    "polygonIds": [
+      "uruk-de-xiv-4-0bbe71843c6a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 576,
+    "polygonIds": [
+      "uruk-dc-xiv-3-4-71ab766d574d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 580,
+    "polygonIds": [
+      "uruk-dc-dd-xiv-4-588adbf87fbf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 581,
+    "polygonIds": [
+      "uruk-dc-xiv-4-e9c4da1dde69"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 583,
+    "polygonIds": [
+      "uruk-dc-xiv-3-3e0172c0f4cf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 584,
+    "polygonIds": [
+      "uruk-dc-xiv-3-dc-dd-xiv-4-dc-xiv-4-96b0d911d35a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 588,
+    "polygonIds": [
+      "uruk-eb-xiv-5-7c22622cdac5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 589,
+    "polygonIds": [
+      "uruk-ea-xiv-3-cb70afa2c743"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 599,
+    "polygonIds": [
+      "uruk-ob-xv-3-4-bda2a339a08f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 605,
+    "polygonIds": [
+      "uruk-ob-xv-3-fed96c8009d5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 612,
+    "polygonIds": [
+      "uruk-oc-xv-3-e19ff366ca01"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 617,
+    "polygonIds": [
+      "uruk-ob-xv-4-474aba67559e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 621,
+    "polygonIds": [
+      "uruk-oa-xv-4-160370d21780"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 622,
+    "polygonIds": [
+      "uruk-p-vi-2-9c93fe08d428"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 623,
+    "polygonIds": [
+      "uruk-p-vi-3-64aab6e28bb0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 770,
+    "polygonIds": [
+      "uruk-oc-xv-4-cd0d8cef3fd6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 771,
+    "polygonIds": [
+      "uruk-oc-xv-5-4f23fd9bf390"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 781,
+    "polygonIds": [
+      "uruk-ea-xiv-4-be764dbd1c25"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 783,
+    "polygonIds": [
+      "uruk-nd-xvi-4-a4b021b14ec9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 848,
+    "polygonIds": [
+      "uruk-od-xvi-4-cf6b0bf88f6a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 849,
+    "polygonIds": [
+      "uruk-oc-xvi-2-ea6501bc40ff"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 854,
+    "polygonIds": [
+      "uruk-pd-xvi-3-8039a6c7a36d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 856,
+    "polygonIds": [
+      "uruk-pe-xvi-3-d51f3faf8317"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 857,
+    "polygonIds": [
+      "uruk-od-xv-3-ae7e57889a94"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 858,
+    "polygonIds": [
+      "uruk-lc-xviii-2-0299cf3cb598"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 860,
+    "polygonIds": [
+      "uruk-qb-xiv-5-273e242d6e85"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 862,
+    "polygonIds": [
+      "uruk-le-xvi-3-fe4b29a4ebd9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 867,
+    "polygonIds": [
+      "uruk-de-xiv-2-ef549de94432"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 869,
+    "polygonIds": [
+      "uruk-ea-xiv-2-963d084b6f8a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 870,
+    "polygonIds": [
+      "uruk-ea-xiv-2-963d084b6f8a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 873,
+    "polygonIds": [
+      "uruk-de-xiv-3-5f53b922e1d9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 875,
+    "polygonIds": [
+      "uruk-nc-xvi-5-11e38b545bf1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 885,
+    "polygonIds": [
+      "uruk-od-xvi-3-31be46638725"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 893,
+    "polygonIds": [
+      "uruk-nd-xvi-5-nd-xvii-1-edbd1b4ccba9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 894,
+    "polygonIds": [
+      "uruk-ke-xvii-3-b6f8f1c42661"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1321,
+    "polygonIds": [
+      "uruk-vb-xviii-1-a74b371d3046"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1323,
+    "polygonIds": [
+      "uruk-u-xviii-db19732fc9b8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1359,
+    "polygonIds": [
+      "uruk-ue-xvii-15caa5eafad9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1400,
+    "polygonIds": [
+      "uruk-qd-xiv-5-69adbd0523a1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1401,
+    "polygonIds": [
+      "uruk-ud-viii-4-f58919603873"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1402,
+    "polygonIds": [
+      "uruk-r-vii-5617a49eda9f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1403,
+    "polygonIds": [
+      "uruk-t-xiii-e221d36943ae"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1415,
+    "polygonIds": [
+      "uruk-me-xvi-2-32618c3988d2"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1416,
+    "polygonIds": [
+      "uruk-na-xvi-2-8a81de97f1d1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1417,
+    "polygonIds": [
+      "uruk-nb-xvi-3-ca07287e1823"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1418,
+    "polygonIds": [
+      "uruk-nc-xvi-1-880479319b5a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1419,
+    "polygonIds": [
+      "uruk-nd-xvi-3-d021bb6cc772"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1421,
+    "polygonIds": [
+      "uruk-nd-xvi-2-e7da9c978a2f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1423,
+    "polygonIds": [
+      "uruk-ne-xvi-3-c5cd10df748d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1424,
+    "polygonIds": [
+      "uruk-vc-xviii-1-a945e4e95572"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1447,
+    "polygonIds": [
+      "uruk-oc-xvi-3-40820197ef28"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1449,
+    "polygonIds": [
+      "uruk-pd-xvi-2-4b6930c1b4d2"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1450,
+    "polygonIds": [
+      "uruk-pc-xvii-4-33631c22f614"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1451,
+    "polygonIds": [
+      "uruk-pa-xvi-4-fd6edba91776"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 1452,
+    "polygonIds": [
+      "uruk-od-xiv-5-af4ef5493a6f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4054,
+    "polygonIds": [
+      "uruk-od-xvii-1-2-aed22799f78c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4055,
+    "polygonIds": [
+      "uruk-ob-xvi-1-b3e8c8c62285"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4056,
+    "polygonIds": [
+      "uruk-de-xv-1-6195f32670ec"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4058,
+    "polygonIds": [
+      "uruk-ne-xvii-2-aaf74eb07a91"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4059,
+    "polygonIds": [
+      "uruk-qc-xiv-5-8a6ccd51e7b1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4060,
+    "polygonIds": [
+      "uruk-oe-xiv-5ff3a686aa89"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4061,
+    "polygonIds": [
+      "uruk-oe-xiv-5-f382bfe7ff5e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4064,
+    "polygonIds": [
+      "uruk-qa-xiv-6f6ae63ba51f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4066,
+    "polygonIds": [
+      "uruk-oe-xiv-4-176e96014ae7"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4076,
+    "polygonIds": [
+      "uruk-oa-xv-3-7487a18c70f0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4117,
+    "polygonIds": [
+      "uruk-ob-xv-5-008019e206a5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4119,
+    "polygonIds": [
+      "uruk-ne-xv-5-b5a30c0b34d2"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4127,
+    "polygonIds": [
+      "uruk-oa-xv-5-61d0761b8811"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4138,
+    "polygonIds": [
+      "uruk-pe-qa-xvi-4-48070b227e1f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4142,
+    "polygonIds": [
+      "uruk-nc-xvi-2-5d16d42d18a1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4144,
+    "polygonIds": [
+      "uruk-nb-xvi-4-3fbddc14bd87"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4148,
+    "polygonIds": [
+      "uruk-id-xvii-4-7adc5bda94aa"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4149,
+    "polygonIds": [
+      "uruk-oa-xvi-1-79443e65b875"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4150,
+    "polygonIds": [
+      "uruk-ka-xvii-2-b0fda232cdfb"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4151,
+    "polygonIds": [
+      "uruk-ue-xv-4-825271b82bba"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4154,
+    "polygonIds": [
+      "uruk-ka-xvii-5-506b0cc93542"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4165,
+    "polygonIds": [
+      "uruk-jd-xvii-4-e09b07984db1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4179,
+    "polygonIds": [
+      "uruk-qd-xv-1-21f0c69b8f51"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4180,
+    "polygonIds": [
+      "uruk-qb-xiv-4-2e4e4b542a2f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4183,
+    "polygonIds": [
+      "uruk-qb-xiv-3-8cb00d437a39"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4185,
+    "polygonIds": [
+      "uruk-qc-xv-1-8c702d19d4a4"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4186,
+    "polygonIds": [
+      "uruk-qb-xv-1-b71e56f4d817"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4198,
+    "polygonIds": [
+      "uruk-qa-xiv-5-89cb18799fb7"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4199,
+    "polygonIds": [
+      "uruk-qa-xiv-4-17d7847f2d32"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4200,
+    "polygonIds": [
+      "uruk-qb-xiv-fefa311b2dd0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4212,
+    "polygonIds": [
+      "uruk-qe-xv-1-23ef4cfecfaa"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4218,
+    "polygonIds": [
+      "uruk-qe-xiv-4-30dc55e5e17c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4221,
+    "polygonIds": [
+      "uruk-pe-xiv-4-8e6d4ec70cbc"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4235,
+    "polygonIds": [
+      "uruk-qe-xiv-5-aa8c448957df"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4253,
+    "polygonIds": [
+      "uruk-ob-xvi-4-36c901802c49"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4254,
+    "polygonIds": [
+      "uruk-nb-xvi-5-11522bed4dbb"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4255,
+    "polygonIds": [
+      "uruk-nc-xvii-1-795d72a1f50c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4306,
+    "polygonIds": [
+      "uruk-ob-xvi-3-14069e9c7fa9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4310,
+    "polygonIds": [
+      "uruk-u-xvi-c4f6c9d7c7d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4314,
+    "polygonIds": [
+      "uruk-nd-xvi-5-67f28c6d8386"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4338,
+    "polygonIds": [
+      "uruk-pb-xvi-3-10a06e0b0c30"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4339,
+    "polygonIds": [
+      "uruk-qd-xv-4-8c54e0a9b28d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4340,
+    "polygonIds": [
+      "uruk-qd-xvi-381aea732737"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4342,
+    "polygonIds": [
+      "uruk-pb-xvi-1-b2c6f28a7847"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4345,
+    "polygonIds": [
+      "uruk-oa-ob-xv-3-894c7b9b3cc7"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4358,
+    "polygonIds": [
+      "uruk-md-xv-4-e9b352b06212"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4361,
+    "polygonIds": [
+      "uruk-nb-xvi-3-4-83c4d8f8fe36"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4362,
+    "polygonIds": [
+      "uruk-nc-nd-xvi-2-6af3e26c9f5b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4364,
+    "polygonIds": [
+      "uruk-na-xvi-3-14c7a34a7120"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4366,
+    "polygonIds": [
+      "uruk-ld-xv-1-85f80912b886"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4368,
+    "polygonIds": [
+      "uruk-qd-xxv-5-8429747712cf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4370,
+    "polygonIds": [
+      "uruk-qd-xxv-1-033bb35d4000"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4371,
+    "polygonIds": [
+      "uruk-qa-xxv-3-fa21f4d30356"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  },
+  {
+    "findspotId": 4372,
+    "polygonIds": [
+      "uruk-k-xvii-9db31a991297"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Uruk Tafeln aktualisiert 24-07-25.ods",
+    "sourceRevision": "2026-08-05"
+  }
+]

--- a/ebl/fragmentarium/data/map/uruk_polygon_inventory.json
+++ b/ebl/fragmentarium/data/map/uruk_polygon_inventory.json
@@ -1,0 +1,1026 @@
+[
+  {
+    "polygonId": "uruk-dc-dd-xiv-4-588adbf87fbf",
+    "name": "Dc-Dd XIV/4",
+    "areaName": "Dc-Dd XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "588adbf87fbf"
+  },
+  {
+    "polygonId": "uruk-dc-xiv-2-55d0546c4ba6",
+    "name": "Dc XIV/2",
+    "areaName": "Dc XIV/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "55d0546c4ba6"
+  },
+  {
+    "polygonId": "uruk-dc-xiv-3-3e0172c0f4cf",
+    "name": "Dc XIV/3",
+    "areaName": "Dc XIV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "3e0172c0f4cf"
+  },
+  {
+    "polygonId": "uruk-dc-xiv-3-4-71ab766d574d",
+    "name": "Dc XIV/3-4",
+    "areaName": "Dc XIV/3-4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "71ab766d574d"
+  },
+  {
+    "polygonId": "uruk-dc-xiv-3-dc-dd-xiv-4-dc-xiv-4-96b0d911d35a",
+    "name": "Dc XIV/3; Dc/Dd XIV/4; Dc XIV/4",
+    "areaName": "Dc XIV/3; Dc/Dd XIV/4; Dc XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "96b0d911d35a"
+  },
+  {
+    "polygonId": "uruk-dc-xiv-4-e9c4da1dde69",
+    "name": "Dc XIV/4",
+    "areaName": "Dc XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "e9c4da1dde69"
+  },
+  {
+    "polygonId": "uruk-dd-xiv-3-96468f51be24",
+    "name": "Dd XIV/3",
+    "areaName": "Dd XIV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "96468f51be24"
+  },
+  {
+    "polygonId": "uruk-dd-xiv-5-295337b2e084",
+    "name": "Dd XIV/5",
+    "areaName": "Dd XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "295337b2e084"
+  },
+  {
+    "polygonId": "uruk-de-ea-xiv-5-01c349b5750a",
+    "name": "De-Ea XIV/5",
+    "areaName": "De-Ea XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "01c349b5750a"
+  },
+  {
+    "polygonId": "uruk-de-xiv-2-ef549de94432",
+    "name": "De XIV/2",
+    "areaName": "De XIV/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "ef549de94432"
+  },
+  {
+    "polygonId": "uruk-de-xiv-3-5f53b922e1d9",
+    "name": "De XIV/3",
+    "areaName": "De XIV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "5f53b922e1d9"
+  },
+  {
+    "polygonId": "uruk-de-xiv-4-0bbe71843c6a",
+    "name": "De XIV/4",
+    "areaName": "De XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "0bbe71843c6a"
+  },
+  {
+    "polygonId": "uruk-de-xv-1-6195f32670ec",
+    "name": "De XV/1",
+    "areaName": "De XV/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "6195f32670ec"
+  },
+  {
+    "polygonId": "uruk-ea-xiv-2-963d084b6f8a",
+    "name": "Ea XIV/2",
+    "areaName": "Ea XIV/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "963d084b6f8a"
+  },
+  {
+    "polygonId": "uruk-ea-xiv-3-cb70afa2c743",
+    "name": "Ea XIV/3",
+    "areaName": "Ea XIV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "cb70afa2c743"
+  },
+  {
+    "polygonId": "uruk-ea-xiv-4-be764dbd1c25",
+    "name": "Ea XIV/4",
+    "areaName": "Ea XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "be764dbd1c25"
+  },
+  {
+    "polygonId": "uruk-eb-xiv-2-28590548f8cd",
+    "name": "Eb XIV/2",
+    "areaName": "Eb XIV/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "28590548f8cd"
+  },
+  {
+    "polygonId": "uruk-eb-xiv-4-d58a24dd9283",
+    "name": "Eb XIV/4",
+    "areaName": "Eb XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "d58a24dd9283"
+  },
+  {
+    "polygonId": "uruk-eb-xiv-5-7c22622cdac5",
+    "name": "Eb XIV/5",
+    "areaName": "Eb XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "7c22622cdac5"
+  },
+  {
+    "polygonId": "uruk-id-xvii-4-7adc5bda94aa",
+    "name": "Id XVII/4",
+    "areaName": "Id XVII/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "7adc5bda94aa"
+  },
+  {
+    "polygonId": "uruk-jd-xvii-4-e09b07984db1",
+    "name": "Jd XVII/4",
+    "areaName": "Jd XVII/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "e09b07984db1"
+  },
+  {
+    "polygonId": "uruk-k-xvii-9db31a991297",
+    "name": "K XVII",
+    "areaName": "K XVII",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "9db31a991297"
+  },
+  {
+    "polygonId": "uruk-ka-xvii-2-b0fda232cdfb",
+    "name": "Ka XVII/2",
+    "areaName": "Ka XVII/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "b0fda232cdfb"
+  },
+  {
+    "polygonId": "uruk-ka-xvii-5-506b0cc93542",
+    "name": "Ka XVII/5",
+    "areaName": "Ka XVII/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "506b0cc93542"
+  },
+  {
+    "polygonId": "uruk-ke-xvii-3-b6f8f1c42661",
+    "name": "Ke XVII/3",
+    "areaName": "Ke XVII/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "b6f8f1c42661"
+  },
+  {
+    "polygonId": "uruk-la-xii-5-519b74458172",
+    "name": "La XII/5",
+    "areaName": "La XII/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "519b74458172"
+  },
+  {
+    "polygonId": "uruk-lc-xviii-2-0299cf3cb598",
+    "name": "Lc XVIII/2",
+    "areaName": "Lc XVIII/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "0299cf3cb598"
+  },
+  {
+    "polygonId": "uruk-ld-xv-1-85f80912b886",
+    "name": "Ld XV/1",
+    "areaName": "Ld XV/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "85f80912b886"
+  },
+  {
+    "polygonId": "uruk-le-xvi-3-fe4b29a4ebd9",
+    "name": "Le XVI/3",
+    "areaName": "Le XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "fe4b29a4ebd9"
+  },
+  {
+    "polygonId": "uruk-md-xv-4-e9b352b06212",
+    "name": "Md XV/4",
+    "areaName": "Md XV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "e9b352b06212"
+  },
+  {
+    "polygonId": "uruk-me-xvi-2-32618c3988d2",
+    "name": "Me XVI/2",
+    "areaName": "Me XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "32618c3988d2"
+  },
+  {
+    "polygonId": "uruk-na-xvi-2-8a81de97f1d1",
+    "name": "Na XVI/2",
+    "areaName": "Na XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8a81de97f1d1"
+  },
+  {
+    "polygonId": "uruk-na-xvi-3-14c7a34a7120",
+    "name": "Na XVI/3",
+    "areaName": "Na XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "14c7a34a7120"
+  },
+  {
+    "polygonId": "uruk-nb-xvi-3-4-83c4d8f8fe36",
+    "name": "Nb XVI/3-4",
+    "areaName": "Nb XVI/3-4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "83c4d8f8fe36"
+  },
+  {
+    "polygonId": "uruk-nb-xvi-3-ca07287e1823",
+    "name": "Nb XVI/3",
+    "areaName": "Nb XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "ca07287e1823"
+  },
+  {
+    "polygonId": "uruk-nb-xvi-4-3fbddc14bd87",
+    "name": "Nb XVI/4",
+    "areaName": "Nb XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "3fbddc14bd87"
+  },
+  {
+    "polygonId": "uruk-nb-xvi-5-11522bed4dbb",
+    "name": "Nb XVI/5",
+    "areaName": "Nb XVI/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "11522bed4dbb"
+  },
+  {
+    "polygonId": "uruk-nc-nd-xvi-2-6af3e26c9f5b",
+    "name": "Nc-Nd XVI/2",
+    "areaName": "Nc-Nd XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "6af3e26c9f5b"
+  },
+  {
+    "polygonId": "uruk-nc-xvi-1-880479319b5a",
+    "name": "Nc XVI/1",
+    "areaName": "Nc XVI/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "880479319b5a"
+  },
+  {
+    "polygonId": "uruk-nc-xvi-2-5d16d42d18a1",
+    "name": "Nc XVI/2",
+    "areaName": "Nc XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "5d16d42d18a1"
+  },
+  {
+    "polygonId": "uruk-nc-xvi-5-11e38b545bf1",
+    "name": "Nc XVI/5",
+    "areaName": "Nc XVI/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "11e38b545bf1"
+  },
+  {
+    "polygonId": "uruk-nc-xvii-1-795d72a1f50c",
+    "name": "Nc XVII/1",
+    "areaName": "Nc XVII/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "795d72a1f50c"
+  },
+  {
+    "polygonId": "uruk-nd-xvi-2-e7da9c978a2f",
+    "name": "Nd XVI/2",
+    "areaName": "Nd XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "e7da9c978a2f"
+  },
+  {
+    "polygonId": "uruk-nd-xvi-3-d021bb6cc772",
+    "name": "Nd XVI/3",
+    "areaName": "Nd XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "d021bb6cc772"
+  },
+  {
+    "polygonId": "uruk-nd-xvi-4-5-ne-xvi-3-5-ca3ee571ba37",
+    "name": "Nd XVI/4-5, Ne XVI/3-5",
+    "areaName": "Nd XVI/4-5, Ne XVI/3-5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "ca3ee571ba37"
+  },
+  {
+    "polygonId": "uruk-nd-xvi-4-a4b021b14ec9",
+    "name": "Nd XVI/4",
+    "areaName": "Nd XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "a4b021b14ec9"
+  },
+  {
+    "polygonId": "uruk-nd-xvi-5-67f28c6d8386",
+    "name": "Nd XVI/5",
+    "areaName": "Nd XVI/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "67f28c6d8386"
+  },
+  {
+    "polygonId": "uruk-nd-xvi-5-nd-xvii-1-edbd1b4ccba9",
+    "name": "Nd XVI/5, Nd XVII/1",
+    "areaName": "Nd XVI/5, Nd XVII/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "edbd1b4ccba9"
+  },
+  {
+    "polygonId": "uruk-nd-xxiii-08a9658955dd",
+    "name": "Nd XXIII",
+    "areaName": "Nd XXIII",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "08a9658955dd"
+  },
+  {
+    "polygonId": "uruk-ne-xv-5-b5a30c0b34d2",
+    "name": "Ne XV/5",
+    "areaName": "Ne XV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "b5a30c0b34d2"
+  },
+  {
+    "polygonId": "uruk-ne-xvi-3-c5cd10df748d",
+    "name": "Ne XVI/3",
+    "areaName": "Ne XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "c5cd10df748d"
+  },
+  {
+    "polygonId": "uruk-ne-xvii-2-aaf74eb07a91",
+    "name": "Ne XVII/2",
+    "areaName": "Ne XVII/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "aaf74eb07a91"
+  },
+  {
+    "polygonId": "uruk-oa-ob-xv-3-894c7b9b3cc7",
+    "name": "Oa-Ob XV/3",
+    "areaName": "Oa-Ob XV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "894c7b9b3cc7"
+  },
+  {
+    "polygonId": "uruk-oa-xv-3-7487a18c70f0",
+    "name": "Oa XV/3",
+    "areaName": "Oa XV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "7487a18c70f0"
+  },
+  {
+    "polygonId": "uruk-oa-xv-4-160370d21780",
+    "name": "Oa XV/4",
+    "areaName": "Oa XV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "160370d21780"
+  },
+  {
+    "polygonId": "uruk-oa-xv-5-61d0761b8811",
+    "name": "Oa XV/5",
+    "areaName": "Oa XV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "61d0761b8811"
+  },
+  {
+    "polygonId": "uruk-oa-xvi-1-79443e65b875",
+    "name": "Oa XVI/1",
+    "areaName": "Oa XVI/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "79443e65b875"
+  },
+  {
+    "polygonId": "uruk-ob-xv-3-4-bda2a339a08f",
+    "name": "Ob XV/3-4",
+    "areaName": "Ob XV/3-4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "bda2a339a08f"
+  },
+  {
+    "polygonId": "uruk-ob-xv-3-fed96c8009d5",
+    "name": "Ob XV/3",
+    "areaName": "Ob XV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "fed96c8009d5"
+  },
+  {
+    "polygonId": "uruk-ob-xv-4-474aba67559e",
+    "name": "Ob XV/4",
+    "areaName": "Ob XV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "474aba67559e"
+  },
+  {
+    "polygonId": "uruk-ob-xv-5-008019e206a5",
+    "name": "Ob XV/5",
+    "areaName": "Ob XV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "008019e206a5"
+  },
+  {
+    "polygonId": "uruk-ob-xvi-1-b3e8c8c62285",
+    "name": "Ob XVI/1",
+    "areaName": "Ob XVI/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "b3e8c8c62285"
+  },
+  {
+    "polygonId": "uruk-ob-xvi-3-14069e9c7fa9",
+    "name": "Ob XVI/3",
+    "areaName": "Ob XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "14069e9c7fa9"
+  },
+  {
+    "polygonId": "uruk-ob-xvi-4-36c901802c49",
+    "name": "Ob XVI/4",
+    "areaName": "Ob XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "36c901802c49"
+  },
+  {
+    "polygonId": "uruk-oc-xv-3-e19ff366ca01",
+    "name": "Oc XV/3",
+    "areaName": "Oc XV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "e19ff366ca01"
+  },
+  {
+    "polygonId": "uruk-oc-xv-4-cd0d8cef3fd6",
+    "name": "Oc XV/4",
+    "areaName": "Oc XV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "cd0d8cef3fd6"
+  },
+  {
+    "polygonId": "uruk-oc-xv-5-4f23fd9bf390",
+    "name": "Oc XV/5",
+    "areaName": "Oc XV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "4f23fd9bf390"
+  },
+  {
+    "polygonId": "uruk-oc-xvi-2-ea6501bc40ff",
+    "name": "Oc XVI/2",
+    "areaName": "Oc XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "ea6501bc40ff"
+  },
+  {
+    "polygonId": "uruk-oc-xvi-3-40820197ef28",
+    "name": "Oc XVI/3",
+    "areaName": "Oc XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "40820197ef28"
+  },
+  {
+    "polygonId": "uruk-od-xiv-5-af4ef5493a6f",
+    "name": "Od XIV/5",
+    "areaName": "Od XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "af4ef5493a6f"
+  },
+  {
+    "polygonId": "uruk-od-xv-3-ae7e57889a94",
+    "name": "Od XV/3",
+    "areaName": "Od XV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "ae7e57889a94"
+  },
+  {
+    "polygonId": "uruk-od-xvi-3-31be46638725",
+    "name": "Od XVI/3",
+    "areaName": "Od XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "31be46638725"
+  },
+  {
+    "polygonId": "uruk-od-xvi-4-cf6b0bf88f6a",
+    "name": "Od XVI/4",
+    "areaName": "Od XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "cf6b0bf88f6a"
+  },
+  {
+    "polygonId": "uruk-od-xvii-1-2-aed22799f78c",
+    "name": "Od XVII/1-2",
+    "areaName": "Od XVII/1-2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "aed22799f78c"
+  },
+  {
+    "polygonId": "uruk-oe-pa-xvii-2-5e18c19f28b3",
+    "name": "Oe-Pa XVII/2",
+    "areaName": "Oe-Pa XVII/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "5e18c19f28b3"
+  },
+  {
+    "polygonId": "uruk-oe-xiv-4-176e96014ae7",
+    "name": "Oe XIV/4",
+    "areaName": "Oe XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "176e96014ae7"
+  },
+  {
+    "polygonId": "uruk-oe-xiv-5-f382bfe7ff5e",
+    "name": "Oe XIV/5",
+    "areaName": "Oe XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "f382bfe7ff5e"
+  },
+  {
+    "polygonId": "uruk-oe-xiv-5ff3a686aa89",
+    "name": "Oe XIV",
+    "areaName": "Oe XIV",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "5ff3a686aa89"
+  },
+  {
+    "polygonId": "uruk-p-vi-2-9c93fe08d428",
+    "name": "P VI/2",
+    "areaName": "P VI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "9c93fe08d428"
+  },
+  {
+    "polygonId": "uruk-p-vi-3-64aab6e28bb0",
+    "name": "P VI/3",
+    "areaName": "P VI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "64aab6e28bb0"
+  },
+  {
+    "polygonId": "uruk-pa-xvi-2-29df82537bea",
+    "name": "Pa XVI/2",
+    "areaName": "Pa XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "29df82537bea"
+  },
+  {
+    "polygonId": "uruk-pa-xvi-4-fd6edba91776",
+    "name": "Pa XVI/4",
+    "areaName": "Pa XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "fd6edba91776"
+  },
+  {
+    "polygonId": "uruk-pb-xvi-1-b2c6f28a7847",
+    "name": "Pb XVI/1",
+    "areaName": "Pb XVI/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "b2c6f28a7847"
+  },
+  {
+    "polygonId": "uruk-pb-xvi-3-10a06e0b0c30",
+    "name": "Pb XVI/3",
+    "areaName": "Pb XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "10a06e0b0c30"
+  },
+  {
+    "polygonId": "uruk-pc-xvii-4-33631c22f614",
+    "name": "Pc XVII/4",
+    "areaName": "Pc XVII/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "33631c22f614"
+  },
+  {
+    "polygonId": "uruk-pd-xvi-2-4b6930c1b4d2",
+    "name": "Pd XVI/2",
+    "areaName": "Pd XVI/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "4b6930c1b4d2"
+  },
+  {
+    "polygonId": "uruk-pd-xvi-3-8039a6c7a36d",
+    "name": "Pd XVI/3",
+    "areaName": "Pd XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8039a6c7a36d"
+  },
+  {
+    "polygonId": "uruk-pd-xvi-4-2f30eec5583b",
+    "name": "Pd XVI/4",
+    "areaName": "Pd XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "2f30eec5583b"
+  },
+  {
+    "polygonId": "uruk-pd-xvi-4-f4d48327f7f6",
+    "name": "Pd XVI/4",
+    "areaName": "Pd XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "f4d48327f7f6"
+  },
+  {
+    "polygonId": "uruk-pe-qa-xvi-4-48070b227e1f",
+    "name": "Pe-Qa XVI/4",
+    "areaName": "Pe-Qa XVI/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "48070b227e1f"
+  },
+  {
+    "polygonId": "uruk-pe-xiv-4-8e6d4ec70cbc",
+    "name": "Pe XIV/4",
+    "areaName": "Pe XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8e6d4ec70cbc"
+  },
+  {
+    "polygonId": "uruk-pe-xiv-5-905a067ab399",
+    "name": "Pe XIV/5",
+    "areaName": "Pe XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "905a067ab399"
+  },
+  {
+    "polygonId": "uruk-pe-xvi-3-d51f3faf8317",
+    "name": "Pe XVI/3",
+    "areaName": "Pe XVI/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "d51f3faf8317"
+  },
+  {
+    "polygonId": "uruk-qa-xiv-4-17d7847f2d32",
+    "name": "Qa XIV/4",
+    "areaName": "Qa XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "17d7847f2d32"
+  },
+  {
+    "polygonId": "uruk-qa-xiv-5-89cb18799fb7",
+    "name": "Qa XIV/5",
+    "areaName": "Qa XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "89cb18799fb7"
+  },
+  {
+    "polygonId": "uruk-qa-xiv-6f6ae63ba51f",
+    "name": "Qa XIV",
+    "areaName": "Qa XIV",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "6f6ae63ba51f"
+  },
+  {
+    "polygonId": "uruk-qa-xxv-3-fa21f4d30356",
+    "name": "Qa XXV/3",
+    "areaName": "Qa XXV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "fa21f4d30356"
+  },
+  {
+    "polygonId": "uruk-qb-xiv-3-8cb00d437a39",
+    "name": "Qb XIV/3",
+    "areaName": "Qb XIV/3",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8cb00d437a39"
+  },
+  {
+    "polygonId": "uruk-qb-xiv-4-2e4e4b542a2f",
+    "name": "Qb XIV/4",
+    "areaName": "Qb XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "2e4e4b542a2f"
+  },
+  {
+    "polygonId": "uruk-qb-xiv-5-273e242d6e85",
+    "name": "Qb XIV/5",
+    "areaName": "Qb XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "273e242d6e85"
+  },
+  {
+    "polygonId": "uruk-qb-xiv-fefa311b2dd0",
+    "name": "Qb XIV",
+    "areaName": "Qb XIV",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "fefa311b2dd0"
+  },
+  {
+    "polygonId": "uruk-qb-xv-1-b71e56f4d817",
+    "name": "Qb XV/1",
+    "areaName": "Qb XV/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "b71e56f4d817"
+  },
+  {
+    "polygonId": "uruk-qc-xiv-5-8a6ccd51e7b1",
+    "name": "Qc XIV/5",
+    "areaName": "Qc XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8a6ccd51e7b1"
+  },
+  {
+    "polygonId": "uruk-qc-xv-1-8c702d19d4a4",
+    "name": "Qc XV/1",
+    "areaName": "Qc XV/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8c702d19d4a4"
+  },
+  {
+    "polygonId": "uruk-qd-xiv-5-69adbd0523a1",
+    "name": "Qd XIV/5",
+    "areaName": "Qd XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "69adbd0523a1"
+  },
+  {
+    "polygonId": "uruk-qd-xv-1-21f0c69b8f51",
+    "name": "Qd XV/1",
+    "areaName": "Qd XV/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "21f0c69b8f51"
+  },
+  {
+    "polygonId": "uruk-qd-xv-4-8c54e0a9b28d",
+    "name": "Qd XV/4",
+    "areaName": "Qd XV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8c54e0a9b28d"
+  },
+  {
+    "polygonId": "uruk-qd-xvi-381aea732737",
+    "name": "Qd XVI",
+    "areaName": "Qd XVI",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "381aea732737"
+  },
+  {
+    "polygonId": "uruk-qd-xxv-1-033bb35d4000",
+    "name": "Qd XXV/1",
+    "areaName": "Qd XXV/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "033bb35d4000"
+  },
+  {
+    "polygonId": "uruk-qd-xxv-5-8429747712cf",
+    "name": "Qd XXV/5",
+    "areaName": "Qd XXV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "8429747712cf"
+  },
+  {
+    "polygonId": "uruk-qe-xiv-4-30dc55e5e17c",
+    "name": "Qe XIV/4",
+    "areaName": "Qe XIV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "30dc55e5e17c"
+  },
+  {
+    "polygonId": "uruk-qe-xiv-5-aa8c448957df",
+    "name": "Qe XIV/5",
+    "areaName": "Qe XIV/5",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "aa8c448957df"
+  },
+  {
+    "polygonId": "uruk-qe-xv-1-23ef4cfecfaa",
+    "name": "Qe XV/1",
+    "areaName": "Qe XV/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "23ef4cfecfaa"
+  },
+  {
+    "polygonId": "uruk-qe-xvi-fcbd869640e4",
+    "name": "Qe XVI",
+    "areaName": "Qe XVI",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "fcbd869640e4"
+  },
+  {
+    "polygonId": "uruk-r-vii-5617a49eda9f",
+    "name": "R VII",
+    "areaName": "R VII",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "5617a49eda9f"
+  },
+  {
+    "polygonId": "uruk-t-xiii-e221d36943ae",
+    "name": "T XIII",
+    "areaName": "T XIII",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "e221d36943ae"
+  },
+  {
+    "polygonId": "uruk-u-xvi-c4f6c9d7c7d8",
+    "name": "U XVI",
+    "areaName": "U XVI",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "c4f6c9d7c7d8"
+  },
+  {
+    "polygonId": "uruk-u-xviii-db19732fc9b8",
+    "name": "U XVIII",
+    "areaName": "U XVIII",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "db19732fc9b8"
+  },
+  {
+    "polygonId": "uruk-ub-xviii-4-1462df44fd82",
+    "name": "Ub XVIII/4",
+    "areaName": "Ub XVIII/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "1462df44fd82"
+  },
+  {
+    "polygonId": "uruk-ud-viii-4-f58919603873",
+    "name": "Ud VIII/4",
+    "areaName": "Ud VIII/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "f58919603873"
+  },
+  {
+    "polygonId": "uruk-ue-xiii-1-078e015ee26e",
+    "name": "Ue XIII/1",
+    "areaName": "Ue XIII/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "078e015ee26e"
+  },
+  {
+    "polygonId": "uruk-ue-xv-4-825271b82bba",
+    "name": "Ue XV/4",
+    "areaName": "Ue XV/4",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "825271b82bba"
+  },
+  {
+    "polygonId": "uruk-ue-xvii-15caa5eafad9",
+    "name": "Ue XVII",
+    "areaName": "Ue XVII",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "15caa5eafad9"
+  },
+  {
+    "polygonId": "uruk-ue-xviii-1-4c5b1b215704",
+    "name": "Ue XVIII/1",
+    "areaName": "Ue XVIII/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "4c5b1b215704"
+  },
+  {
+    "polygonId": "uruk-ue-xviii-2-0dcddf1aedc1",
+    "name": "Ue XVIII/2",
+    "areaName": "Ue XVIII/2",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "0dcddf1aedc1"
+  },
+  {
+    "polygonId": "uruk-va-xviii-1-cd71a9c255f0",
+    "name": "Va XVIII/1",
+    "areaName": "Va XVIII/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "cd71a9c255f0"
+  },
+  {
+    "polygonId": "uruk-vb-xviii-1-a74b371d3046",
+    "name": "Vb XVIII/1",
+    "areaName": "Vb XVIII/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "a74b371d3046"
+  },
+  {
+    "polygonId": "uruk-vc-xviii-1-a945e4e95572",
+    "name": "Vc XVIII/1",
+    "areaName": "Vc XVIII/1",
+    "siteId": "URUK",
+    "siteName": "Uruk",
+    "geometryChecksum": "a945e4e95572"
+  }
+]


### PR DESCRIPTION
## Stack & Frontend Consumers

> **Map backend stack — slice 05 of 6.** Branch: `map/backend-05-multisite-artifacts`.
> `master` → #760 → #761 → #762 → #759 → **#758 (this PR)** → #757.
> Based on `map/backend-04-assur-map-data` so this PR shows **only its incremental diff** (Kalḫu / Nippur / Uruk curated polygon data).

### Same-repository dependency

- Direct parent: **#759 — `map/backend-04-assur-map-data`** (the `/findspots/map-data` endpoint).
- Base branch: `map/backend-04-assur-map-data`.
- Merge only after #759 (and #760 → #761 → #762 ahead of it).

### What this PR introduces (incremental slice 05)

- Committed curated polygon mappings + inventories for **Kalḫu, Nippur, Uruk** (`ebl/fragmentarium/data/map/{kalhu,nippur,uruk}_*`).
- No new endpoint, schema, or query code — the `/findspots/map-data` endpoint from #759 begins returning rows for `site=KALHU`, `site=NIPPUR`, `site=URUK` once this data is present.

### Frontend consumers

- **None currently — this backend PR has no frontend runtime consumer.**
  - `ElectronicBabylonianLiterature/ebl-frontend#808` explicitly sets `mapDataSiteParam: null` for `kalhu`, `nippur`, `uruk`, so the frontend never requests `/findspots/map-data` for those sites.
  - `ebl-frontend#796`'s Kalḫu/Nippur/Uruk polygons render from static client-side GeoJSON (`public/map-data/findspots/*.geojson`), not from this endpoint.
- **Future activation gap:** requires a future frontend change — one line per site in `src/map/mapSites.ts` (`mapDataSiteParam: 'KALHU' | 'NIPPUR' | 'URUK'`) plus verification of each site's rows. No such PR is open.

### Merge / deployment order

- **May merge and deploy independently** (after #759). Safe in production with no frontend change — the data is inert until a frontend site is switched on.
- **Not** a coordinated cross-repo release. No frontend PR is gated on it; it gates no frontend PR.

### Downstream backend

- **#757** (`map/backend-06-artifact-transfer`) — stacked directly on this branch.

---

## Summary by Sourcery

Provide deterministic multisite findspot-to-polygon artifacts and expose them through map APIs and findspot-filtered fragment queries.

New Features:
- Add a map-data endpoint that exposes findspot polygons, location metadata, and authorization-aware fragment counts across configured archaeological sites.
- Support filtering fragment searches by one or multiple findspot IDs with validation and a bounded ID list.
- Generate version-controlled polygon inventories, findspot mappings, curation templates, and reports for Assur, Uruk, Kalhu, and Nippur.

Enhancements:
- Introduce validated map-location domain models and schemas while keeping map crosswalks read-only and sourced from generated artifacts.
- Add deterministic shapefile/ODS processing with CRS normalization, stable polygon identities, source matching, conflict detection, and curated mapping validation.
- Centralize script and genre query filters and add batched fragment counting by findspot with visibility constraints.

Build:
- Add pyproj and required geospatial system libraries to the project and CI dependencies.

Tests:
- Add coverage for map artifact generation, geospatial normalization, curation validation, map-data API behavior, findspot filtering, and authorization-aware counts.

Chores:
- Add committed map source metadata and generated artifacts for the supported sites.
