### PR TITLE
Map/backend 04 assur map data

### DIFF
--- a/ebl/context.py
+++ b/ebl/context.py
@@ -13,6 +13,9 @@ from ebl.files.application.file_repository import FileRepository
 from ebl.fragmentarium.application.annotations_repository import AnnotationsRepository
 from ebl.fragmentarium.application.fragment_repository import FragmentRepository
 from ebl.fragmentarium.application.fragment_updater import FragmentUpdater
+from ebl.fragmentarium.application.map_artifact_repository import (
+    MapArtifactRepository,
+)
 from ebl.fragmentarium.application.transliteration_update_factory import (
     TransliterationUpdateFactory,
 )
@@ -61,6 +64,7 @@ class Context:
     provenance_repository: ProvenanceRepository
     provenance_service: ProvenanceService
     realia_repository: RealiaRepository
+    map_artifact_repository: MapArtifactRepository = attr.Factory(MapArtifactRepository)
 
     def get_bibliography(self):
         return Bibliography(self.bibliography_repository, self.changelog)

--- a/ebl/fragmentarium/application/findspot_map_data_schema.py
+++ b/ebl/fragmentarium/application/findspot_map_data_schema.py
@@ -1,0 +1,51 @@
+from marshmallow import Schema, fields
+
+
+class FindspotMapDataSchema(Schema):
+    findspot_id = fields.Method("serialize_findspot_id", data_key="findspotId")
+    site_id = fields.Method("serialize_site_id", data_key="siteId")
+    site_name = fields.Method("serialize_site_name", data_key="siteName")
+    polygon_ids = fields.Method("serialize_polygon_ids", data_key="polygonIds")
+    accessible_fragment_count = fields.Integer(
+        data_key="accessibleFragmentCount", dump_only=True
+    )
+    location_precision = fields.Method(
+        "serialize_location_precision", data_key="locationPrecision"
+    )
+    match_method = fields.Method("serialize_match_method", data_key="matchMethod")
+    sector = fields.Method("serialize_sector")
+    area = fields.Method("serialize_area")
+    building = fields.Method("serialize_building")
+    room = fields.Method("serialize_room")
+
+    def serialize_findspot_id(self, obj):
+        return obj.findspot.id_
+
+    def serialize_site_id(self, obj):
+        return obj.findspot.site.id if obj.findspot.site else None
+
+    def serialize_site_name(self, obj):
+        return obj.findspot.site.long_name if obj.findspot.site else None
+
+    def serialize_polygon_ids(self, obj):
+        if not obj.findspot.map_location:
+            return []
+        return list(obj.findspot.map_location.polygon_ids)
+
+    def serialize_location_precision(self, obj):
+        return obj.findspot.map_location.location_precision.value
+
+    def serialize_match_method(self, obj):
+        return obj.findspot.map_location.match_method.value
+
+    def serialize_sector(self, obj):
+        return obj.findspot.sector or None
+
+    def serialize_area(self, obj):
+        return obj.findspot.area or None
+
+    def serialize_building(self, obj):
+        return obj.findspot.building or None
+
+    def serialize_room(self, obj):
+        return obj.findspot.room or None

--- a/ebl/fragmentarium/application/findspot_map_data_service.py
+++ b/ebl/fragmentarium/application/findspot_map_data_service.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import attr
+
+from ebl.common.domain.scopes import Scope
+from ebl.fragmentarium.application.fragment_repository import FragmentRepository
+from ebl.fragmentarium.application.map_artifact_repository import (
+    MapArtifactRepository,
+)
+from ebl.fragmentarium.domain.findspot import Findspot
+from ebl.fragmentarium.infrastructure.mongo_findspot_repository import (
+    MongoFindspotRepository,
+)
+from ebl.provenance.application.provenance_service import ProvenanceService
+
+
+@dataclass(frozen=True)
+class FindspotMapData:
+    findspot: Findspot
+    accessible_fragment_count: int
+
+
+class FindspotMapDataService:
+    """Serves map-data from the version-controlled, read-only findspot-to-polygon
+    mapping artifacts, joined at request time against live Findspot metadata and
+    authorization-filtered fragment counts. No mapLocation value is read from or
+    written to MongoDB by this service."""
+
+    def __init__(
+        self,
+        findspot_repository: MongoFindspotRepository,
+        fragment_repository: FragmentRepository,
+        provenance_service: ProvenanceService,
+        map_artifact_repository: Optional[MapArtifactRepository] = None,
+    ) -> None:
+        self._findspot_repository = findspot_repository
+        self._fragment_repository = fragment_repository
+        self._provenance_service = provenance_service
+        self._map_artifact_repository = (
+            map_artifact_repository or MapArtifactRepository()
+        )
+
+    def find_map_data(
+        self,
+        site_id: Optional[str] = None,
+        user_scopes: Sequence[Scope] = (),
+        script_period: Optional[str] = None,
+        script_period_modifier: Optional[str] = None,
+        genre: Optional[Sequence[str]] = None,
+    ) -> Sequence[FindspotMapData]:
+        map_locations = self._map_artifact_repository.load_map_locations(
+            (site_id,) if site_id is not None else None
+        )
+        if not map_locations:
+            return []
+
+        site = None if site_id is None else self._provenance_service.find_by_id(site_id)
+        findspots = sorted(
+            (
+                attr.evolve(findspot, map_location=map_locations[findspot.id_])
+                for findspot in self._findspot_repository.find_all()
+                if findspot.id_ in map_locations
+                and (site is None or (findspot.site and findspot.site.id == site.id))
+            ),
+            key=lambda findspot: findspot.id_,
+        )
+
+        counts = self._fragment_repository.count_fragments_by_findspot_ids(
+            [findspot.id_ for findspot in findspots],
+            user_scopes,
+            script_period,
+            script_period_modifier,
+            genre,
+        )
+        return [
+            FindspotMapData(findspot, counts.get(findspot.id_, 0))
+            for findspot in findspots
+        ]

--- a/ebl/fragmentarium/application/fragment_repository.py
+++ b/ebl/fragmentarium/application/fragment_repository.py
@@ -122,6 +122,17 @@ class FragmentRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def count_fragments_by_findspot_ids(
+        self,
+        findspot_ids: Sequence[int],
+        user_scopes: Sequence[Scope],
+        script_period: Optional[str] = None,
+        script_period_modifier: Optional[str] = None,
+        genre: Optional[Sequence[str]] = None,
+    ) -> dict:
+        raise NotImplementedError
+
+    @abstractmethod
     def list_all_fragments(self) -> Sequence[str]:
         raise NotImplementedError
 

--- a/ebl/fragmentarium/data/map/assur_findspot_polygon_curation_report.md
+++ b/ebl/fragmentarium/data/map/assur_findspot_polygon_curation_report.md
@@ -1,0 +1,24 @@
+# Aššur Map Curation Report
+
+- Generated from immutable ODS and shapefile sources.
+- Verified mappings: 317
+- Unresolved rows: 29
+- Source conflicts: 0
+- Invalid source rows: 0
+
+## Deterministic rule used
+
+`normalize(ODS.area) == normalize(shapefile.Name without leading digits)`
+
+Normalization applies Unicode NFKC, trims whitespace, removes `?`, and case-folds both sides.
+
+## Human decision required
+
+The remaining rows need scholarly curation because no unique deterministic polygon match exists.
+
+Unresolved area labels:
+
+- `<blank>`: 7
+- `Wohnquartier`: 16
+- `i3? town area`: 1
+- `town area`: 5

--- a/ebl/fragmentarium/data/map/assur_findspot_polygon_curation_template.json
+++ b/ebl/fragmentarium/data/map/assur_findspot_polygon_curation_template.json
@@ -1,0 +1,292 @@
+[
+  {
+    "findspotId": 4266,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4267,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4268,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4269,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4270,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4271,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4272,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4273,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4274,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4275,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4276,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4277,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4278,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4279,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4280,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4281,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "Wohnquartier",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4396,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "town area",
+    "sector": "Aššur temple",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4414,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "",
+    "sector": "Aššur temple",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4427,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "town area",
+    "sector": "Aššur temple",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4453,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4470,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "town area",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4521,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "",
+    "sector": "Aššur temple",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4543,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "i3? town area",
+    "sector": "Aššur temple",
+    "map": "heinrich1982die@365",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4568,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "town area",
+    "sector": "Aššur temple",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4575,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "town area",
+    "sector": "Aššur temple",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4602,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "",
+    "sector": "Aššur temple",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4636,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4637,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "",
+    "sector": "",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  },
+  {
+    "findspotId": 4662,
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "area": "",
+    "sector": "Houses 65-66",
+    "map": "???",
+    "status": "needs-human-curation",
+    "requiredDecision": "Assign a polygon ID or confirm the row is unmapped."
+  }
+]

--- a/ebl/fragmentarium/data/map/assur_findspot_polygon_mappings.json
+++ b/ebl/fragmentarium/data/map/assur_findspot_polygon_mappings.json
@@ -1,0 +1,3172 @@
+[
+  {
+    "findspotId": 1406,
+    "polygonIds": [
+      "assur-dd9iv-ab130cd33b86"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4384,
+    "polygonIds": [
+      "assur-fe5iii-6bff491dc11f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4385,
+    "polygonIds": [
+      "assur-fb5ii-c2ef37047215"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4386,
+    "polygonIds": [
+      "assur-ga5ii-3088de6caaf3"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4387,
+    "polygonIds": [
+      "assur-ga5iii-21acb7b27aa6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4388,
+    "polygonIds": [
+      "assur-fc5iii-6eb6aba7b1e1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4389,
+    "polygonIds": [
+      "assur-fe5ii-3e9fb1eb128a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4390,
+    "polygonIds": [
+      "assur-hb4ii-984bc19a4843"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4391,
+    "polygonIds": [
+      "assur-gd4ii-9be07638fbff"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4392,
+    "polygonIds": [
+      "assur-gb4ii-4e46b9b143ad"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4393,
+    "polygonIds": [
+      "assur-ga4i-1423b39dd202"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4394,
+    "polygonIds": [
+      "assur-ga4ii-40b5cc297561"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4395,
+    "polygonIds": [
+      "assur-gb3v-cbe161c398e8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4397,
+    "polygonIds": [
+      "assur-ga4ii-40b5cc297561"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4398,
+    "polygonIds": [
+      "assur-g4-35f877be9450"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4399,
+    "polygonIds": [
+      "assur-eb6i-a69f84fae394"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4400,
+    "polygonIds": [
+      "assur-eb6i-a69f84fae394"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4401,
+    "polygonIds": [
+      "assur-de5v-b4930efd61c1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4402,
+    "polygonIds": [
+      "assur-ee5iv-898e94441cbf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4403,
+    "polygonIds": [
+      "assur-ee5v-302a510c01d2"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4404,
+    "polygonIds": [
+      "assur-ee5iv-898e94441cbf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4405,
+    "polygonIds": [
+      "assur-ea5v-d293ab969788"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4406,
+    "polygonIds": [
+      "assur-ee5ii-ab93b4168d31"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4407,
+    "polygonIds": [
+      "assur-ea6i-a66d4d602381"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4408,
+    "polygonIds": [
+      "assur-ea5v-d293ab969788"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4409,
+    "polygonIds": [
+      "assur-ea6ii-2f294f57d786"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4410,
+    "polygonIds": [
+      "assur-eb5v-71efa0213895"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4411,
+    "polygonIds": [
+      "assur-ea5v-d293ab969788"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4412,
+    "polygonIds": [
+      "assur-ea5v-d293ab969788"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4413,
+    "polygonIds": [
+      "assur-de5iv-bde9abf49c29"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4415,
+    "polygonIds": [
+      "assur-ed6v-57cae57f5031"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4416,
+    "polygonIds": [
+      "assur-ea6ii-2f294f57d786"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4417,
+    "polygonIds": [
+      "assur-ea6ii-2f294f57d786"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4418,
+    "polygonIds": [
+      "assur-ea6ii-2f294f57d786"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4419,
+    "polygonIds": [
+      "assur-dd6ii-08e487e4fda3"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4420,
+    "polygonIds": [
+      "assur-ed5iii-6a03df7cfbfc"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4421,
+    "polygonIds": [
+      "assur-da5iv-a4ab08f22278"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4422,
+    "polygonIds": [
+      "assur-da5iii-6a62aeabdf81"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4423,
+    "polygonIds": [
+      "assur-gc4v-1985c493b282"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4424,
+    "polygonIds": [
+      "assur-gc4v-1985c493b282"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4425,
+    "polygonIds": [
+      "assur-eb7ii-f72a9729f147"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4426,
+    "polygonIds": [
+      "assur-ga4v-f6ca1aebcd97"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4428,
+    "polygonIds": [
+      "assur-fc5iii-6eb6aba7b1e1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4429,
+    "polygonIds": [
+      "assur-gd5ii-fecfb9950eb0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4430,
+    "polygonIds": [
+      "assur-gd5ii-fecfb9950eb0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4431,
+    "polygonIds": [
+      "assur-gd5ii-fecfb9950eb0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4432,
+    "polygonIds": [
+      "assur-gc5i-9d7eec32dfdd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4433,
+    "polygonIds": [
+      "assur-gb5ii-6ad615e8405b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4434,
+    "polygonIds": [
+      "assur-gb5i-61fb399ff411"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4435,
+    "polygonIds": [
+      "assur-gb5i-61fb399ff411"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4436,
+    "polygonIds": [
+      "assur-gc5v-2798b87e53dc"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4437,
+    "polygonIds": [
+      "assur-gb5ii-6ad615e8405b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4438,
+    "polygonIds": [
+      "assur-gb5ii-6ad615e8405b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4439,
+    "polygonIds": [
+      "assur-ea7iii-c01b12def1aa"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4440,
+    "polygonIds": [
+      "assur-ea7iii-c01b12def1aa"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4441,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4442,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4443,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4444,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4445,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4446,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4447,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4448,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4449,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4450,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4451,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4452,
+    "polygonIds": [
+      "assur-he4iii-484562f8f1ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4454,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4455,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4456,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4457,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4458,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4459,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4460,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4461,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4462,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4463,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4464,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4465,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4466,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4467,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4468,
+    "polygonIds": [
+      "assur-ee5iv-898e94441cbf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4469,
+    "polygonIds": [
+      "assur-ee5iv-898e94441cbf"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4471,
+    "polygonIds": [
+      "assur-ee5iii-43ee169f4603"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4472,
+    "polygonIds": [
+      "assur-ee6v-64ea5b739a46"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4473,
+    "polygonIds": [
+      "assur-ee6v-64ea5b739a46"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4474,
+    "polygonIds": [
+      "assur-ee6v-7i-9d2184703a67"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4475,
+    "polygonIds": [
+      "assur-ee7i-a5f5979278de"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4476,
+    "polygonIds": [
+      "assur-fa6v-c87b4cbab63d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4477,
+    "polygonIds": [
+      "assur-fa6v-c87b4cbab63d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4478,
+    "polygonIds": [
+      "assur-ee6v-64ea5b739a46"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4479,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4480,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4481,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4482,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4483,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4484,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4485,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4486,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4487,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4488,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4489,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4490,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4491,
+    "polygonIds": [
+      "assur-bb6i-3d76dc1e02af"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4492,
+    "polygonIds": [
+      "assur-ia8i-6aa9d256700b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4493,
+    "polygonIds": [
+      "assur-ia8i-6aa9d256700b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4494,
+    "polygonIds": [
+      "assur-da8i-6b5ce207f9c1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4495,
+    "polygonIds": [
+      "assur-de7iv-fb89af1923be"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4496,
+    "polygonIds": [
+      "assur-de7iv-fb89af1923be"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4497,
+    "polygonIds": [
+      "assur-de7iv-fb89af1923be"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4498,
+    "polygonIds": [
+      "assur-ea9i-5e10d62f21ea"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4499,
+    "polygonIds": [
+      "assur-ea9i-5e10d62f21ea"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4500,
+    "polygonIds": [
+      "assur-ec9i-e68eedba1579"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4501,
+    "polygonIds": [
+      "assur-ec9i-e68eedba1579"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4502,
+    "polygonIds": [
+      "assur-fe10i-3c7ed857e189"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4503,
+    "polygonIds": [
+      "assur-fe10i-3c7ed857e189"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4504,
+    "polygonIds": [
+      "assur-fe10i-3c7ed857e189"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4505,
+    "polygonIds": [
+      "assur-fe10i-3c7ed857e189"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4506,
+    "polygonIds": [
+      "assur-ga10i-a13746659919"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4507,
+    "polygonIds": [
+      "assur-fe10i-3c7ed857e189"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4508,
+    "polygonIds": [
+      "assur-fe9v-51de8f60bedc"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4509,
+    "polygonIds": [
+      "assur-fe9v-51de8f60bedc"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4510,
+    "polygonIds": [
+      "assur-ga5iii-21acb7b27aa6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4511,
+    "polygonIds": [
+      "assur-eb5iii-36f55ad7d8f3"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4512,
+    "polygonIds": [
+      "assur-id3v-b2da9fe54e6d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4513,
+    "polygonIds": [
+      "assur-be5i-f5ecbd35972a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4514,
+    "polygonIds": [
+      "assur-ib7i-ee0365a27ee5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4515,
+    "polygonIds": [
+      "assur-dc9v-2d4f68a5e8c3"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4516,
+    "polygonIds": [
+      "assur-da6ii-016b9bbe05f4"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4517,
+    "polygonIds": [
+      "assur-da6iv-e2f748bf874e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4518,
+    "polygonIds": [
+      "assur-ic4v-6332648aea16"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4519,
+    "polygonIds": [
+      "assur-id4v-b45c39108b04"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4520,
+    "polygonIds": [
+      "assur-id4v-b45c39108b04"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4522,
+    "polygonIds": [
+      "assur-id5i-9cf249acf23a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4523,
+    "polygonIds": [
+      "assur-ic4v-6332648aea16"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4524,
+    "polygonIds": [
+      "assur-ic4v-6332648aea16"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4525,
+    "polygonIds": [
+      "assur-id4iv-becfbc958fce"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4526,
+    "polygonIds": [
+      "assur-ic4iv-c0a218a92708"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4527,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4528,
+    "polygonIds": [
+      "assur-hc4v-478fa3bdc4c8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4529,
+    "polygonIds": [
+      "assur-hc4iv-f2f64d75d970"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4530,
+    "polygonIds": [
+      "assur-ha3v-5e86c360cff0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4531,
+    "polygonIds": [
+      "assur-hd4ii-5f535f7de6ba"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4532,
+    "polygonIds": [
+      "assur-hd4i-0ed0e29b0f09"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4533,
+    "polygonIds": [
+      "assur-hd4i-0ed0e29b0f09"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4534,
+    "polygonIds": [
+      "assur-he4i-030d5af2f188"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4535,
+    "polygonIds": [
+      "assur-he4ii-f0314ef9a16b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4536,
+    "polygonIds": [
+      "assur-hd4i-0ed0e29b0f09"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4537,
+    "polygonIds": [
+      "assur-hd4i-0ed0e29b0f09"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4538,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4539,
+    "polygonIds": [
+      "assur-he4ii-f0314ef9a16b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4540,
+    "polygonIds": [
+      "assur-hb5iii-f3a81030678e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4541,
+    "polygonIds": [
+      "assur-hd4i-0ed0e29b0f09"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4542,
+    "polygonIds": [
+      "assur-hc3v-e656693e7ee1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4544,
+    "polygonIds": [
+      "assur-hc4i-88e7d0f8b8c5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4545,
+    "polygonIds": [
+      "assur-gb4ii-4e46b9b143ad"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4546,
+    "polygonIds": [
+      "assur-hc4i-88e7d0f8b8c5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4547,
+    "polygonIds": [
+      "assur-hc4i-88e7d0f8b8c5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4548,
+    "polygonIds": [
+      "assur-hc4i-88e7d0f8b8c5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4549,
+    "polygonIds": [
+      "assur-gc4i-d54b77ef4c6e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4550,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4551,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4552,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4553,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4554,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4555,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4556,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4557,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4558,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4559,
+    "polygonIds": [
+      "assur-ic4v-6332648aea16"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4560,
+    "polygonIds": [
+      "assur-hd3v-eb5d4942ef7a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4561,
+    "polygonIds": [
+      "assur-ib4iv-a6b663a19751"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4562,
+    "polygonIds": [
+      "assur-ib4iv-a6b663a19751"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4563,
+    "polygonIds": [
+      "assur-ib4iv-a6b663a19751"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4564,
+    "polygonIds": [
+      "assur-hd4v-96ead1e90c88"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4565,
+    "polygonIds": [
+      "assur-ib4iv-a6b663a19751"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4566,
+    "polygonIds": [
+      "assur-ib4iv-a6b663a19751"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4567,
+    "polygonIds": [
+      "assur-ia4iv-b128914b08d6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4569,
+    "polygonIds": [
+      "assur-ia4v-bcc63bb63b4d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4570,
+    "polygonIds": [
+      "assur-ia4ii-4ea6406187c8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4571,
+    "polygonIds": [
+      "assur-ib4ii-6d81d4c48c28"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4572,
+    "polygonIds": [
+      "assur-ia4i-43241c493419"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4573,
+    "polygonIds": [
+      "assur-ib4iii-0a4e3a9fea3c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4574,
+    "polygonIds": [
+      "assur-he4i-030d5af2f188"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4576,
+    "polygonIds": [
+      "assur-ia3iv-954858445363"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4577,
+    "polygonIds": [
+      "assur-ia3iv-954858445363"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4578,
+    "polygonIds": [
+      "assur-ic4i-df9fe989b4ff"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4579,
+    "polygonIds": [
+      "assur-ic3ii-b81d7278c59c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4580,
+    "polygonIds": [
+      "assur-ib4ii-6d81d4c48c28"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4581,
+    "polygonIds": [
+      "assur-ic4iv-c0a218a92708"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4582,
+    "polygonIds": [
+      "assur-ic4iii-6b755722331e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4583,
+    "polygonIds": [
+      "assur-ic4iii-6b755722331e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4584,
+    "polygonIds": [
+      "assur-id3iv-5388a6fdd9f3"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4585,
+    "polygonIds": [
+      "assur-ib3ii-5f955c916bd6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4586,
+    "polygonIds": [
+      "assur-ic3ii-b81d7278c59c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4587,
+    "polygonIds": [
+      "assur-ic4ii-12e470b76085"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4588,
+    "polygonIds": [
+      "assur-ib4i-69c767eaaa9b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4589,
+    "polygonIds": [
+      "assur-ib4i-69c767eaaa9b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4590,
+    "polygonIds": [
+      "assur-ib4i-69c767eaaa9b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4591,
+    "polygonIds": [
+      "assur-ib3iv-5d5a2ab832b9"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4592,
+    "polygonIds": [
+      "assur-ib3iii-9c0254833076"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4593,
+    "polygonIds": [
+      "assur-hd4i-0ed0e29b0f09"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4594,
+    "polygonIds": [
+      "assur-ib4iv-a6b663a19751"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4595,
+    "polygonIds": [
+      "assur-id4v-b45c39108b04"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4596,
+    "polygonIds": [
+      "assur-ib4v-a8f3256907f1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4597,
+    "polygonIds": [
+      "assur-ic5i-5cb3680f11f1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4598,
+    "polygonIds": [
+      "assur-id4v-b45c39108b04"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4599,
+    "polygonIds": [
+      "assur-id4v-b45c39108b04"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4600,
+    "polygonIds": [
+      "assur-gd5ii-fecfb9950eb0"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4601,
+    "polygonIds": [
+      "assur-id5i-9cf249acf23a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4603,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4604,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4605,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4606,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4607,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4608,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4609,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4610,
+    "polygonIds": [
+      "assur-h4-d61258ca24f6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4611,
+    "polygonIds": [
+      "assur-hb4v-dda5f259287d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4612,
+    "polygonIds": [
+      "assur-ic6iii-26ecdd95a8d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4613,
+    "polygonIds": [
+      "assur-ib6iii-a1259d123f1e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4614,
+    "polygonIds": [
+      "assur-ib6iii-a1259d123f1e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4615,
+    "polygonIds": [
+      "assur-ic6iii-26ecdd95a8d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4616,
+    "polygonIds": [
+      "assur-ib6iii-a1259d123f1e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4617,
+    "polygonIds": [
+      "assur-ic6iii-26ecdd95a8d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4618,
+    "polygonIds": [
+      "assur-ic6iii-26ecdd95a8d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4619,
+    "polygonIds": [
+      "assur-ib6iii-a1259d123f1e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4620,
+    "polygonIds": [
+      "assur-ib6iii-a1259d123f1e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4621,
+    "polygonIds": [
+      "assur-ic6iii-26ecdd95a8d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4622,
+    "polygonIds": [
+      "assur-ic6iii-26ecdd95a8d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4623,
+    "polygonIds": [
+      "assur-he8i-e1127cc93dfe"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4624,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4625,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4626,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4627,
+    "polygonIds": [
+      "assur-he8i-e1127cc93dfe"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4628,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4629,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4630,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4631,
+    "polygonIds": [
+      "assur-hc8i-7c55133a9d29"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4632,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4633,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4634,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4635,
+    "polygonIds": [
+      "assur-hd8i-04d1913af44c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4638,
+    "polygonIds": [
+      "assur-l9-081650a81622"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4639,
+    "polygonIds": [
+      "assur-l9-081650a81622"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4640,
+    "polygonIds": [
+      "assur-la9ii-a1ccc873746b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4641,
+    "polygonIds": [
+      "assur-l8-d809790a6828"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4642,
+    "polygonIds": [
+      "assur-l8-d809790a6828"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4643,
+    "polygonIds": [
+      "assur-la9ii-a1ccc873746b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4644,
+    "polygonIds": [
+      "assur-la9ii-a1ccc873746b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4645,
+    "polygonIds": [
+      "assur-la9ii-a1ccc873746b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4646,
+    "polygonIds": [
+      "assur-la9ii-a1ccc873746b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4647,
+    "polygonIds": [
+      "assur-la9ii-a1ccc873746b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4648,
+    "polygonIds": [
+      "assur-l9-081650a81622"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4649,
+    "polygonIds": [
+      "assur-l9-081650a81622"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4650,
+    "polygonIds": [
+      "assur-l9-081650a81622"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4651,
+    "polygonIds": [
+      "assur-hc10iv-e9ba6785720f"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4652,
+    "polygonIds": [
+      "assur-cd9ii-35f1792f2c59"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4653,
+    "polygonIds": [
+      "assur-cd9i-70cce66085df"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4654,
+    "polygonIds": [
+      "assur-ed10i-122e56db4bf8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4655,
+    "polygonIds": [
+      "assur-be4v-797c28d39cb5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4656,
+    "polygonIds": [
+      "assur-be4v-797c28d39cb5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4657,
+    "polygonIds": [
+      "assur-be4v-797c28d39cb5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4658,
+    "polygonIds": [
+      "assur-be4v-797c28d39cb5"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4659,
+    "polygonIds": [
+      "assur-be5i-f5ecbd35972a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4660,
+    "polygonIds": [
+      "assur-be5i-f5ecbd35972a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4661,
+    "polygonIds": [
+      "assur-bd5i-1106b4b8fc7c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4663,
+    "polygonIds": [
+      "assur-bd5i-1106b4b8fc7c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4664,
+    "polygonIds": [
+      "assur-bd5i-1106b4b8fc7c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4665,
+    "polygonIds": [
+      "assur-bd5i-1106b4b8fc7c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4666,
+    "polygonIds": [
+      "assur-be5i-f5ecbd35972a"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4667,
+    "polygonIds": [
+      "assur-bd5i-1106b4b8fc7c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4668,
+    "polygonIds": [
+      "assur-bd5i-1106b4b8fc7c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4669,
+    "polygonIds": [
+      "assur-bd5i-1106b4b8fc7c"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4670,
+    "polygonIds": [
+      "assur-bc5ii-310134341079"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4671,
+    "polygonIds": [
+      "assur-bc5iii-9496f1c01d5b"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4672,
+    "polygonIds": [
+      "assur-bc5ii-310134341079"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4673,
+    "polygonIds": [
+      "assur-de5v-b4930efd61c1"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4674,
+    "polygonIds": [
+      "assur-ea5v-d293ab969788"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4675,
+    "polygonIds": [
+      "assur-eb5v-71efa0213895"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4676,
+    "polygonIds": [
+      "assur-db5iv-3f293e1fa0bd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4677,
+    "polygonIds": [
+      "assur-db5iv-3f293e1fa0bd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4678,
+    "polygonIds": [
+      "assur-db5iv-3f293e1fa0bd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4679,
+    "polygonIds": [
+      "assur-db5iv-3f293e1fa0bd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4680,
+    "polygonIds": [
+      "assur-cd6i-18c98d0c1647"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4681,
+    "polygonIds": [
+      "assur-da6ii-016b9bbe05f4"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4682,
+    "polygonIds": [
+      "assur-da6iv-e2f748bf874e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4683,
+    "polygonIds": [
+      "assur-da6iv-e2f748bf874e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4684,
+    "polygonIds": [
+      "assur-da6iv-e2f748bf874e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4685,
+    "polygonIds": [
+      "assur-ce6iv-d9f48276e9ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4686,
+    "polygonIds": [
+      "assur-ce6iv-d9f48276e9ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4687,
+    "polygonIds": [
+      "assur-ce6iv-d9f48276e9ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4688,
+    "polygonIds": [
+      "assur-ce6iv-d9f48276e9ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4689,
+    "polygonIds": [
+      "assur-ce6iv-d9f48276e9ab"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4690,
+    "polygonIds": [
+      "assur-ce6iii-01ed729cc729"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4691,
+    "polygonIds": [
+      "assur-ce6iii-01ed729cc729"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4692,
+    "polygonIds": [
+      "assur-c6-1047f1e15a68"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4693,
+    "polygonIds": [
+      "assur-be7i-38ce66f15dcd"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4694,
+    "polygonIds": [
+      "assur-be8i-6f4ff2e5c4aa"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4695,
+    "polygonIds": [
+      "assur-be8i-6f4ff2e5c4aa"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4696,
+    "polygonIds": [
+      "assur-bd8ii-66e6a0a429d8"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4697,
+    "polygonIds": [
+      "assur-cc9i-af66f2996084"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4698,
+    "polygonIds": [
+      "assur-cd9ii-35f1792f2c59"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4699,
+    "polygonIds": [
+      "assur-da9iii-d31b8edb8af6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4700,
+    "polygonIds": [
+      "assur-da9iii-d31b8edb8af6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4701,
+    "polygonIds": [
+      "assur-da9iii-d31b8edb8af6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4702,
+    "polygonIds": [
+      "assur-dd9iv-ab130cd33b86"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4703,
+    "polygonIds": [
+      "assur-de9v-d6499ffb6a89"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4704,
+    "polygonIds": [
+      "assur-ea7ii-8e7d7e44b6f4"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4705,
+    "polygonIds": [
+      "assur-ge9i-f06fc5d649e6"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4706,
+    "polygonIds": [
+      "assur-fc8i-713e9a4a2d5d"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4707,
+    "polygonIds": [
+      "assur-fd8i-554d058cd5c7"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4708,
+    "polygonIds": [
+      "assur-id8i-d16dd7b3c388"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4709,
+    "polygonIds": [
+      "assur-fd8i-554d058cd5c7"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4710,
+    "polygonIds": [
+      "assur-fd8i-554d058cd5c7"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4711,
+    "polygonIds": [
+      "assur-gb9i-f02183f4767e"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  },
+  {
+    "findspotId": 4712,
+    "polygonIds": [
+      "assur-gd10i-10d1c2f64360"
+    ],
+    "locationPrecision": "excavation-area",
+    "matchMethod": "verified-source",
+    "source": "Assur Tafeln.ods",
+    "sourceRevision": "2026-07-27"
+  }
+]

--- a/ebl/fragmentarium/data/map/assur_polygon_inventory.json
+++ b/ebl/fragmentarium/data/map/assur_polygon_inventory.json
@@ -1,0 +1,1074 @@
+[
+  {
+    "polygonId": "assur-bb6i-3d76dc1e02af",
+    "name": "bB6I",
+    "areaName": "bB6I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "3d76dc1e02af"
+  },
+  {
+    "polygonId": "assur-bc5ii-310134341079",
+    "name": "bC5II",
+    "areaName": "bC5II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "310134341079"
+  },
+  {
+    "polygonId": "assur-bc5iii-9496f1c01d5b",
+    "name": "bC5III",
+    "areaName": "bC5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "9496f1c01d5b"
+  },
+  {
+    "polygonId": "assur-bd5i-1106b4b8fc7c",
+    "name": "bD5I",
+    "areaName": "bD5I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "1106b4b8fc7c"
+  },
+  {
+    "polygonId": "assur-bd8ii-66e6a0a429d8",
+    "name": "bD8II",
+    "areaName": "bD8II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "66e6a0a429d8"
+  },
+  {
+    "polygonId": "assur-be4v-797c28d39cb5",
+    "name": "bE4V",
+    "areaName": "bE4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "797c28d39cb5"
+  },
+  {
+    "polygonId": "assur-be5i-f5ecbd35972a",
+    "name": "bE5I",
+    "areaName": "bE5I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f5ecbd35972a"
+  },
+  {
+    "polygonId": "assur-be7i-38ce66f15dcd",
+    "name": "bE7I",
+    "areaName": "bE7I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "38ce66f15dcd"
+  },
+  {
+    "polygonId": "assur-be8i-6f4ff2e5c4aa",
+    "name": "bE8I",
+    "areaName": "bE8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6f4ff2e5c4aa"
+  },
+  {
+    "polygonId": "assur-c6-1047f1e15a68",
+    "name": "c6",
+    "areaName": "c6",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "1047f1e15a68"
+  },
+  {
+    "polygonId": "assur-cc9i-af66f2996084",
+    "name": "cC9I",
+    "areaName": "cC9I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "af66f2996084"
+  },
+  {
+    "polygonId": "assur-cd6i-18c98d0c1647",
+    "name": "cD6I",
+    "areaName": "cD6I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "18c98d0c1647"
+  },
+  {
+    "polygonId": "assur-cd9i-70cce66085df",
+    "name": "cD9I",
+    "areaName": "cD9I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "70cce66085df"
+  },
+  {
+    "polygonId": "assur-cd9ii-35f1792f2c59",
+    "name": "cD9II",
+    "areaName": "cD9II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "35f1792f2c59"
+  },
+  {
+    "polygonId": "assur-ce6iii-01ed729cc729",
+    "name": "cE6III",
+    "areaName": "cE6III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "01ed729cc729"
+  },
+  {
+    "polygonId": "assur-ce6iv-d9f48276e9ab",
+    "name": "cE6IV",
+    "areaName": "cE6IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d9f48276e9ab"
+  },
+  {
+    "polygonId": "assur-da5iii-6a62aeabdf81",
+    "name": "dA5III",
+    "areaName": "dA5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6a62aeabdf81"
+  },
+  {
+    "polygonId": "assur-da5iv-a4ab08f22278",
+    "name": "dA5IV",
+    "areaName": "dA5IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a4ab08f22278"
+  },
+  {
+    "polygonId": "assur-da6ii-016b9bbe05f4",
+    "name": "dA6II",
+    "areaName": "dA6II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "016b9bbe05f4"
+  },
+  {
+    "polygonId": "assur-da6iv-e2f748bf874e",
+    "name": "dA6IV",
+    "areaName": "dA6IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "e2f748bf874e"
+  },
+  {
+    "polygonId": "assur-da8i-6b5ce207f9c1",
+    "name": "dA8I",
+    "areaName": "dA8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6b5ce207f9c1"
+  },
+  {
+    "polygonId": "assur-da9iii-d31b8edb8af6",
+    "name": "dA9III",
+    "areaName": "dA9III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d31b8edb8af6"
+  },
+  {
+    "polygonId": "assur-db5iv-3f293e1fa0bd",
+    "name": "dB5IV",
+    "areaName": "dB5IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "3f293e1fa0bd"
+  },
+  {
+    "polygonId": "assur-dc9v-2d4f68a5e8c3",
+    "name": "dC9V",
+    "areaName": "dC9V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "2d4f68a5e8c3"
+  },
+  {
+    "polygonId": "assur-dd6ii-08e487e4fda3",
+    "name": "dD6II",
+    "areaName": "dD6II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "08e487e4fda3"
+  },
+  {
+    "polygonId": "assur-dd9iv-ab130cd33b86",
+    "name": "dD9IV",
+    "areaName": "dD9IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "ab130cd33b86"
+  },
+  {
+    "polygonId": "assur-de5iv-bde9abf49c29",
+    "name": "dE5IV",
+    "areaName": "dE5IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "bde9abf49c29"
+  },
+  {
+    "polygonId": "assur-de5v-b4930efd61c1",
+    "name": "dE5V",
+    "areaName": "dE5V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "b4930efd61c1"
+  },
+  {
+    "polygonId": "assur-de7iv-fb89af1923be",
+    "name": "dE7IV",
+    "areaName": "dE7IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "fb89af1923be"
+  },
+  {
+    "polygonId": "assur-de9v-d6499ffb6a89",
+    "name": "dE9V",
+    "areaName": "dE9V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d6499ffb6a89"
+  },
+  {
+    "polygonId": "assur-ea5v-d293ab969788",
+    "name": "eA5V",
+    "areaName": "eA5V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d293ab969788"
+  },
+  {
+    "polygonId": "assur-ea6i-a66d4d602381",
+    "name": "eA6I",
+    "areaName": "eA6I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a66d4d602381"
+  },
+  {
+    "polygonId": "assur-ea6ii-2f294f57d786",
+    "name": "eA6II",
+    "areaName": "eA6II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "2f294f57d786"
+  },
+  {
+    "polygonId": "assur-ea7ii-8e7d7e44b6f4",
+    "name": "eA7II",
+    "areaName": "eA7II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "8e7d7e44b6f4"
+  },
+  {
+    "polygonId": "assur-ea7iii-c01b12def1aa",
+    "name": "eA7III",
+    "areaName": "eA7III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "c01b12def1aa"
+  },
+  {
+    "polygonId": "assur-ea9i-5e10d62f21ea",
+    "name": "eA9I",
+    "areaName": "eA9I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "5e10d62f21ea"
+  },
+  {
+    "polygonId": "assur-eb5iii-36f55ad7d8f3",
+    "name": "eB5III",
+    "areaName": "eB5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "36f55ad7d8f3"
+  },
+  {
+    "polygonId": "assur-eb5v-71efa0213895",
+    "name": "eB5V",
+    "areaName": "eB5V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "71efa0213895"
+  },
+  {
+    "polygonId": "assur-eb6i-a69f84fae394",
+    "name": "eB6I",
+    "areaName": "eB6I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a69f84fae394"
+  },
+  {
+    "polygonId": "assur-eb7ii-f72a9729f147",
+    "name": "eB7II",
+    "areaName": "eB7II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f72a9729f147"
+  },
+  {
+    "polygonId": "assur-ec9i-e68eedba1579",
+    "name": "eC9I",
+    "areaName": "eC9I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "e68eedba1579"
+  },
+  {
+    "polygonId": "assur-ed10i-122e56db4bf8",
+    "name": "eD10I",
+    "areaName": "eD10I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "122e56db4bf8"
+  },
+  {
+    "polygonId": "assur-ed5iii-6a03df7cfbfc",
+    "name": "eD5III",
+    "areaName": "eD5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6a03df7cfbfc"
+  },
+  {
+    "polygonId": "assur-ed6v-57cae57f5031",
+    "name": "eD6V",
+    "areaName": "eD6V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "57cae57f5031"
+  },
+  {
+    "polygonId": "assur-ee5ii-ab93b4168d31",
+    "name": "eE5II",
+    "areaName": "eE5II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "ab93b4168d31"
+  },
+  {
+    "polygonId": "assur-ee5iii-43ee169f4603",
+    "name": "eE5III",
+    "areaName": "eE5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "43ee169f4603"
+  },
+  {
+    "polygonId": "assur-ee5iv-898e94441cbf",
+    "name": "eE5IV",
+    "areaName": "eE5IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "898e94441cbf"
+  },
+  {
+    "polygonId": "assur-ee5v-302a510c01d2",
+    "name": "eE5V",
+    "areaName": "eE5V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "302a510c01d2"
+  },
+  {
+    "polygonId": "assur-ee6v-64ea5b739a46",
+    "name": "eE6V",
+    "areaName": "eE6V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "64ea5b739a46"
+  },
+  {
+    "polygonId": "assur-ee6v-7i-9d2184703a67",
+    "name": "eE6V/7I",
+    "areaName": "eE6V/7I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "9d2184703a67"
+  },
+  {
+    "polygonId": "assur-ee7i-a5f5979278de",
+    "name": "eE7I",
+    "areaName": "eE7I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a5f5979278de"
+  },
+  {
+    "polygonId": "assur-fa6v-c87b4cbab63d",
+    "name": "fA6V",
+    "areaName": "fA6V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "c87b4cbab63d"
+  },
+  {
+    "polygonId": "assur-fb5ii-c2ef37047215",
+    "name": "fB5II",
+    "areaName": "fB5II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "c2ef37047215"
+  },
+  {
+    "polygonId": "assur-fc5iii-6eb6aba7b1e1",
+    "name": "fC5III",
+    "areaName": "fC5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6eb6aba7b1e1"
+  },
+  {
+    "polygonId": "assur-fc8i-713e9a4a2d5d",
+    "name": "fC8I",
+    "areaName": "fC8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "713e9a4a2d5d"
+  },
+  {
+    "polygonId": "assur-fd8i-554d058cd5c7",
+    "name": "fD8I",
+    "areaName": "fD8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "554d058cd5c7"
+  },
+  {
+    "polygonId": "assur-fe10i-3c7ed857e189",
+    "name": "fE10I",
+    "areaName": "fE10I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "3c7ed857e189"
+  },
+  {
+    "polygonId": "assur-fe5ii-3e9fb1eb128a",
+    "name": "fE5II",
+    "areaName": "fE5II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "3e9fb1eb128a"
+  },
+  {
+    "polygonId": "assur-fe5iii-6bff491dc11f",
+    "name": "fE5III",
+    "areaName": "fE5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6bff491dc11f"
+  },
+  {
+    "polygonId": "assur-fe9v-51de8f60bedc",
+    "name": "fE9V",
+    "areaName": "fE9V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "51de8f60bedc"
+  },
+  {
+    "polygonId": "assur-g4-35f877be9450",
+    "name": "g4",
+    "areaName": "g4",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "35f877be9450"
+  },
+  {
+    "polygonId": "assur-ga10i-a13746659919",
+    "name": "gA10I",
+    "areaName": "gA10I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a13746659919"
+  },
+  {
+    "polygonId": "assur-ga4i-1423b39dd202",
+    "name": "gA4I",
+    "areaName": "gA4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "1423b39dd202"
+  },
+  {
+    "polygonId": "assur-ga4ii-40b5cc297561",
+    "name": "gA4II",
+    "areaName": "gA4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "40b5cc297561"
+  },
+  {
+    "polygonId": "assur-ga4v-f6ca1aebcd97",
+    "name": "gA4V",
+    "areaName": "gA4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f6ca1aebcd97"
+  },
+  {
+    "polygonId": "assur-ga5ii-3088de6caaf3",
+    "name": "gA5II",
+    "areaName": "gA5II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "3088de6caaf3"
+  },
+  {
+    "polygonId": "assur-ga5iii-21acb7b27aa6",
+    "name": "gA5III",
+    "areaName": "gA5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "21acb7b27aa6"
+  },
+  {
+    "polygonId": "assur-gb3v-cbe161c398e8",
+    "name": "gB3V",
+    "areaName": "gB3V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "cbe161c398e8"
+  },
+  {
+    "polygonId": "assur-gb4ii-4e46b9b143ad",
+    "name": "gB4II",
+    "areaName": "gB4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "4e46b9b143ad"
+  },
+  {
+    "polygonId": "assur-gb5i-61fb399ff411",
+    "name": "gB5I",
+    "areaName": "gB5I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "61fb399ff411"
+  },
+  {
+    "polygonId": "assur-gb5ii-6ad615e8405b",
+    "name": "gB5II",
+    "areaName": "gB5II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6ad615e8405b"
+  },
+  {
+    "polygonId": "assur-gb9i-f02183f4767e",
+    "name": "gB9I",
+    "areaName": "gB9I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f02183f4767e"
+  },
+  {
+    "polygonId": "assur-gc4i-d54b77ef4c6e",
+    "name": "gC4I",
+    "areaName": "gC4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d54b77ef4c6e"
+  },
+  {
+    "polygonId": "assur-gc4v-1985c493b282",
+    "name": "gC4V",
+    "areaName": "gC4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "1985c493b282"
+  },
+  {
+    "polygonId": "assur-gc5i-9d7eec32dfdd",
+    "name": "gC5I",
+    "areaName": "gC5I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "9d7eec32dfdd"
+  },
+  {
+    "polygonId": "assur-gc5v-2798b87e53dc",
+    "name": "gC5V",
+    "areaName": "gC5V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "2798b87e53dc"
+  },
+  {
+    "polygonId": "assur-gd10i-10d1c2f64360",
+    "name": "gD10I",
+    "areaName": "gD10I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "10d1c2f64360"
+  },
+  {
+    "polygonId": "assur-gd4ii-9be07638fbff",
+    "name": "gD4II",
+    "areaName": "gD4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "9be07638fbff"
+  },
+  {
+    "polygonId": "assur-gd5ii-fecfb9950eb0",
+    "name": "gD5II",
+    "areaName": "gD5II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "fecfb9950eb0"
+  },
+  {
+    "polygonId": "assur-ge9i-f06fc5d649e6",
+    "name": "gE9I",
+    "areaName": "gE9I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f06fc5d649e6"
+  },
+  {
+    "polygonId": "assur-h4-d61258ca24f6",
+    "name": "h4",
+    "areaName": "h4",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d61258ca24f6"
+  },
+  {
+    "polygonId": "assur-ha3v-5e86c360cff0",
+    "name": "hA3V",
+    "areaName": "hA3V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "5e86c360cff0"
+  },
+  {
+    "polygonId": "assur-hb4ii-984bc19a4843",
+    "name": "hB4II",
+    "areaName": "hB4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "984bc19a4843"
+  },
+  {
+    "polygonId": "assur-hb4v-dda5f259287d",
+    "name": "hB4V",
+    "areaName": "hB4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "dda5f259287d"
+  },
+  {
+    "polygonId": "assur-hb5iii-f3a81030678e",
+    "name": "hB5III",
+    "areaName": "hB5III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f3a81030678e"
+  },
+  {
+    "polygonId": "assur-hc10iv-e9ba6785720f",
+    "name": "hC10IV",
+    "areaName": "hC10IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "e9ba6785720f"
+  },
+  {
+    "polygonId": "assur-hc3v-e656693e7ee1",
+    "name": "hC3V",
+    "areaName": "hC3V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "e656693e7ee1"
+  },
+  {
+    "polygonId": "assur-hc4i-88e7d0f8b8c5",
+    "name": "hC4I",
+    "areaName": "hC4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "88e7d0f8b8c5"
+  },
+  {
+    "polygonId": "assur-hc4iv-f2f64d75d970",
+    "name": "hC4IV",
+    "areaName": "hC4IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f2f64d75d970"
+  },
+  {
+    "polygonId": "assur-hc4v-478fa3bdc4c8",
+    "name": "hC4V",
+    "areaName": "hC4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "478fa3bdc4c8"
+  },
+  {
+    "polygonId": "assur-hc8i-7c55133a9d29",
+    "name": "hC8I",
+    "areaName": "hC8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "7c55133a9d29"
+  },
+  {
+    "polygonId": "assur-hd3v-eb5d4942ef7a",
+    "name": "hD3V",
+    "areaName": "hD3V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "eb5d4942ef7a"
+  },
+  {
+    "polygonId": "assur-hd4i-0ed0e29b0f09",
+    "name": "hD4I",
+    "areaName": "hD4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "0ed0e29b0f09"
+  },
+  {
+    "polygonId": "assur-hd4ii-5f535f7de6ba",
+    "name": "hD4II",
+    "areaName": "hD4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "5f535f7de6ba"
+  },
+  {
+    "polygonId": "assur-hd4v-96ead1e90c88",
+    "name": "hD4V",
+    "areaName": "hD4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "96ead1e90c88"
+  },
+  {
+    "polygonId": "assur-hd8i-04d1913af44c",
+    "name": "hD8I",
+    "areaName": "hD8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "04d1913af44c"
+  },
+  {
+    "polygonId": "assur-he4i-030d5af2f188",
+    "name": "hE4I",
+    "areaName": "hE4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "030d5af2f188"
+  },
+  {
+    "polygonId": "assur-he4ii-f0314ef9a16b",
+    "name": "hE4II",
+    "areaName": "hE4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "f0314ef9a16b"
+  },
+  {
+    "polygonId": "assur-he4iii-484562f8f1ab",
+    "name": "hE4III",
+    "areaName": "hE4III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "484562f8f1ab"
+  },
+  {
+    "polygonId": "assur-he8i-e1127cc93dfe",
+    "name": "hE8I",
+    "areaName": "hE8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "e1127cc93dfe"
+  },
+  {
+    "polygonId": "assur-i3-4b3b8fad7570",
+    "name": "i3",
+    "areaName": "i3",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "4b3b8fad7570"
+  },
+  {
+    "polygonId": "assur-ia3iv-954858445363",
+    "name": "iA3IV",
+    "areaName": "iA3IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "954858445363"
+  },
+  {
+    "polygonId": "assur-ia4i-43241c493419",
+    "name": "iA4I",
+    "areaName": "iA4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "43241c493419"
+  },
+  {
+    "polygonId": "assur-ia4ii-4ea6406187c8",
+    "name": "iA4II",
+    "areaName": "iA4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "4ea6406187c8"
+  },
+  {
+    "polygonId": "assur-ia4iv-b128914b08d6",
+    "name": "iA4IV",
+    "areaName": "iA4IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "b128914b08d6"
+  },
+  {
+    "polygonId": "assur-ia4v-bcc63bb63b4d",
+    "name": "iA4V",
+    "areaName": "iA4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "bcc63bb63b4d"
+  },
+  {
+    "polygonId": "assur-ia8i-6aa9d256700b",
+    "name": "iA8I",
+    "areaName": "iA8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6aa9d256700b"
+  },
+  {
+    "polygonId": "assur-ib3ii-5f955c916bd6",
+    "name": "iB3II",
+    "areaName": "iB3II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "5f955c916bd6"
+  },
+  {
+    "polygonId": "assur-ib3iii-9c0254833076",
+    "name": "iB3III",
+    "areaName": "iB3III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "9c0254833076"
+  },
+  {
+    "polygonId": "assur-ib3iv-5d5a2ab832b9",
+    "name": "iB3IV",
+    "areaName": "iB3IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "5d5a2ab832b9"
+  },
+  {
+    "polygonId": "assur-ib4i-69c767eaaa9b",
+    "name": "iB4I",
+    "areaName": "iB4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "69c767eaaa9b"
+  },
+  {
+    "polygonId": "assur-ib4ii-6d81d4c48c28",
+    "name": "iB4II",
+    "areaName": "iB4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6d81d4c48c28"
+  },
+  {
+    "polygonId": "assur-ib4iii-0a4e3a9fea3c",
+    "name": "iB4III",
+    "areaName": "iB4III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "0a4e3a9fea3c"
+  },
+  {
+    "polygonId": "assur-ib4iv-a6b663a19751",
+    "name": "iB4IV",
+    "areaName": "iB4IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a6b663a19751"
+  },
+  {
+    "polygonId": "assur-ib4v-a8f3256907f1",
+    "name": "iB4V",
+    "areaName": "iB4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a8f3256907f1"
+  },
+  {
+    "polygonId": "assur-ib6iii-a1259d123f1e",
+    "name": "iB6III",
+    "areaName": "iB6III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a1259d123f1e"
+  },
+  {
+    "polygonId": "assur-ib7i-ee0365a27ee5",
+    "name": "iB7I",
+    "areaName": "iB7I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "ee0365a27ee5"
+  },
+  {
+    "polygonId": "assur-ic3ii-b81d7278c59c",
+    "name": "iC3II",
+    "areaName": "iC3II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "b81d7278c59c"
+  },
+  {
+    "polygonId": "assur-ic4i-df9fe989b4ff",
+    "name": "iC4I",
+    "areaName": "iC4I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "df9fe989b4ff"
+  },
+  {
+    "polygonId": "assur-ic4ii-12e470b76085",
+    "name": "iC4II",
+    "areaName": "iC4II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "12e470b76085"
+  },
+  {
+    "polygonId": "assur-ic4iii-6b755722331e",
+    "name": "iC4III",
+    "areaName": "iC4III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6b755722331e"
+  },
+  {
+    "polygonId": "assur-ic4iv-c0a218a92708",
+    "name": "iC4IV",
+    "areaName": "iC4IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "c0a218a92708"
+  },
+  {
+    "polygonId": "assur-ic4v-6332648aea16",
+    "name": "iC4V",
+    "areaName": "iC4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "6332648aea16"
+  },
+  {
+    "polygonId": "assur-ic5i-5cb3680f11f1",
+    "name": "iC5I",
+    "areaName": "iC5I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "5cb3680f11f1"
+  },
+  {
+    "polygonId": "assur-ic6iii-26ecdd95a8d8",
+    "name": "iC6III",
+    "areaName": "iC6III",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "26ecdd95a8d8"
+  },
+  {
+    "polygonId": "assur-id3iv-5388a6fdd9f3",
+    "name": "iD3IV",
+    "areaName": "iD3IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "5388a6fdd9f3"
+  },
+  {
+    "polygonId": "assur-id3v-b2da9fe54e6d",
+    "name": "iD3V",
+    "areaName": "iD3V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "b2da9fe54e6d"
+  },
+  {
+    "polygonId": "assur-id4iv-becfbc958fce",
+    "name": "iD4IV",
+    "areaName": "iD4IV",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "becfbc958fce"
+  },
+  {
+    "polygonId": "assur-id4v-b45c39108b04",
+    "name": "iD4V",
+    "areaName": "iD4V",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "b45c39108b04"
+  },
+  {
+    "polygonId": "assur-id5i-9cf249acf23a",
+    "name": "iD5I",
+    "areaName": "iD5I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "9cf249acf23a"
+  },
+  {
+    "polygonId": "assur-id8i-d16dd7b3c388",
+    "name": "iD8I",
+    "areaName": "iD8I",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d16dd7b3c388"
+  },
+  {
+    "polygonId": "assur-l8-d809790a6828",
+    "name": "l8",
+    "areaName": "l8",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "d809790a6828"
+  },
+  {
+    "polygonId": "assur-l9-081650a81622",
+    "name": "l9",
+    "areaName": "l9",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "081650a81622"
+  },
+  {
+    "polygonId": "assur-la9ii-a1ccc873746b",
+    "name": "lA9II",
+    "areaName": "lA9II",
+    "siteId": "ASSUR",
+    "siteName": "Aššur",
+    "geometryChecksum": "a1ccc873746b"
+  }
+]

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get_extended.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository_get_extended.py
@@ -20,6 +20,11 @@ from ebl.fragmentarium.infrastructure.queries import (
     aggregate_needs_revision,
     aggregate_path_of_the_pioneers,
     aggregate_random,
+    match_user_scopes,
+)
+from ebl.fragmentarium.infrastructure.query_filters import (
+    filter_by_genre,
+    filter_by_script,
 )
 from ebl.transliteration.infrastructure.queries import query_number_is
 from ebl.common.query.query_collation import CollatedFieldQuery
@@ -185,7 +190,7 @@ class MongoFragmentRepositoryGetExtended(MongoFragmentRepositoryBase):
             raise NotFoundError(f"Fragment {number} not found.") from error
 
     def fetch_scopes(self, number: MuseumNumber) -> List[Scope]:
-        fragment = next(
+        fragment: dict = next(
             self._fragments.find_many(
                 query_number_is(number), projection={"authorizedScopes": True}
             ),
@@ -194,6 +199,36 @@ class MongoFragmentRepositoryGetExtended(MongoFragmentRepositoryBase):
         return [
             Scope.from_string(value) for value in fragment.get("authorizedScopes", [])
         ]
+
+    def count_fragments_by_findspot_ids(
+        self,
+        findspot_ids: Sequence[int],
+        user_scopes: Sequence[Scope] = (),
+        script_period: Optional[str] = None,
+        script_period_modifier: Optional[str] = None,
+        genre: Optional[Sequence[str]] = None,
+    ) -> dict:
+        if not findspot_ids:
+            return {}
+        cursor = self._fragments.aggregate(
+            [
+                {
+                    "$match": {
+                        "archaeology.findspotId": {"$in": list(findspot_ids)},
+                        **match_user_scopes(user_scopes),
+                        **filter_by_script(script_period, script_period_modifier),
+                        **filter_by_genre(genre),
+                    }
+                },
+                {
+                    "$group": {
+                        "_id": "$archaeology.findspotId",
+                        "count": {"$sum": 1},
+                    }
+                },
+            ]
+        )
+        return {item["_id"]: item["count"] for item in cursor}
 
     def fetch_names(self, name_query: str) -> List[str]:
         if len(name_query) < 3:

--- a/ebl/fragmentarium/web/bootstrap.py
+++ b/ebl/fragmentarium/web/bootstrap.py
@@ -9,6 +9,7 @@ from ebl.fragmentarium.application.fragmentarium import Fragmentarium
 from ebl.fragmentarium.web.annotations import AnnotationResource
 from ebl.fragmentarium.web.edition import EditionResource
 from ebl.fragmentarium.web.findspots import FindspotResource
+from ebl.fragmentarium.web.findspot_map_data import FindspotMapDataResource
 from ebl.fragmentarium.web.folio_pager import FolioPagerResource
 from ebl.fragmentarium.web.folios import FoliosResource
 from ebl.fragmentarium.web.fragment_genre import FragmentGenreResource
@@ -47,6 +48,9 @@ from ebl.fragmentarium.web.statistics import make_statistics_resource
 from ebl.fragmentarium.web.archaeology import ArchaeologyResource
 from ebl.fragmentarium.web.fragments_afo_register import (
     AfoRegisterFragmentsQueryResource,
+)
+from ebl.fragmentarium.application.findspot_map_data_service import (
+    FindspotMapDataService,
 )
 from ebl.corpus.web.chapters import ChaptersByFragmentResource
 from ebl.corpus.application.corpus import Corpus, CorpusDependencies
@@ -142,6 +146,15 @@ def create_fragmentarium_routes(api: falcon.App, context: Context):
     folios = FoliosResource(finder)
     chapters = ChaptersByFragmentResource(corpus, finder)
     findspots = FindspotResource(context.findspot_repository)
+    findspot_map_data = FindspotMapDataResource(
+        FindspotMapDataService(
+            context.findspot_repository,
+            context.fragment_repository,
+            provenance_service,
+            context.map_artifact_repository,
+        ),
+        provenance_service,
+    )
 
     all_fragments = FragmentsListResource(context.fragment_repository)
     all_signs = make_all_fragment_signs_resource(
@@ -189,6 +202,7 @@ def create_fragmentarium_routes(api: falcon.App, context: Context):
         ("/fragments/all-ocred-signs", all_ocred_signs),
         ("/fragments/colophon-names", colophon_names),
         ("/findspots", findspots),
+        ("/findspots/map-data", findspot_map_data),
         ("/fragments/{number}/scopes", scopes),
         ("/fragments/{number}/named-entities", named_entities),
     ]

--- a/ebl/fragmentarium/web/findspot_map_data.py
+++ b/ebl/fragmentarium/web/findspot_map_data.py
@@ -1,0 +1,45 @@
+from falcon import Request, Response
+
+from ebl.common.query.parameter_parser import parse_genre
+from ebl.errors import DataError
+from ebl.fragmentarium.application.findspot_map_data_schema import (
+    FindspotMapDataSchema,
+)
+from ebl.fragmentarium.application.findspot_map_data_service import (
+    FindspotMapDataService,
+)
+from ebl.provenance.application.provenance_service import ProvenanceService
+
+
+class FindspotMapDataResource:
+    def __init__(
+        self,
+        service: FindspotMapDataService,
+        provenance_service: ProvenanceService,
+    ) -> None:
+        self._service = service
+        self._provenance_service = provenance_service
+
+    def _parse_site(self, site: str | None) -> str | None:
+        if site is None:
+            return None
+        if site != site.upper():
+            raise DataError("site must be the canonical provenance identifier.")
+        if self._provenance_service.find_by_id(site) is None:
+            raise DataError(f"Invalid site identifier: {site}")
+        return site
+
+    def on_get(self, req: Request, resp: Response) -> None:
+        site_id = self._parse_site(req.get_param("site"))
+        genre = parse_genre(dict(req.params)).get("genre")
+        data = self._service.find_map_data(
+            site_id=site_id,
+            user_scopes=req.context.user.get_scopes(
+                prefix="read:", suffix="-fragments"
+            ),
+            script_period=req.get_param("scriptPeriod"),
+            script_period_modifier=req.get_param("scriptPeriodModifier"),
+            genre=genre,
+        )
+        schema = FindspotMapDataSchema(many=True)
+        resp.media = {"findspots": schema.dump(data)}

--- a/ebl/tests/fragmentarium/test_findspot_map_data_route.py
+++ b/ebl/tests/fragmentarium/test_findspot_map_data_route.py
@@ -1,0 +1,245 @@
+import json
+
+import attr
+import falcon
+import pytest
+from falcon import testing
+from falcon_auth import NoneAuthBackend
+
+import ebl.app
+from ebl.common.domain.period import Period, PeriodModifier
+from ebl.common.domain.scopes import Scope
+from ebl.fragmentarium.application.map_artifact_repository import (
+    MapArtifactRepository,
+)
+from ebl.fragmentarium.domain.archaeology import Archaeology
+from ebl.fragmentarium.domain.fragment import Genre, Script
+from ebl.tests.factories.archaeology import FindspotFactory
+from ebl.tests.factories.fragment import FragmentFactory
+from ebl.transliteration.domain.museum_number import MuseumNumber
+from ebl.users.domain.user import Guest
+
+
+def _mapping_record(findspot_id, *polygon_ids):
+    return {
+        "findspotId": findspot_id,
+        "polygonIds": list(polygon_ids),
+        "locationPrecision": "excavation-area",
+        "matchMethod": "verified-source",
+        "source": "Test Tafeln.ods",
+        "sourceRevision": "2026-08-05",
+    }
+
+
+def _write_mappings(data_dir, site_id, records):
+    path = data_dir / f"{site_id.lower()}_findspot_polygon_mappings.json"
+    path.write_text(json.dumps(records), encoding="utf-8")
+
+
+def _seed_fragment(fragment_repository, site, findspot_id, number, scopes=()):
+    fragment = FragmentFactory.build(
+        number=MuseumNumber.of(number),
+        archaeology=Archaeology(site=site, findspot_id=findspot_id),
+        authorized_scopes=list(scopes),
+    )
+    fragment_repository.create(fragment)
+
+
+@pytest.fixture
+def map_data(
+    tmp_path,
+    context,
+    findspot_repository,
+    fragment_repository,
+    seeded_provenance_service,
+):
+    assur = seeded_provenance_service.find_by_id("ASSUR")
+    nippur = seeded_provenance_service.find_by_id("NIPPUR")
+
+    _write_mappings(
+        tmp_path,
+        "ASSUR",
+        [
+            _mapping_record(100, "assur-a"),
+            _mapping_record(101, "assur-a", "assur-b"),
+            _mapping_record(102, "assur-a"),
+        ],
+    )
+    _write_mappings(tmp_path, "NIPPUR", [_mapping_record(104, "nippur-a")])
+
+    for findspot in [
+        FindspotFactory.build(
+            id_=100, site=assur, sector="S1", area="A1", building="B1", room="R1"
+        ),
+        FindspotFactory.build(
+            id_=101, site=assur, sector="S2", area="A2", building="B2", room="R2"
+        ),
+        FindspotFactory.build(
+            id_=102, site=assur, sector="S3", area="A3", building="B3", room="R3"
+        ),
+        FindspotFactory.build(id_=103, site=assur),
+        FindspotFactory.build(id_=104, site=nippur),
+    ]:
+        findspot_repository.create(findspot)
+
+    _seed_fragment(fragment_repository, assur, 100, "X.100")
+    _seed_fragment(
+        fragment_repository, assur, 100, "X.101", scopes=[Scope.READ_CAIC_FRAGMENTS]
+    )
+    _seed_fragment(fragment_repository, assur, 102, "X.102")
+    _seed_fragment(fragment_repository, nippur, 104, "X.104")
+
+    test_context = attr.evolve(
+        context, map_artifact_repository=MapArtifactRepository(data_dir=tmp_path)
+    )
+    return testing.TestClient(ebl.app.create_app(test_context))
+
+
+@pytest.fixture
+def guest_map_data_client(tmp_path, context, map_data):
+    test_context = attr.evolve(
+        context,
+        auth_backend=NoneAuthBackend(Guest),
+        map_artifact_repository=MapArtifactRepository(data_dir=tmp_path),
+    )
+    return testing.TestClient(ebl.app.create_app(test_context))
+
+
+def test_map_data_omits_unmapped_and_exposes_polygons(map_data):
+    response = map_data.simulate_get("/findspots/map-data")
+    payload = response.json["findspots"]
+
+    assert response.status == falcon.HTTP_OK
+    assert [item["findspotId"] for item in payload] == [100, 101, 102, 104]
+    assert 103 not in [item["findspotId"] for item in payload]
+    assert next(item for item in payload if item["findspotId"] == 101)[
+        "polygonIds"
+    ] == [
+        "assur-a",
+        "assur-b",
+    ]
+    assert (
+        next(item for item in payload if item["findspotId"] == 100)["siteId"] == "ASSUR"
+    )
+    assert "fragmentCount" not in payload[0]
+
+
+def test_map_data_counts_follow_visibility_rules(map_data, guest_map_data_client):
+    auth_payload = {
+        item["findspotId"]: item
+        for item in map_data.simulate_get("/findspots/map-data").json["findspots"]
+    }
+    guest_payload = {
+        item["findspotId"]: item
+        for item in guest_map_data_client.simulate_get("/findspots/map-data").json[
+            "findspots"
+        ]
+    }
+
+    assert auth_payload[100]["accessibleFragmentCount"] == 2
+    assert guest_payload[100]["accessibleFragmentCount"] == 1
+    assert auth_payload[101]["accessibleFragmentCount"] == 0
+    assert auth_payload[102]["accessibleFragmentCount"] == 1
+    assert auth_payload[104]["accessibleFragmentCount"] == 1
+
+
+def test_map_data_site_filter_and_invalid_site(map_data):
+    filtered = map_data.simulate_get("/findspots/map-data?site=ASSUR")
+    invalid = map_data.simulate_get("/findspots/map-data?site=assur")
+
+    assert [item["findspotId"] for item in filtered.json["findspots"]] == [
+        100,
+        101,
+        102,
+    ]
+    assert invalid.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+
+
+def test_map_data_unmapped_site_returns_empty(map_data):
+    response = map_data.simulate_get("/findspots/map-data?site=NINEVEH")
+
+    assert response.status == falcon.HTTP_OK
+    assert response.json["findspots"] == []
+
+
+@pytest.fixture
+def map_data_with_script_and_genre(
+    tmp_path,
+    context,
+    findspot_repository,
+    fragment_repository,
+    seeded_provenance_service,
+):
+    assur = seeded_provenance_service.find_by_id("ASSUR")
+    _write_mappings(tmp_path, "ASSUR", [_mapping_record(200, "assur-c")])
+    findspot_repository.create(FindspotFactory.build(id_=200, site=assur))
+
+    fragment_repository.create(
+        FragmentFactory.build(
+            number=MuseumNumber.of("X.200"),
+            archaeology=Archaeology(site=assur, findspot_id=200),
+            script=Script(Period.OLD_BABYLONIAN, PeriodModifier.NONE),
+            genres=(Genre(["ARCHIVAL", "Administrative"], False),),
+        )
+    )
+    fragment_repository.create(
+        FragmentFactory.build(
+            number=MuseumNumber.of("X.201"),
+            archaeology=Archaeology(site=assur, findspot_id=200),
+            script=Script(Period.NEO_ASSYRIAN, PeriodModifier.NONE),
+            genres=(Genre(["CANONICAL", "Catalogues"], False),),
+        )
+    )
+
+    test_context = attr.evolve(
+        context, map_artifact_repository=MapArtifactRepository(data_dir=tmp_path)
+    )
+    return testing.TestClient(ebl.app.create_app(test_context))
+
+
+def _count_for(client, query):
+    response = client.simulate_get(f"/findspots/map-data{query}")
+    return response.json["findspots"][0]["accessibleFragmentCount"]
+
+
+def test_map_data_script_filter(map_data_with_script_and_genre):
+    client = map_data_with_script_and_genre
+
+    assert _count_for(client, "") == 2
+    assert _count_for(client, "?scriptPeriod=Old Babylonian") == 1
+    assert _count_for(client, "?scriptPeriod=Neo-Assyrian") == 1
+
+
+def test_map_data_genre_filter(map_data_with_script_and_genre):
+    client = map_data_with_script_and_genre
+
+    assert _count_for(client, "?genre=ARCHIVAL:Administrative") == 1
+    assert _count_for(client, "?genre=CANONICAL:Catalogues") == 1
+
+
+def test_map_data_combined_script_and_genre_filter(map_data_with_script_and_genre):
+    client = map_data_with_script_and_genre
+
+    assert (
+        _count_for(client, "?scriptPeriod=Old Babylonian&genre=ARCHIVAL:Administrative")
+        == 1
+    )
+    assert (
+        _count_for(client, "?scriptPeriod=Neo-Assyrian&genre=ARCHIVAL:Administrative")
+        == 0
+    )
+
+
+def test_map_data_uses_one_count_query(map_data, fragment_repository, monkeypatch):
+    calls = {"count": 0}
+    original = fragment_repository.count_fragments_by_findspot_ids
+
+    def wrapped(*args, **kwargs):
+        calls["count"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(fragment_repository, "count_fragments_by_findspot_ids", wrapped)
+
+    map_data.simulate_get("/findspots/map-data")
+
+    assert calls["count"] == 1


### PR DESCRIPTION
## Stack & Frontend Consumers

> **Map backend stack — slice 04 of 6.** Branch: `map/backend-04-assur-map-data`.
> `master` → #760 → #761 → #762 → **#759 (this PR)** → #758 → #757.

### Same-repository dependency

- Direct parent: **#762 — `map/backend-03-artifact-foundation`** (the map-artifact pipeline + `MapArtifactRepository`).
- Base branch: **`map/backend-03-artifact-foundation`** (retargeted from `master`; branch ancestry is clean — this PR now shows only its incremental commit `01c8568c`). GitHub auto-retargets this PR to `master` as the parents merge.
- Merge only after #762 (and #761, #760).

### What this PR introduces (slice 04, incremental commit `01c8568c`)

- `GET /findspots/map-data?site=<CANONICAL_PROVENANCE_ID>` — `ebl/fragmentarium/web/findspot_map_data.py`, `application/findspot_map_data_service.py`, `application/findspot_map_data_schema.py`, wired in `ebl/fragmentarium/web/bootstrap.py`.
- `MapArtifactRepository` wired into `ebl/context.py`.
- Response rows: `findspotId, siteId, siteName, polygonIds, accessibleFragmentCount, locationPrecision, matchMethod, sector, area, building, room`.
- Authorization-aware `accessibleFragmentCount` (batched, visibility-constrained) via `mongo_fragment_repository_get_extended.py`.
- Optional `site` / `scriptPeriod` / `scriptPeriodModifier` / `genre` filters; `site` validated against the provenance service.
- Committed **Aššur** curated polygon mappings + inventory + curation report (`ebl/fragmentarium/data/map/assur_*`).

Delivered by earlier slices, not this PR: `MapLocation` domain contract (#760); `findspotId` / `findspotIds` query filter (#761); the artifact pipeline + `MapArtifactRepository` class + `Maps/` GIS sources (#762).

### Frontend consumers

- **`ElectronicBabylonianLiterature/ebl-frontend#808` — Aššur linkage. Hard runtime consumer.**
  - `ApiFindspotRepository.fetchMapData()` calls `GET /findspots/map-data?site=ASSUR` on map-tab mount (ASSUR is the one site with a non-`null` `mapDataSiteParam`). The frontend `FindspotMapDataDto` + `findspotMapDataSanitizer.ts` mirror this schema field-for-field, including `accessibleFragmentCount`.
  - The `findspotId` fragment-search links in the same PR require **#761** (see that PR).
  - Fails *safe* if the endpoint is absent: the fetch is caught, `useFragmentMapData` moves to `status: 'error'`, and the map/basemap stay usable — but the Aššur evidence-linkage feature shows an error state instead of data.
- **`ebl-frontend#812` (evidence inspector), `#811` (visualizations), `#815` (analytical 3D), `#814` (research exports), `#809` (spatial search)** — consume the `accessibleFragmentCount` / polygon summaries **transitively via #808's loaded state**. They add no new API call and degrade to their capability-disabled / empty states without this endpoint.
- **Build-time only:** `ebl-frontend#795` pins its GeoJSON generator contract against fixtures that correspond to the #762 artifact format — not a merge or deploy dependency.
- **Not consumed:** `ebl-frontend#796`'s multi-site polygons are static client-side GeoJSON; `#807`, `#810`, `#813` make no eBL API call.

### Merge / deployment order — coordinated release with `ebl-frontend#808`

This PR (with #760/#761/#762 ahead of it) and **`ebl-frontend#808`** form the live **Aššur fragment-linkage** feature.

1. Merge the backend stack through this PR (#760 → #761 → #762 → #759).
2. Deploy and verify `GET /findspots/map-data?site=ASSUR` returns rows with `accessibleFragmentCount`, and `GET /fragments/query?findspotId=<id>` filters.
3. Merge `ebl-frontend#808` (after its frontend parent `map/frontend-v2-04-map-first-layout` / `ebl-frontend#807`).

**Backend-first.** `ebl-frontend#808` is capability-gated and fails safe, so it **may be reviewed now**, before this PR merges — but the Aššur feature must not be considered active until this backend contract has deployed successfully.

### Downstream backend

- **#758** (`map/backend-05-multisite-artifacts`) — stacked directly on this branch; adds Kalḫu/Nippur/Uruk polygon data to this same endpoint. **No current frontend consumer.**
- **#757** (`map/backend-06-artifact-transfer`) — transitively stacked; developer transfer-archive script.

---

## Summary by Sourcery

Provide reproducible archaeological map data and APIs that connect findspots to polygons while preserving filtering and access-control behavior.

New Features:
- Add deterministic map artifact generation and curated findspot-to-polygon mappings for Assur, Uruk, Kalhu, and Nippur.
- Expose findspot map data through a new API endpoint with site, script, genre, and authorization-aware fragment counts.
- Support single and comma-separated multiple findspot ID filters in fragment searches.

Bug Fixes:
- Ensure map geometries are normalized to EPSG:4326 and reject invalid or implausible source data during artifact generation.

Enhancements:
- Add map-location domain models and serialization support while sourcing live map data from version-controlled artifacts.
- Refactor shared script and genre query filtering for reuse across fragment queries and map fragment counts.

Build:
- Add pyproj and install PROJ system dependencies for coordinate reprojection.

Tests:
- Add coverage for map source loading, geometry identity, artifact reproducibility, curation validation, map-location serialization, API behavior, visibility filtering, and findspot query filters.

Chores:
- Add generated map inventories, mappings, curation templates, and reports for Assur.
