### PR TITLE
feat(map): add optional findspot map-location contract

### DIFF
--- a/ebl/fragmentarium/application/archaeology_schemas.py
+++ b/ebl/fragmentarium/application/archaeology_schemas.py
@@ -34,7 +34,7 @@ class ExcavationPlanSchema(Schema):
         return ExcavationPlan(**data)
 
 
-class ProvenanceSiteMixin:
+class ProvenanceSiteMixin(Schema):
     def serialize_site(self, obj):
         return getattr(obj.site, "long_name", None)
 

--- a/ebl/fragmentarium/application/archaeology_schemas.py
+++ b/ebl/fragmentarium/application/archaeology_schemas.py
@@ -7,6 +7,7 @@ from ebl.fragmentarium.domain.archaeology import (
     Archaeology,
     ExcavationNumber,
 )
+from ebl.fragmentarium.application.map_location_schema import MapLocationSchema
 from ebl.fragmentarium.domain.findspot import (
     BuildingType,
     ExcavationPlan,
@@ -14,7 +15,7 @@ from ebl.fragmentarium.domain.findspot import (
 )
 from ebl.common.application.schemas import deserialize_provenance_record
 from ebl.schemas import NameEnumField
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_dump, post_load
 
 
 class ExcavationNumberSchema(AbstractMuseumNumberSchema):
@@ -55,6 +56,9 @@ class FindspotSchema(ProvenanceSiteMixin, Schema):
     plans = fields.Nested(ExcavationPlanSchema, many=True, load_default=())
     room = fields.String()
     context = fields.String()
+    map_location = fields.Nested(
+        MapLocationSchema, allow_none=True, load_default=None, data_key="mapLocation"
+    )
     primary_context = fields.Boolean(
         data_key="primaryContext",
         allow_none=True,
@@ -65,6 +69,12 @@ class FindspotSchema(ProvenanceSiteMixin, Schema):
     def create_findspot(self, data, **kwargs) -> Findspot:
         data["plans"] = tuple(data["plans"])
         return Findspot(**data)
+
+    @post_dump
+    def omit_missing_map_location(self, data, **kwargs):
+        if data.get("mapLocation") is None:
+            data.pop("mapLocation", None)
+        return data
 
 
 class ArchaeologySchema(ProvenanceSiteMixin, Schema):

--- a/ebl/fragmentarium/application/map_location_schema.py
+++ b/ebl/fragmentarium/application/map_location_schema.py
@@ -1,0 +1,66 @@
+from marshmallow import (
+    EXCLUDE,
+    Schema,
+    ValidationError,
+    fields,
+    post_load,
+    validates_schema,
+    validate,
+)
+
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+from ebl.schemas import ValueEnumField
+
+
+def _strip_or_none(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+class MapLocationSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    polygon_ids = fields.List(
+        fields.String(validate=validate.Length(min=1)),
+        required=True,
+        data_key="polygonIds",
+        validate=validate.Length(min=1),
+    )
+    location_precision = ValueEnumField(
+        MapLocationPrecision, required=True, data_key="locationPrecision"
+    )
+    match_method = ValueEnumField(
+        MapLocationMatchMethod, required=True, data_key="matchMethod"
+    )
+    source = fields.String(required=True, validate=validate.Length(min=1))
+    source_revision = fields.String(
+        required=True, data_key="sourceRevision", validate=validate.Length(min=1)
+    )
+
+    @validates_schema
+    def validate_map_location(self, data, **kwargs) -> None:
+        polygon_ids = data.get("polygon_ids", ())
+        if len(set(polygon_ids)) != len(polygon_ids):
+            raise ValidationError("polygonIds must be unique.", "polygonIds")
+        if any(not polygon_id.strip() for polygon_id in polygon_ids):
+            raise ValidationError(
+                "polygonIds must not contain empty values.", "polygonIds"
+            )
+        if _strip_or_none(data.get("source")) is None:
+            raise ValidationError("source must not be empty.", "source")
+        if _strip_or_none(data.get("source_revision")) is None:
+            raise ValidationError("sourceRevision must not be empty.", "sourceRevision")
+
+    @post_load
+    def create_map_location(self, data, **kwargs) -> MapLocation:
+        data["polygon_ids"] = tuple(data["polygon_ids"])
+        data["source"] = data["source"].strip()
+        data["source_revision"] = data["source_revision"].strip()
+        return MapLocation(**data)

--- a/ebl/fragmentarium/application/map_location_schema.py
+++ b/ebl/fragmentarium/application/map_location_schema.py
@@ -1,5 +1,4 @@
 from marshmallow import (
-    EXCLUDE,
     Schema,
     ValidationError,
     fields,
@@ -16,17 +15,7 @@ from ebl.fragmentarium.domain.map_location import (
 from ebl.schemas import ValueEnumField
 
 
-def _strip_or_none(value: str | None) -> str | None:
-    if value is None:
-        return None
-    stripped = value.strip()
-    return stripped or None
-
-
 class MapLocationSchema(Schema):
-    class Meta:
-        unknown = EXCLUDE
-
     polygon_ids = fields.List(
         fields.String(validate=validate.Length(min=1)),
         required=True,
@@ -46,16 +35,16 @@ class MapLocationSchema(Schema):
 
     @validates_schema
     def validate_map_location(self, data, **kwargs) -> None:
-        polygon_ids = data.get("polygon_ids", ())
+        polygon_ids = data["polygon_ids"]
         if len(set(polygon_ids)) != len(polygon_ids):
             raise ValidationError("polygonIds must be unique.", "polygonIds")
         if any(not polygon_id.strip() for polygon_id in polygon_ids):
             raise ValidationError(
                 "polygonIds must not contain empty values.", "polygonIds"
             )
-        if _strip_or_none(data.get("source")) is None:
+        if not data["source"].strip():
             raise ValidationError("source must not be empty.", "source")
-        if _strip_or_none(data.get("source_revision")) is None:
+        if not data["source_revision"].strip():
             raise ValidationError("sourceRevision must not be empty.", "sourceRevision")
 
     @post_load

--- a/ebl/fragmentarium/application/map_location_schema.py
+++ b/ebl/fragmentarium/application/map_location_schema.py
@@ -49,7 +49,4 @@ class MapLocationSchema(Schema):
 
     @post_load
     def create_map_location(self, data, **kwargs) -> MapLocation:
-        data["polygon_ids"] = tuple(data["polygon_ids"])
-        data["source"] = data["source"].strip()
-        data["source_revision"] = data["source_revision"].strip()
         return MapLocation(**data)

--- a/ebl/fragmentarium/domain/findspot.py
+++ b/ebl/fragmentarium/domain/findspot.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 from enum import Enum, auto
 from ebl.bibliography.domain.reference import Reference
 from ebl.fragmentarium.domain.date_range import DateRange
+from ebl.fragmentarium.domain.map_location import MapLocation
 from ebl.provenance.domain.provenance_model import ProvenanceRecord
 
 
@@ -37,5 +38,6 @@ class Findspot:
     plans: Sequence[ExcavationPlan] = ()
     room: str = ""
     context: str = ""
+    map_location: Optional[MapLocation] = None
     primary_context: Optional[bool] = None
     notes: str = ""

--- a/ebl/fragmentarium/domain/map_location.py
+++ b/ebl/fragmentarium/domain/map_location.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+import attr
+
+
+class MapLocationPrecision(Enum):
+    EXCAVATION_AREA = "excavation-area"
+
+
+class MapLocationMatchMethod(Enum):
+    CURATED = "curated"
+    VERIFIED_SOURCE = "verified-source"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class MapLocation:
+    polygon_ids: tuple[str, ...]
+    location_precision: MapLocationPrecision
+    match_method: MapLocationMatchMethod
+    source: str
+    source_revision: str
+
+    def __attrs_post_init__(self):
+        if not self.polygon_ids:
+            raise ValueError("polygonIds must not be empty.")
+        if len(set(self.polygon_ids)) != len(self.polygon_ids):
+            raise ValueError("polygonIds must be unique.")
+        if any(not polygon_id.strip() for polygon_id in self.polygon_ids):
+            raise ValueError("polygonIds must not contain empty values.")
+        if not self.source.strip():
+            raise ValueError("source must not be empty.")
+        if not self.source_revision.strip():
+            raise ValueError("sourceRevision must not be empty.")

--- a/ebl/fragmentarium/domain/map_location.py
+++ b/ebl/fragmentarium/domain/map_location.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Iterable
 
 import attr
 
@@ -12,13 +13,21 @@ class MapLocationMatchMethod(Enum):
     VERIFIED_SOURCE = "verified-source"
 
 
+def _to_tuple(polygon_ids: Iterable[str]) -> tuple[str, ...]:
+    return tuple(polygon_ids)
+
+
+def _stripped(value: str) -> str:
+    return value.strip()
+
+
 @attr.s(auto_attribs=True, frozen=True)
 class MapLocation:
-    polygon_ids: tuple[str, ...]
+    polygon_ids: tuple[str, ...] = attr.ib(converter=_to_tuple)
     location_precision: MapLocationPrecision
     match_method: MapLocationMatchMethod
-    source: str
-    source_revision: str
+    source: str = attr.ib(converter=_stripped)
+    source_revision: str = attr.ib(converter=_stripped)
 
     def __attrs_post_init__(self):
         if not self.polygon_ids:
@@ -27,7 +36,7 @@ class MapLocation:
             raise ValueError("polygonIds must be unique.")
         if any(not polygon_id.strip() for polygon_id in self.polygon_ids):
             raise ValueError("polygonIds must not contain empty values.")
-        if not self.source.strip():
+        if not self.source:
             raise ValueError("source must not be empty.")
-        if not self.source_revision.strip():
+        if not self.source_revision:
             raise ValueError("sourceRevision must not be empty.")

--- a/ebl/tests/fragmentarium/test_findspot_repository_map_location.py
+++ b/ebl/tests/fragmentarium/test_findspot_repository_map_location.py
@@ -1,0 +1,35 @@
+import attr
+
+from ebl.fragmentarium.application.archaeology_schemas import FindspotSchema
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+from ebl.tests.factories.archaeology import FindspotFactory
+
+
+def test_create_and_fetch_with_map_location(
+    database, findspot_repository, seeded_provenance_service
+):
+    site = seeded_provenance_service.find_by_id("ASSUR")
+    findspot = attr.evolve(
+        FindspotFactory.build(
+            id_=4242,
+            site=site,
+            map_location=MapLocation(
+                ("assur-1",),
+                MapLocationPrecision.EXCAVATION_AREA,
+                MapLocationMatchMethod.CURATED,
+                "Assur Tafeln.ods",
+                "2026-07-27",
+            ),
+        )
+    )
+
+    findspot_repository.create(findspot)
+
+    assert database["findspots"].find_one({"_id": 4242}) == FindspotSchema(
+        context={"provenance_service": seeded_provenance_service}
+    ).dump(findspot)
+    assert findspot_repository.find_all()[0] == findspot

--- a/ebl/tests/fragmentarium/test_fragment_archaeology_route.py
+++ b/ebl/tests/fragmentarium/test_fragment_archaeology_route.py
@@ -14,8 +14,13 @@ from ebl.fragmentarium.domain.archaeology import (
 from ebl.tests.factories.provenance import DEFAULT_PROVENANCES
 from ebl.fragmentarium.domain.fragment import Fragment
 
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
 from ebl.fragmentarium.web.dtos import create_response_dto
-from ebl.tests.factories.archaeology import DateRangeFactory
+from ebl.tests.factories.archaeology import DateRangeFactory, FindspotFactory
 from ebl.tests.factories.fragment import FragmentFactory
 
 
@@ -96,6 +101,40 @@ def test_update_archaeology(
 
     get_result = client.simulate_get(f"/fragments/{fragment_number}")
     assert get_result.json == {**expected_json, "realiaInfo": []}
+
+
+def test_fragment_get_surfaces_findspot_map_location(
+    client, fragmentarium, findspot_repository, seeded_provenance_service
+) -> None:
+    findspot = FindspotFactory.build(
+        id_=4242,
+        site=seeded_provenance_service.find_by_id("ASSUR"),
+        map_location=MapLocation(
+            ("assur-1", "assur-2"),
+            MapLocationPrecision.EXCAVATION_AREA,
+            MapLocationMatchMethod.CURATED,
+            "Assur Tafeln.ods",
+            "2026-07-27",
+        ),
+    )
+    findspot_repository.create(findspot)
+    fragment: Fragment = FragmentFactory.build(
+        archaeology=attr.evolve(
+            ARCHAEOLOGY, site=None, findspot=None, findspot_id=findspot.id_
+        )
+    )
+    fragment_number = fragmentarium.create(fragment)
+
+    get_result = client.simulate_get(f"/fragments/{fragment_number}")
+
+    assert get_result.status == falcon.HTTP_OK
+    assert get_result.json["archaeology"]["findspot"]["mapLocation"] == {
+        "polygonIds": ["assur-1", "assur-2"],
+        "locationPrecision": "excavation-area",
+        "matchMethod": "curated",
+        "source": "Assur Tafeln.ods",
+        "sourceRevision": "2026-07-27",
+    }
 
 
 def test_invalid_excavation_number_update(client, fragmentarium, user):

--- a/ebl/tests/fragmentarium/test_map_location.py
+++ b/ebl/tests/fragmentarium/test_map_location.py
@@ -34,6 +34,22 @@ def test_map_location_is_hashable():
     assert hash(_map_location()) == hash(_map_location())
 
 
+def test_map_location_accepts_polygon_id_sequence():
+    assert _map_location(polygon_ids=["assur-1", "assur-2"]).polygon_ids == (
+        "assur-1",
+        "assur-2",
+    )
+
+
+def test_map_location_normalizes_source_whitespace():
+    map_location = _map_location(
+        source="  Assur Tafeln.ods  ", source_revision=" 2026-07-27 "
+    )
+
+    assert map_location.source == "Assur Tafeln.ods"
+    assert map_location.source_revision == "2026-07-27"
+
+
 @pytest.mark.parametrize(
     "changes,message",
     [

--- a/ebl/tests/fragmentarium/test_map_location.py
+++ b/ebl/tests/fragmentarium/test_map_location.py
@@ -1,0 +1,52 @@
+import pytest
+
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+
+
+def _map_location(**changes) -> MapLocation:
+    return MapLocation(
+        **{
+            "polygon_ids": ("assur-1",),
+            "location_precision": MapLocationPrecision.EXCAVATION_AREA,
+            "match_method": MapLocationMatchMethod.CURATED,
+            "source": "Assur Tafeln.ods",
+            "source_revision": "2026-07-27",
+            **changes,
+        }
+    )
+
+
+def test_map_location_is_created():
+    map_location = _map_location(polygon_ids=("assur-1", "assur-2"))
+
+    assert map_location.polygon_ids == ("assur-1", "assur-2")
+    assert map_location.location_precision == MapLocationPrecision.EXCAVATION_AREA
+    assert map_location.match_method == MapLocationMatchMethod.CURATED
+    assert map_location.source == "Assur Tafeln.ods"
+    assert map_location.source_revision == "2026-07-27"
+
+
+def test_map_location_is_hashable():
+    assert hash(_map_location()) == hash(_map_location())
+
+
+@pytest.mark.parametrize(
+    "changes,message",
+    [
+        ({"polygon_ids": ()}, "polygonIds must not be empty."),
+        ({"polygon_ids": ("assur-1", "assur-1")}, "polygonIds must be unique."),
+        (
+            {"polygon_ids": ("assur-1", "  ")},
+            "polygonIds must not contain empty values.",
+        ),
+        ({"source": "   "}, "source must not be empty."),
+        ({"source_revision": "  "}, "sourceRevision must not be empty."),
+    ],
+)
+def test_map_location_rejects_invalid_values(changes, message):
+    with pytest.raises(ValueError, match=message):
+        _map_location(**changes)

--- a/ebl/tests/fragmentarium/test_map_location_schemas.py
+++ b/ebl/tests/fragmentarium/test_map_location_schemas.py
@@ -1,0 +1,92 @@
+import attr
+import pytest
+from marshmallow import ValidationError
+
+from ebl.fragmentarium.application.archaeology_schemas import FindspotSchema
+from ebl.fragmentarium.application.map_location_schema import MapLocationSchema
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+from ebl.tests.factories.archaeology import FindspotFactory
+
+
+def _map_location(*polygon_ids, source="Assur Tafeln.ods", revision="2026-07-27"):
+    return MapLocation(
+        polygon_ids=tuple(polygon_ids),
+        location_precision=MapLocationPrecision.EXCAVATION_AREA,
+        match_method=MapLocationMatchMethod.VERIFIED_SOURCE,
+        source=source,
+        source_revision=revision,
+    )
+
+
+@pytest.mark.parametrize("polygon_ids", [("assur-1",), ("assur-1", "assur-2")])
+def test_map_location_schema_round_trip(polygon_ids):
+    schema = MapLocationSchema()
+    payload = {
+        "polygonIds": list(polygon_ids),
+        "locationPrecision": "excavation-area",
+        "matchMethod": "verified-source",
+        "source": "Assur Tafeln.ods",
+        "sourceRevision": "2026-07-27",
+    }
+    assert schema.dump(schema.load(payload)) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "polygonIds": [],
+            "locationPrecision": "excavation-area",
+            "matchMethod": "verified-source",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+        {
+            "polygonIds": ["assur-1", "assur-1"],
+            "locationPrecision": "excavation-area",
+            "matchMethod": "verified-source",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+        {
+            "polygonIds": ["assur-1"],
+            "locationPrecision": "not-a-precision",
+            "matchMethod": "verified-source",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+        {
+            "polygonIds": ["assur-1"],
+            "locationPrecision": "excavation-area",
+            "matchMethod": "not-a-method",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+    ],
+)
+def test_map_location_schema_rejects_invalid_payload(payload):
+    with pytest.raises(ValidationError):
+        MapLocationSchema().load(payload)
+
+
+def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
+    site = seeded_provenance_service.find_by_id("ASSUR")
+    findspot = attr.evolve(FindspotFactory.build(site=site, map_location=None))
+    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+
+    assert "mapLocation" not in schema.dump(findspot)
+    assert schema.load(schema.dump(findspot)).map_location is None
+
+
+def test_findspot_schema_round_trip_with_map_location(seeded_provenance_service):
+    site = seeded_provenance_service.find_by_id("ASSUR")
+    findspot = attr.evolve(
+        FindspotFactory.build(site=site, map_location=_map_location("assur-1"))
+    )
+    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+
+    assert schema.load(schema.dump(findspot)) == findspot

--- a/ebl/tests/fragmentarium/test_map_location_schemas.py
+++ b/ebl/tests/fragmentarium/test_map_location_schemas.py
@@ -1,4 +1,5 @@
-import attr
+from typing import cast
+
 import pytest
 from marshmallow import ValidationError
 
@@ -22,50 +23,35 @@ def _map_location(*polygon_ids, source="Assur Tafeln.ods", revision="2026-07-27"
     )
 
 
-@pytest.mark.parametrize("polygon_ids", [("assur-1",), ("assur-1", "assur-2")])
-def test_map_location_schema_round_trip(polygon_ids):
-    schema = MapLocationSchema()
-    payload = {
-        "polygonIds": list(polygon_ids),
+def _payload(**changes) -> dict:
+    return {
+        "polygonIds": ["assur-1"],
         "locationPrecision": "excavation-area",
         "matchMethod": "verified-source",
         "source": "Assur Tafeln.ods",
         "sourceRevision": "2026-07-27",
+        **changes,
     }
+
+
+@pytest.mark.parametrize("polygon_ids", [["assur-1"], ["assur-1", "assur-2"]])
+def test_map_location_schema_round_trip(polygon_ids):
+    schema = MapLocationSchema()
+    payload = _payload(polygonIds=polygon_ids)
+
     assert schema.dump(schema.load(payload)) == payload
 
 
 @pytest.mark.parametrize(
     "payload",
     [
-        {
-            "polygonIds": [],
-            "locationPrecision": "excavation-area",
-            "matchMethod": "verified-source",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
-        {
-            "polygonIds": ["assur-1", "assur-1"],
-            "locationPrecision": "excavation-area",
-            "matchMethod": "verified-source",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
-        {
-            "polygonIds": ["assur-1"],
-            "locationPrecision": "not-a-precision",
-            "matchMethod": "verified-source",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
-        {
-            "polygonIds": ["assur-1"],
-            "locationPrecision": "excavation-area",
-            "matchMethod": "not-a-method",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
+        _payload(polygonIds=[]),
+        _payload(polygonIds=["assur-1", "assur-1"]),
+        _payload(polygonIds=["assur-1", "  "]),
+        _payload(locationPrecision="not-a-precision"),
+        _payload(matchMethod="not-a-method"),
+        _payload(source="   "),
+        _payload(sourceRevision="  "),
     ],
 )
 def test_map_location_schema_rejects_invalid_payload(payload):
@@ -73,20 +59,27 @@ def test_map_location_schema_rejects_invalid_payload(payload):
         MapLocationSchema().load(payload)
 
 
-def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
-    site = seeded_provenance_service.find_by_id("ASSUR")
-    findspot = attr.evolve(FindspotFactory.build(site=site, map_location=None))
-    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+def test_map_location_schema_rejects_unknown_field():
+    with pytest.raises(ValidationError):
+        MapLocationSchema().load(_payload(unknown="value"))
 
-    assert "mapLocation" not in schema.dump(findspot)
-    assert schema.load(schema.dump(findspot)).map_location is None
+
+def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
+    findspot = FindspotFactory.build(
+        site=seeded_provenance_service.find_by_id("ASSUR"), map_location=None
+    )
+    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+    dumped = cast(dict, schema.dump(findspot))
+
+    assert "mapLocation" not in dumped
+    assert schema.load(dumped) == findspot
 
 
 def test_findspot_schema_round_trip_with_map_location(seeded_provenance_service):
-    site = seeded_provenance_service.find_by_id("ASSUR")
-    findspot = attr.evolve(
-        FindspotFactory.build(site=site, map_location=_map_location("assur-1"))
+    findspot = FindspotFactory.build(
+        site=seeded_provenance_service.find_by_id("ASSUR"),
+        map_location=_map_location("assur-1"),
     )
     schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
 
-    assert schema.load(schema.dump(findspot)) == findspot
+    assert schema.load(cast(dict, schema.dump(findspot))) == findspot

--- a/ebl/tests/fragmentarium/test_map_location_schemas.py
+++ b/ebl/tests/fragmentarium/test_map_location_schemas.py
@@ -64,6 +64,18 @@ def test_map_location_schema_rejects_unknown_field():
         MapLocationSchema().load(_payload(unknown="value"))
 
 
+def test_map_location_schema_normalizes_source_whitespace():
+    loaded = cast(
+        MapLocation,
+        MapLocationSchema().load(
+            _payload(source="  Assur Tafeln.ods  ", sourceRevision=" 2026-07-27 ")
+        ),
+    )
+
+    assert loaded.source == "Assur Tafeln.ods"
+    assert loaded.source_revision == "2026-07-27"
+
+
 def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
     findspot = FindspotFactory.build(
         site=seeded_provenance_service.find_by_id("ASSUR"), map_location=None


### PR DESCRIPTION
## Stack & Frontend Consumers

> **Map backend stack — slice 01 of 6 (stack root).** This PR targets `master` and is the root of the six-part map backend stack:
> `master` → **#760 (this PR)** → #761 → #762 → #759 → #758 → #757.

### Same-repository dependency

- Direct parent: **none** — stack root.
- Base branch: `master`.
- Head branch: `map/backend-01-map-location-contract`.

### What this PR introduces (slice 01)

- `MapLocation` domain model on `Findspot` — optional, with polygon identifiers, `precision`, `matchMethod`, `source`, and `sourceRevision`.
- Domain + schema validation/normalization (non-empty unique polygon ids; required source metadata; canonical `source`).
- Exposure of `mapLocation` through archaeology and fragment responses when present.
- Tests for domain validation, schema round-trips, persistence, and fragment-API exposure.

This is a **backend-internal foundation**. It does not add an HTTP endpoint or a query parameter. Its contract is delivered to the frontend later, through the `/findspots/map-data` response shape in **#759** (fields `locationPrecision`, `matchMethod`, `polygonIds`, `sector`/`area`/`building`/`room`).

### Frontend consumers

- **No direct runtime consumer.** No frontend PR imports or calls anything added here directly.
- **Indirect:** the `MapLocation` field vocabulary surfaces to `ebl-frontend#808` via the `#759` endpoint response. `ebl-frontend`'s `FindspotMapDataDto` (`src/map/findspotMapData.ts`) mirrors that vocabulary, but the frontend never depends on this PR on its own.

### Merge / deployment order

- `CAN_MERGE_NOW` once approved. `READY_FOR_REVIEW`.
- No cross-repository coordination. Merges first in the backend stack; nothing in the frontend is gated on it in isolation.
- **Backend stack note:** branches `map/backend-02..06` were cut from this branch's original commit `9142c70b` and do **not** yet contain this branch's two later commits (`test(map): close coverage/type gaps…`, `fix(map): normalize MapLocation source…`). Rebase `map/backend-02-findspot-query` (and the branches stacked on it) onto the current tip of this branch before retargeting **#761**'s base to `map/backend-01-map-location-contract`.

### Downstream backend

- **#761** `map/backend-02-findspot-query` — adds `findspotId` / `findspotIds` fragment-query filters (branch currently forks from this branch's first commit; see note above).
- Transitively: #762 → #759 → #758 → #757.

---

## Summary by Sourcery

Add optional map-location support to findspots and expose validated location metadata through the fragmentarium API.

New Features:
- Add an optional map-location contract to findspots, including polygon identifiers, precision, matching method, source, and source revision.
- Expose findspot map locations through archaeology and fragment responses when present.

Enhancements:
- Validate and normalize map-location values during domain and schema serialization, including non-empty unique polygon identifiers and required source metadata.

Tests:
- Add coverage for map-location domain validation, schema round trips, persistence, and fragment API exposure.
