### PR TITLE
Map/backend 02 findspot query

### DIFF
--- a/ebl/common/query/parameter_parser.py
+++ b/ebl/common/query/parameter_parser.py
@@ -6,6 +6,7 @@ from ebl.transliteration.application.transliteration_query_factory import (
 )
 
 COUNT_MODES = ("exact", "none", "page")
+MAX_FINDSPOT_IDS = 200
 
 
 def parse_integer_field(field: str) -> Callable[[Dict], Dict]:
@@ -106,6 +107,30 @@ def parse_genre(parameters: Dict) -> Dict:
     genre = parameters.get("genre", "").split(":")
 
     return {**parameters, "genre": genre} if any(genre) else parameters
+
+
+def parse_findspot_ids(parameters: Dict) -> Dict:
+    if "findspotIds" not in parameters:
+        return parameters
+
+    raw = parameters["findspotIds"]
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    if not values:
+        raise DataError("findspotIds must not be empty.")
+    if len(values) > MAX_FINDSPOT_IDS:
+        raise DataError(
+            f"findspotIds must not contain more than {MAX_FINDSPOT_IDS} values."
+        )
+    try:
+        ids = [int(value) for value in values]
+    except ValueError as error:
+        raise DataError(
+            f"findspotIds must be a comma-separated list of integers, got {raw!r}"
+        ) from error
+    if any(value < 0 for value in ids):
+        raise DataError("findspotIds must be non-negative.")
+
+    return {**parameters, "findspotIds": sorted(set(ids))}
 
 
 def parse_count(parameters: Dict) -> Dict:

--- a/ebl/fragmentarium/application/archaeology_schemas.py
+++ b/ebl/fragmentarium/application/archaeology_schemas.py
@@ -34,7 +34,7 @@ class ExcavationPlanSchema(Schema):
         return ExcavationPlan(**data)
 
 
-class ProvenanceSiteMixin:
+class ProvenanceSiteMixin(Schema):
     def serialize_site(self, obj):
         return getattr(obj.site, "long_name", None)
 

--- a/ebl/fragmentarium/application/archaeology_schemas.py
+++ b/ebl/fragmentarium/application/archaeology_schemas.py
@@ -7,6 +7,7 @@ from ebl.fragmentarium.domain.archaeology import (
     Archaeology,
     ExcavationNumber,
 )
+from ebl.fragmentarium.application.map_location_schema import MapLocationSchema
 from ebl.fragmentarium.domain.findspot import (
     BuildingType,
     ExcavationPlan,
@@ -14,7 +15,7 @@ from ebl.fragmentarium.domain.findspot import (
 )
 from ebl.common.application.schemas import deserialize_provenance_record
 from ebl.schemas import NameEnumField
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_dump, post_load
 
 
 class ExcavationNumberSchema(AbstractMuseumNumberSchema):
@@ -55,6 +56,9 @@ class FindspotSchema(ProvenanceSiteMixin, Schema):
     plans = fields.Nested(ExcavationPlanSchema, many=True, load_default=())
     room = fields.String()
     context = fields.String()
+    map_location = fields.Nested(
+        MapLocationSchema, allow_none=True, load_default=None, data_key="mapLocation"
+    )
     primary_context = fields.Boolean(
         data_key="primaryContext",
         allow_none=True,
@@ -65,6 +69,12 @@ class FindspotSchema(ProvenanceSiteMixin, Schema):
     def create_findspot(self, data, **kwargs) -> Findspot:
         data["plans"] = tuple(data["plans"])
         return Findspot(**data)
+
+    @post_dump
+    def omit_missing_map_location(self, data, **kwargs):
+        if data.get("mapLocation") is None:
+            data.pop("mapLocation", None)
+        return data
 
 
 class ArchaeologySchema(ProvenanceSiteMixin, Schema):

--- a/ebl/fragmentarium/application/map_location_schema.py
+++ b/ebl/fragmentarium/application/map_location_schema.py
@@ -1,0 +1,66 @@
+from marshmallow import (
+    EXCLUDE,
+    Schema,
+    ValidationError,
+    fields,
+    post_load,
+    validates_schema,
+    validate,
+)
+
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+from ebl.schemas import ValueEnumField
+
+
+def _strip_or_none(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+class MapLocationSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    polygon_ids = fields.List(
+        fields.String(validate=validate.Length(min=1)),
+        required=True,
+        data_key="polygonIds",
+        validate=validate.Length(min=1),
+    )
+    location_precision = ValueEnumField(
+        MapLocationPrecision, required=True, data_key="locationPrecision"
+    )
+    match_method = ValueEnumField(
+        MapLocationMatchMethod, required=True, data_key="matchMethod"
+    )
+    source = fields.String(required=True, validate=validate.Length(min=1))
+    source_revision = fields.String(
+        required=True, data_key="sourceRevision", validate=validate.Length(min=1)
+    )
+
+    @validates_schema
+    def validate_map_location(self, data, **kwargs) -> None:
+        polygon_ids = data.get("polygon_ids", ())
+        if len(set(polygon_ids)) != len(polygon_ids):
+            raise ValidationError("polygonIds must be unique.", "polygonIds")
+        if any(not polygon_id.strip() for polygon_id in polygon_ids):
+            raise ValidationError(
+                "polygonIds must not contain empty values.", "polygonIds"
+            )
+        if _strip_or_none(data.get("source")) is None:
+            raise ValidationError("source must not be empty.", "source")
+        if _strip_or_none(data.get("source_revision")) is None:
+            raise ValidationError("sourceRevision must not be empty.", "sourceRevision")
+
+    @post_load
+    def create_map_location(self, data, **kwargs) -> MapLocation:
+        data["polygon_ids"] = tuple(data["polygon_ids"])
+        data["source"] = data["source"].strip()
+        data["source_revision"] = data["source_revision"].strip()
+        return MapLocation(**data)

--- a/ebl/fragmentarium/application/map_location_schema.py
+++ b/ebl/fragmentarium/application/map_location_schema.py
@@ -1,5 +1,4 @@
 from marshmallow import (
-    EXCLUDE,
     Schema,
     ValidationError,
     fields,
@@ -16,17 +15,7 @@ from ebl.fragmentarium.domain.map_location import (
 from ebl.schemas import ValueEnumField
 
 
-def _strip_or_none(value: str | None) -> str | None:
-    if value is None:
-        return None
-    stripped = value.strip()
-    return stripped or None
-
-
 class MapLocationSchema(Schema):
-    class Meta:
-        unknown = EXCLUDE
-
     polygon_ids = fields.List(
         fields.String(validate=validate.Length(min=1)),
         required=True,
@@ -46,16 +35,16 @@ class MapLocationSchema(Schema):
 
     @validates_schema
     def validate_map_location(self, data, **kwargs) -> None:
-        polygon_ids = data.get("polygon_ids", ())
+        polygon_ids = data["polygon_ids"]
         if len(set(polygon_ids)) != len(polygon_ids):
             raise ValidationError("polygonIds must be unique.", "polygonIds")
         if any(not polygon_id.strip() for polygon_id in polygon_ids):
             raise ValidationError(
                 "polygonIds must not contain empty values.", "polygonIds"
             )
-        if _strip_or_none(data.get("source")) is None:
+        if not data["source"].strip():
             raise ValidationError("source must not be empty.", "source")
-        if _strip_or_none(data.get("source_revision")) is None:
+        if not data["source_revision"].strip():
             raise ValidationError("sourceRevision must not be empty.", "sourceRevision")
 
     @post_load

--- a/ebl/fragmentarium/application/map_location_schema.py
+++ b/ebl/fragmentarium/application/map_location_schema.py
@@ -49,7 +49,4 @@ class MapLocationSchema(Schema):
 
     @post_load
     def create_map_location(self, data, **kwargs) -> MapLocation:
-        data["polygon_ids"] = tuple(data["polygon_ids"])
-        data["source"] = data["source"].strip()
-        data["source_revision"] = data["source_revision"].strip()
         return MapLocation(**data)

--- a/ebl/fragmentarium/domain/findspot.py
+++ b/ebl/fragmentarium/domain/findspot.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 from enum import Enum, auto
 from ebl.bibliography.domain.reference import Reference
 from ebl.fragmentarium.domain.date_range import DateRange
+from ebl.fragmentarium.domain.map_location import MapLocation
 from ebl.provenance.domain.provenance_model import ProvenanceRecord
 
 
@@ -37,5 +38,6 @@ class Findspot:
     plans: Sequence[ExcavationPlan] = ()
     room: str = ""
     context: str = ""
+    map_location: Optional[MapLocation] = None
     primary_context: Optional[bool] = None
     notes: str = ""

--- a/ebl/fragmentarium/domain/map_location.py
+++ b/ebl/fragmentarium/domain/map_location.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+import attr
+
+
+class MapLocationPrecision(Enum):
+    EXCAVATION_AREA = "excavation-area"
+
+
+class MapLocationMatchMethod(Enum):
+    CURATED = "curated"
+    VERIFIED_SOURCE = "verified-source"
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class MapLocation:
+    polygon_ids: tuple[str, ...]
+    location_precision: MapLocationPrecision
+    match_method: MapLocationMatchMethod
+    source: str
+    source_revision: str
+
+    def __attrs_post_init__(self):
+        if not self.polygon_ids:
+            raise ValueError("polygonIds must not be empty.")
+        if len(set(self.polygon_ids)) != len(self.polygon_ids):
+            raise ValueError("polygonIds must be unique.")
+        if any(not polygon_id.strip() for polygon_id in self.polygon_ids):
+            raise ValueError("polygonIds must not contain empty values.")
+        if not self.source.strip():
+            raise ValueError("source must not be empty.")
+        if not self.source_revision.strip():
+            raise ValueError("sourceRevision must not be empty.")

--- a/ebl/fragmentarium/domain/map_location.py
+++ b/ebl/fragmentarium/domain/map_location.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Iterable
 
 import attr
 
@@ -12,13 +13,21 @@ class MapLocationMatchMethod(Enum):
     VERIFIED_SOURCE = "verified-source"
 
 
+def _to_tuple(polygon_ids: Iterable[str]) -> tuple[str, ...]:
+    return tuple(polygon_ids)
+
+
+def _stripped(value: str) -> str:
+    return value.strip()
+
+
 @attr.s(auto_attribs=True, frozen=True)
 class MapLocation:
-    polygon_ids: tuple[str, ...]
+    polygon_ids: tuple[str, ...] = attr.ib(converter=_to_tuple)
     location_precision: MapLocationPrecision
     match_method: MapLocationMatchMethod
-    source: str
-    source_revision: str
+    source: str = attr.ib(converter=_stripped)
+    source_revision: str = attr.ib(converter=_stripped)
 
     def __attrs_post_init__(self):
         if not self.polygon_ids:
@@ -27,7 +36,7 @@ class MapLocation:
             raise ValueError("polygonIds must be unique.")
         if any(not polygon_id.strip() for polygon_id in self.polygon_ids):
             raise ValueError("polygonIds must not contain empty values.")
-        if not self.source.strip():
+        if not self.source:
             raise ValueError("source must not be empty.")
-        if not self.source_revision.strip():
+        if not self.source_revision:
             raise ValueError("sourceRevision must not be empty.")

--- a/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
+++ b/ebl/fragmentarium/infrastructure/fragment_pattern_matcher.py
@@ -1,8 +1,12 @@
-from typing import List, Dict, Sequence, Optional
+from typing import Callable, Dict, List, Optional, Sequence
 from ebl.common.domain.scopes import Scope
 from ebl.fragmentarium.infrastructure.queries import (
     match_user_scopes,
     number_is,
+)
+from ebl.fragmentarium.infrastructure.query_filters import (
+    filter_by_genre,
+    filter_by_script,
 )
 from ebl.fragmentarium.infrastructure.fragment_lemma_matcher import (
     LemmaMatcher,
@@ -52,21 +56,12 @@ class PatternMatcher:
         return [{"$sort": sort_fields}] if sort_fields else []
 
     def _filter_by_script(self) -> Dict:
-        parameters = {
-            "scriptPeriod": "script.period",
-            "scriptPeriodModifier": "script.periodModifier",
-        }
-
-        return {
-            path: self._query.get(parameter)
-            for parameter, path in parameters.items()
-            if self._query.get(parameter)
-        }
+        return filter_by_script(
+            self._query.get("scriptPeriod"), self._query.get("scriptPeriodModifier")
+        )
 
     def _filter_by_genre(self) -> Dict:
-        if genre := self._query.get("genre"):
-            return {"genres.category": {"$all": genre}}
-        return {}
+        return filter_by_genre(self._query.get("genre"))
 
     def _filter_by_museum(self) -> Dict:
         return {"museum": museum} if (museum := self._query.get("museum")) else {}
@@ -117,6 +112,16 @@ class PatternMatcher:
             else {}
         )
 
+    def _filter_by_findspot_id(self) -> Dict:
+        ids = set(self._query.get("findspotIds", ()))
+        if (findspot_id := self._query.get("findspotId")) is not None:
+            ids.add(findspot_id)
+        if not ids:
+            return {}
+        if len(ids) == 1:
+            return {"archaeology.findspotId": next(iter(ids))}
+        return {"archaeology.findspotId": {"$in": sorted(ids)}}
+
     def _prefilter(self) -> List[Dict]:
         constraints = {
             "$and": compact(
@@ -129,6 +134,7 @@ class PatternMatcher:
                     self._filter_by_script(),
                     self._filter_by_reference(),
                     self._filter_by_dossier(),
+                    self._filter_by_findspot_id(),
                     match_user_scopes(self._scopes),
                 ]
             ),
@@ -198,7 +204,7 @@ class PatternMatcher:
         ]
 
     def _get_pipeline_components(self) -> List[Dict]:
-        dispatcher = {
+        dispatcher: dict[tuple[bool, bool], Callable[[], List[Dict]]] = {
             (True, True): self._merge_pipelines,
             (True, False): self._lemma_matcher.build_pipeline,
             (False, True): self._sign_matcher.build_pipeline,

--- a/ebl/fragmentarium/infrastructure/mongo_fragment_repository.py
+++ b/ebl/fragmentarium/infrastructure/mongo_fragment_repository.py
@@ -47,6 +47,7 @@ class MongoFragmentRepository(
                 ("archaeology.excavationNumber.suffix", pymongo.ASCENDING),
             ]
         )
+        self._fragments.create_index([("archaeology.findspotId", pymongo.ASCENDING)])
         self._fragments.create_index([("record.type", pymongo.ASCENDING)])
         self._fragments.create_index(
             [

--- a/ebl/fragmentarium/infrastructure/query_filters.py
+++ b/ebl/fragmentarium/infrastructure/query_filters.py
@@ -1,0 +1,15 @@
+from typing import Optional, Sequence
+
+
+def filter_by_script(
+    script_period: Optional[str] = None, script_period_modifier: Optional[str] = None
+) -> dict:
+    parameters = {
+        "script.period": script_period,
+        "script.periodModifier": script_period_modifier,
+    }
+    return {path: value for path, value in parameters.items() if value}
+
+
+def filter_by_genre(genre: Optional[Sequence[str]] = None) -> dict:
+    return {"genres.category": {"$all": genre}} if genre else {}

--- a/ebl/fragmentarium/web/fragments.py
+++ b/ebl/fragmentarium/web/fragments.py
@@ -11,6 +11,7 @@ from ebl.common.query.parameter_parser import (
     parse_pages,
     parse_genre,
     parse_non_negative_integer_field,
+    parse_findspot_ids,
     parse_count,
 )
 from ebl.common.query.query_schemas import QueryResultSchema
@@ -140,6 +141,8 @@ class FragmentsQueryResource:
             parse_pages,
             parse_genre,
             parse_count,
+            parse_non_negative_integer_field("findspotId"),
+            parse_findspot_ids,
             parse_integer_field("limit"),
             parse_non_negative_integer_field("offset"),
         )

--- a/ebl/tests/fragmentarium/test_findspot_repository_map_location.py
+++ b/ebl/tests/fragmentarium/test_findspot_repository_map_location.py
@@ -1,0 +1,35 @@
+import attr
+
+from ebl.fragmentarium.application.archaeology_schemas import FindspotSchema
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+from ebl.tests.factories.archaeology import FindspotFactory
+
+
+def test_create_and_fetch_with_map_location(
+    database, findspot_repository, seeded_provenance_service
+):
+    site = seeded_provenance_service.find_by_id("ASSUR")
+    findspot = attr.evolve(
+        FindspotFactory.build(
+            id_=4242,
+            site=site,
+            map_location=MapLocation(
+                ("assur-1",),
+                MapLocationPrecision.EXCAVATION_AREA,
+                MapLocationMatchMethod.CURATED,
+                "Assur Tafeln.ods",
+                "2026-07-27",
+            ),
+        )
+    )
+
+    findspot_repository.create(findspot)
+
+    assert database["findspots"].find_one({"_id": 4242}) == FindspotSchema(
+        context={"provenance_service": seeded_provenance_service}
+    ).dump(findspot)
+    assert findspot_repository.find_all()[0] == findspot

--- a/ebl/tests/fragmentarium/test_fragment_archaeology_route.py
+++ b/ebl/tests/fragmentarium/test_fragment_archaeology_route.py
@@ -14,8 +14,13 @@ from ebl.fragmentarium.domain.archaeology import (
 from ebl.tests.factories.provenance import DEFAULT_PROVENANCES
 from ebl.fragmentarium.domain.fragment import Fragment
 
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
 from ebl.fragmentarium.web.dtos import create_response_dto
-from ebl.tests.factories.archaeology import DateRangeFactory
+from ebl.tests.factories.archaeology import DateRangeFactory, FindspotFactory
 from ebl.tests.factories.fragment import FragmentFactory
 
 
@@ -96,6 +101,40 @@ def test_update_archaeology(
 
     get_result = client.simulate_get(f"/fragments/{fragment_number}")
     assert get_result.json == {**expected_json, "realiaInfo": []}
+
+
+def test_fragment_get_surfaces_findspot_map_location(
+    client, fragmentarium, findspot_repository, seeded_provenance_service
+) -> None:
+    findspot = FindspotFactory.build(
+        id_=4242,
+        site=seeded_provenance_service.find_by_id("ASSUR"),
+        map_location=MapLocation(
+            ("assur-1", "assur-2"),
+            MapLocationPrecision.EXCAVATION_AREA,
+            MapLocationMatchMethod.CURATED,
+            "Assur Tafeln.ods",
+            "2026-07-27",
+        ),
+    )
+    findspot_repository.create(findspot)
+    fragment: Fragment = FragmentFactory.build(
+        archaeology=attr.evolve(
+            ARCHAEOLOGY, site=None, findspot=None, findspot_id=findspot.id_
+        )
+    )
+    fragment_number = fragmentarium.create(fragment)
+
+    get_result = client.simulate_get(f"/fragments/{fragment_number}")
+
+    assert get_result.status == falcon.HTTP_OK
+    assert get_result.json["archaeology"]["findspot"]["mapLocation"] == {
+        "polygonIds": ["assur-1", "assur-2"],
+        "locationPrecision": "excavation-area",
+        "matchMethod": "curated",
+        "source": "Assur Tafeln.ods",
+        "sourceRevision": "2026-07-27",
+    }
 
 
 def test_invalid_excavation_number_update(client, fragmentarium, user):

--- a/ebl/tests/fragmentarium/test_fragment_repository_query_findspot_id.py
+++ b/ebl/tests/fragmentarium/test_fragment_repository_query_findspot_id.py
@@ -1,0 +1,21 @@
+from ebl.common.query.query_result import QueryItem, QueryResult
+from ebl.fragmentarium.domain.archaeology import Archaeology
+from ebl.tests.factories.fragment import FragmentFactory
+from ebl.transliteration.domain.museum_number import MuseumNumber
+
+
+def test_query_fragmentarium_findspot_id(fragment_repository):
+    matching = FragmentFactory.build(
+        number=MuseumNumber.of("X.1"),
+        archaeology=Archaeology(findspot_id=123),
+    )
+    other = FragmentFactory.build(
+        number=MuseumNumber.of("X.2"),
+        archaeology=Archaeology(findspot_id=456),
+    )
+    fragment_repository.create_many([matching, other])
+
+    assert fragment_repository.query({"findspotId": 123}) == QueryResult(
+        [QueryItem(matching.number, (), 0)],
+        0,
+    )

--- a/ebl/tests/fragmentarium/test_fragments_query_multi_findspot_id.py
+++ b/ebl/tests/fragmentarium/test_fragments_query_multi_findspot_id.py
@@ -1,0 +1,128 @@
+import falcon
+import pytest
+
+from ebl.common.domain.scopes import Scope
+from ebl.common.query.parameter_parser import MAX_FINDSPOT_IDS, parse_findspot_ids
+from ebl.common.query.query_result import QueryItem, QueryResult
+from ebl.errors import DataError
+from ebl.fragmentarium.domain.archaeology import Archaeology
+from ebl.tests.factories.fragment import FragmentFactory
+from ebl.tests.fragmentarium.fragment_query_test_helpers import (
+    query_item_of,
+    query_result_of,
+)
+from ebl.transliteration.domain.museum_number import MuseumNumber
+
+
+def test_parse_findspot_ids_deduplicates_and_sorts():
+    assert parse_findspot_ids({"findspotIds": "3,1,1,2"})["findspotIds"] == [1, 2, 3]
+
+
+def test_parse_findspot_ids_rejects_malformed():
+    with pytest.raises(DataError):
+        parse_findspot_ids({"findspotIds": "1,x"})
+
+
+def test_parse_findspot_ids_rejects_negative():
+    with pytest.raises(DataError):
+        parse_findspot_ids({"findspotIds": "1,-2"})
+
+
+def test_parse_findspot_ids_rejects_empty():
+    with pytest.raises(DataError):
+        parse_findspot_ids({"findspotIds": " , "})
+
+
+def test_parse_findspot_ids_rejects_over_limit():
+    ids = ",".join(str(value) for value in range(MAX_FINDSPOT_IDS + 1))
+    with pytest.raises(DataError):
+        parse_findspot_ids({"findspotIds": ids})
+
+
+def test_query_fragmentarium_multiple_findspot_ids(fragment_repository):
+    first = FragmentFactory.build(
+        number=MuseumNumber.of("X.1"), archaeology=Archaeology(findspot_id=123)
+    )
+    second = FragmentFactory.build(
+        number=MuseumNumber.of("X.2"), archaeology=Archaeology(findspot_id=456)
+    )
+    other = FragmentFactory.build(
+        number=MuseumNumber.of("X.3"), archaeology=Archaeology(findspot_id=789)
+    )
+    fragment_repository.create_many([first, second, other])
+
+    result = fragment_repository.query({"findspotIds": [123, 456]})
+
+    key = lambda item: str(item.museum_number)  # noqa: E731
+    expected_items = sorted(
+        [QueryItem(first.number, (), 0), QueryItem(second.number, (), 0)], key=key
+    )
+    assert QueryResult(sorted(result.items, key=key), result.match_count_total) == (
+        QueryResult(expected_items, 0)
+    )
+
+
+def test_search_multiple_findspot_ids(client, fragmentarium):
+    matching = FragmentFactory.build(
+        number=MuseumNumber.of("X.1"), archaeology=Archaeology(findspot_id=123)
+    )
+    also_matching = FragmentFactory.build(
+        number=MuseumNumber.of("X.2"), archaeology=Archaeology(findspot_id=456)
+    )
+    non_matching = FragmentFactory.build(
+        number=MuseumNumber.of("X.3"), archaeology=Archaeology(findspot_id=789)
+    )
+    fragmentarium.create(matching)
+    fragmentarium.create(also_matching)
+    fragmentarium.create(non_matching)
+
+    result = client.simulate_get("/fragments/query", params={"findspotIds": "123,456"})
+
+    assert result.status == falcon.HTTP_OK
+    key = lambda item: str(item["museumNumber"])  # noqa: E731
+    items = sorted([query_item_of(matching), query_item_of(also_matching)], key=key)
+    assert sorted(result.json["items"], key=key) == items
+
+
+def test_search_findspot_ids_deduplicates_with_single_param(client, fragmentarium):
+    matching = FragmentFactory.build(
+        number=MuseumNumber.of("X.1"), archaeology=Archaeology(findspot_id=123)
+    )
+    fragmentarium.create(matching)
+
+    result = client.simulate_get(
+        "/fragments/query", params={"findspotId": "123", "findspotIds": "123"}
+    )
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of([query_item_of(matching)], 0)
+
+
+def test_search_findspot_ids_preserves_visibility(client, guest_client, fragmentarium):
+    fragment = FragmentFactory.build(
+        archaeology=Archaeology(findspot_id=123),
+        authorized_scopes=[Scope.READ_ITALIANNINEVEH_FRAGMENTS],
+    )
+    fragmentarium.create(fragment)
+
+    assert client.simulate_get(
+        "/fragments/query", params={"findspotIds": "123,456"}
+    ).json == query_result_of([query_item_of(fragment)], 0)
+    assert guest_client.simulate_get(
+        "/fragments/query", params={"findspotIds": "123,456"}
+    ).json == query_result_of([], 0)
+
+
+@pytest.mark.parametrize("value", ["1,x", "1,-2", " , ", ""])
+def test_search_findspot_ids_rejects_malformed_values(client, value):
+    result = client.simulate_get("/fragments/query", params={"findspotIds": value})
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY
+
+
+def test_search_findspot_ids_rejects_over_limit(client):
+    ids = ",".join(str(value) for value in range(MAX_FINDSPOT_IDS + 1))
+
+    result = client.simulate_get("/fragments/query", params={"findspotIds": ids})
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY

--- a/ebl/tests/fragmentarium/test_fragments_search_route_findspot_id.py
+++ b/ebl/tests/fragmentarium/test_fragments_search_route_findspot_id.py
@@ -1,0 +1,52 @@
+import falcon
+import pytest
+
+from ebl.common.domain.scopes import Scope
+from ebl.fragmentarium.domain.archaeology import Archaeology
+from ebl.tests.factories.fragment import FragmentFactory
+from ebl.tests.fragmentarium.fragment_query_test_helpers import (
+    query_item_of,
+    query_result_of,
+)
+from ebl.transliteration.domain.museum_number import MuseumNumber
+
+
+def test_search_findspot_id(client, fragmentarium):
+    matching = FragmentFactory.build(
+        number=MuseumNumber.of("X.1"),
+        archaeology=Archaeology(findspot_id=123),
+    )
+    fragmentarium.create(matching)
+    fragmentarium.create(
+        FragmentFactory.build(
+            number=MuseumNumber.of("X.2"),
+            archaeology=Archaeology(findspot_id=456),
+        )
+    )
+
+    result = client.simulate_get("/fragments/query", params={"findspotId": "123"})
+
+    assert result.status == falcon.HTTP_OK
+    assert result.json == query_result_of([query_item_of(matching)], 0)
+
+
+def test_search_findspot_id_preserves_visibility(client, guest_client, fragmentarium):
+    fragment = FragmentFactory.build(
+        archaeology=Archaeology(findspot_id=123),
+        authorized_scopes=[Scope.READ_ITALIANNINEVEH_FRAGMENTS],
+    )
+    fragmentarium.create(fragment)
+
+    assert client.simulate_get(
+        "/fragments/query", params={"findspotId": "123"}
+    ).json == query_result_of([query_item_of(fragment)], 0)
+    assert guest_client.simulate_get(
+        "/fragments/query", params={"findspotId": "123"}
+    ).json == query_result_of([], 0)
+
+
+@pytest.mark.parametrize("value", ["invalid", "-1"])
+def test_search_findspot_id_rejects_invalid_values(client, value):
+    result = client.simulate_get("/fragments/query", params={"findspotId": value})
+
+    assert result.status == falcon.HTTP_UNPROCESSABLE_ENTITY

--- a/ebl/tests/fragmentarium/test_map_location.py
+++ b/ebl/tests/fragmentarium/test_map_location.py
@@ -34,6 +34,22 @@ def test_map_location_is_hashable():
     assert hash(_map_location()) == hash(_map_location())
 
 
+def test_map_location_accepts_polygon_id_sequence():
+    assert _map_location(polygon_ids=["assur-1", "assur-2"]).polygon_ids == (
+        "assur-1",
+        "assur-2",
+    )
+
+
+def test_map_location_normalizes_source_whitespace():
+    map_location = _map_location(
+        source="  Assur Tafeln.ods  ", source_revision=" 2026-07-27 "
+    )
+
+    assert map_location.source == "Assur Tafeln.ods"
+    assert map_location.source_revision == "2026-07-27"
+
+
 @pytest.mark.parametrize(
     "changes,message",
     [

--- a/ebl/tests/fragmentarium/test_map_location.py
+++ b/ebl/tests/fragmentarium/test_map_location.py
@@ -1,0 +1,52 @@
+import pytest
+
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+
+
+def _map_location(**changes) -> MapLocation:
+    return MapLocation(
+        **{
+            "polygon_ids": ("assur-1",),
+            "location_precision": MapLocationPrecision.EXCAVATION_AREA,
+            "match_method": MapLocationMatchMethod.CURATED,
+            "source": "Assur Tafeln.ods",
+            "source_revision": "2026-07-27",
+            **changes,
+        }
+    )
+
+
+def test_map_location_is_created():
+    map_location = _map_location(polygon_ids=("assur-1", "assur-2"))
+
+    assert map_location.polygon_ids == ("assur-1", "assur-2")
+    assert map_location.location_precision == MapLocationPrecision.EXCAVATION_AREA
+    assert map_location.match_method == MapLocationMatchMethod.CURATED
+    assert map_location.source == "Assur Tafeln.ods"
+    assert map_location.source_revision == "2026-07-27"
+
+
+def test_map_location_is_hashable():
+    assert hash(_map_location()) == hash(_map_location())
+
+
+@pytest.mark.parametrize(
+    "changes,message",
+    [
+        ({"polygon_ids": ()}, "polygonIds must not be empty."),
+        ({"polygon_ids": ("assur-1", "assur-1")}, "polygonIds must be unique."),
+        (
+            {"polygon_ids": ("assur-1", "  ")},
+            "polygonIds must not contain empty values.",
+        ),
+        ({"source": "   "}, "source must not be empty."),
+        ({"source_revision": "  "}, "sourceRevision must not be empty."),
+    ],
+)
+def test_map_location_rejects_invalid_values(changes, message):
+    with pytest.raises(ValueError, match=message):
+        _map_location(**changes)

--- a/ebl/tests/fragmentarium/test_map_location_schemas.py
+++ b/ebl/tests/fragmentarium/test_map_location_schemas.py
@@ -1,0 +1,92 @@
+import attr
+import pytest
+from marshmallow import ValidationError
+
+from ebl.fragmentarium.application.archaeology_schemas import FindspotSchema
+from ebl.fragmentarium.application.map_location_schema import MapLocationSchema
+from ebl.fragmentarium.domain.map_location import (
+    MapLocation,
+    MapLocationMatchMethod,
+    MapLocationPrecision,
+)
+from ebl.tests.factories.archaeology import FindspotFactory
+
+
+def _map_location(*polygon_ids, source="Assur Tafeln.ods", revision="2026-07-27"):
+    return MapLocation(
+        polygon_ids=tuple(polygon_ids),
+        location_precision=MapLocationPrecision.EXCAVATION_AREA,
+        match_method=MapLocationMatchMethod.VERIFIED_SOURCE,
+        source=source,
+        source_revision=revision,
+    )
+
+
+@pytest.mark.parametrize("polygon_ids", [("assur-1",), ("assur-1", "assur-2")])
+def test_map_location_schema_round_trip(polygon_ids):
+    schema = MapLocationSchema()
+    payload = {
+        "polygonIds": list(polygon_ids),
+        "locationPrecision": "excavation-area",
+        "matchMethod": "verified-source",
+        "source": "Assur Tafeln.ods",
+        "sourceRevision": "2026-07-27",
+    }
+    assert schema.dump(schema.load(payload)) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "polygonIds": [],
+            "locationPrecision": "excavation-area",
+            "matchMethod": "verified-source",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+        {
+            "polygonIds": ["assur-1", "assur-1"],
+            "locationPrecision": "excavation-area",
+            "matchMethod": "verified-source",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+        {
+            "polygonIds": ["assur-1"],
+            "locationPrecision": "not-a-precision",
+            "matchMethod": "verified-source",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+        {
+            "polygonIds": ["assur-1"],
+            "locationPrecision": "excavation-area",
+            "matchMethod": "not-a-method",
+            "source": "Assur Tafeln.ods",
+            "sourceRevision": "2026-07-27",
+        },
+    ],
+)
+def test_map_location_schema_rejects_invalid_payload(payload):
+    with pytest.raises(ValidationError):
+        MapLocationSchema().load(payload)
+
+
+def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
+    site = seeded_provenance_service.find_by_id("ASSUR")
+    findspot = attr.evolve(FindspotFactory.build(site=site, map_location=None))
+    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+
+    assert "mapLocation" not in schema.dump(findspot)
+    assert schema.load(schema.dump(findspot)).map_location is None
+
+
+def test_findspot_schema_round_trip_with_map_location(seeded_provenance_service):
+    site = seeded_provenance_service.find_by_id("ASSUR")
+    findspot = attr.evolve(
+        FindspotFactory.build(site=site, map_location=_map_location("assur-1"))
+    )
+    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+
+    assert schema.load(schema.dump(findspot)) == findspot

--- a/ebl/tests/fragmentarium/test_map_location_schemas.py
+++ b/ebl/tests/fragmentarium/test_map_location_schemas.py
@@ -1,4 +1,5 @@
-import attr
+from typing import cast
+
 import pytest
 from marshmallow import ValidationError
 
@@ -22,50 +23,35 @@ def _map_location(*polygon_ids, source="Assur Tafeln.ods", revision="2026-07-27"
     )
 
 
-@pytest.mark.parametrize("polygon_ids", [("assur-1",), ("assur-1", "assur-2")])
-def test_map_location_schema_round_trip(polygon_ids):
-    schema = MapLocationSchema()
-    payload = {
-        "polygonIds": list(polygon_ids),
+def _payload(**changes) -> dict:
+    return {
+        "polygonIds": ["assur-1"],
         "locationPrecision": "excavation-area",
         "matchMethod": "verified-source",
         "source": "Assur Tafeln.ods",
         "sourceRevision": "2026-07-27",
+        **changes,
     }
+
+
+@pytest.mark.parametrize("polygon_ids", [["assur-1"], ["assur-1", "assur-2"]])
+def test_map_location_schema_round_trip(polygon_ids):
+    schema = MapLocationSchema()
+    payload = _payload(polygonIds=polygon_ids)
+
     assert schema.dump(schema.load(payload)) == payload
 
 
 @pytest.mark.parametrize(
     "payload",
     [
-        {
-            "polygonIds": [],
-            "locationPrecision": "excavation-area",
-            "matchMethod": "verified-source",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
-        {
-            "polygonIds": ["assur-1", "assur-1"],
-            "locationPrecision": "excavation-area",
-            "matchMethod": "verified-source",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
-        {
-            "polygonIds": ["assur-1"],
-            "locationPrecision": "not-a-precision",
-            "matchMethod": "verified-source",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
-        {
-            "polygonIds": ["assur-1"],
-            "locationPrecision": "excavation-area",
-            "matchMethod": "not-a-method",
-            "source": "Assur Tafeln.ods",
-            "sourceRevision": "2026-07-27",
-        },
+        _payload(polygonIds=[]),
+        _payload(polygonIds=["assur-1", "assur-1"]),
+        _payload(polygonIds=["assur-1", "  "]),
+        _payload(locationPrecision="not-a-precision"),
+        _payload(matchMethod="not-a-method"),
+        _payload(source="   "),
+        _payload(sourceRevision="  "),
     ],
 )
 def test_map_location_schema_rejects_invalid_payload(payload):
@@ -73,20 +59,27 @@ def test_map_location_schema_rejects_invalid_payload(payload):
         MapLocationSchema().load(payload)
 
 
-def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
-    site = seeded_provenance_service.find_by_id("ASSUR")
-    findspot = attr.evolve(FindspotFactory.build(site=site, map_location=None))
-    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+def test_map_location_schema_rejects_unknown_field():
+    with pytest.raises(ValidationError):
+        MapLocationSchema().load(_payload(unknown="value"))
 
-    assert "mapLocation" not in schema.dump(findspot)
-    assert schema.load(schema.dump(findspot)).map_location is None
+
+def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
+    findspot = FindspotFactory.build(
+        site=seeded_provenance_service.find_by_id("ASSUR"), map_location=None
+    )
+    schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
+    dumped = cast(dict, schema.dump(findspot))
+
+    assert "mapLocation" not in dumped
+    assert schema.load(dumped) == findspot
 
 
 def test_findspot_schema_round_trip_with_map_location(seeded_provenance_service):
-    site = seeded_provenance_service.find_by_id("ASSUR")
-    findspot = attr.evolve(
-        FindspotFactory.build(site=site, map_location=_map_location("assur-1"))
+    findspot = FindspotFactory.build(
+        site=seeded_provenance_service.find_by_id("ASSUR"),
+        map_location=_map_location("assur-1"),
     )
     schema = FindspotSchema(context={"provenance_service": seeded_provenance_service})
 
-    assert schema.load(schema.dump(findspot)) == findspot
+    assert schema.load(cast(dict, schema.dump(findspot))) == findspot

--- a/ebl/tests/fragmentarium/test_map_location_schemas.py
+++ b/ebl/tests/fragmentarium/test_map_location_schemas.py
@@ -64,6 +64,18 @@ def test_map_location_schema_rejects_unknown_field():
         MapLocationSchema().load(_payload(unknown="value"))
 
 
+def test_map_location_schema_normalizes_source_whitespace():
+    loaded = cast(
+        MapLocation,
+        MapLocationSchema().load(
+            _payload(source="  Assur Tafeln.ods  ", sourceRevision=" 2026-07-27 ")
+        ),
+    )
+
+    assert loaded.source == "Assur Tafeln.ods"
+    assert loaded.source_revision == "2026-07-27"
+
+
 def test_findspot_schema_omits_missing_map_location(seeded_provenance_service):
     findspot = FindspotFactory.build(
         site=seeded_provenance_service.find_by_id("ASSUR"), map_location=None


### PR DESCRIPTION
## Stack & Frontend Consumers

> **Map backend stack — slice 02 of 6.** Branch: `map/backend-02-findspot-query`.
> `master` → #760 → **#761 (this PR)** → #762 → #759 → #758 → #757.

### Same-repository dependency

- Direct parent: **#760 — `map/backend-01-map-location-contract`** (the `MapLocation` domain contract).
- Base branch: **`master` (temporary).** This branch was cut from #760's first commit (`9142c70b`) and is missing #760's two later commits, so retargeting the base to `map/backend-01-map-location-contract` right now would render a misleading "reverts tests" diff. **Fix:** rebase this branch onto the current tip of `map/backend-01-map-location-contract`, then set this PR's base to `map/backend-01-map-location-contract`.
- Until then this PR's diff shows slices **01 + 02** combined (commits `9142c70b` + `705e0cd3`).

### What this PR introduces (slice 02, incremental commit `705e0cd3`)

- `findspotId` (single, non-negative int) and `findspotIds` (comma-separated, ≤ `MAX_FINDSPOT_IDS = 200`) parameters on the fragment query API — `ebl/common/query/parameter_parser.py`, `ebl/fragmentarium/infrastructure/query_filters.py` (new), `fragment_pattern_matcher.py`, `ebl/fragmentarium/web/fragments.py`.
- Visibility/scope enforcement on the findspot filter; validation, deduplication, and bounded-list rejection.
- Centralized reusable script/genre query-filter construction.
- Tests: repository-level findspot-id query, multi-id query, and the search route.

### Frontend consumers

- **`ElectronicBabylonianLiterature/ebl-frontend#808` — Aššur linkage.** Hard runtime consumer.
  - `FragmentQuery.findspotId` (`src/query/FragmentQuery.ts`) + `buildFindspotFragmentSearchLink(findspotId)` (`src/map/mapLinks.ts`) → `/library/search?findspotId=N` → `GET /fragments/query?findspotId=N`. Without this filter the query param is ignored and the "fragments from this findspot" links return unfiltered results (misleading).
- **`ebl-frontend#812` — evidence inspector** renders those `findspotId` links in the UI (`MapInspector.tsx` → `<Link to={buildFindspotFragmentSearchLink(findspot.findspotId)}>`); same filter dependency, inherited via #808.
- **`ebl-frontend#809` — spatial search** re-uses `buildFindspotFragmentSearchLink()` for per-findspot result links; a combined multi-findspot query (`findspotIds`) is explicitly deferred by that PR pending a verified contract.

### Merge / deployment order

- Merge after #760.
- **Backend-first for the `findspotId` links:** deploy this filter before `ebl-frontend#808` activates, or the findspot→fragments links silently return unfiltered results. `ebl-frontend#808` still fails *safe* (no crash), so it may be **reviewed** before this merges.
- Part of the **live Aššur fragment-linkage release group** together with #762, #759, and `ebl-frontend#808`.

### Downstream backend

- **#762** `map/backend-03-artifact-foundation` — deterministic map-artifact pipeline (stacked on this branch).
- Transitively: #759 → #758 → #757.

---

## Summary by Sourcery

Enable validated findspot-based fragment searches and expose associated map-location metadata for map integrations.

New Features:
- Add single- and multi-findspot fragment query filters with validation, deduplication, limits, and visibility enforcement.
- Add map-location domain and schema support to findspots and expose map-location data through fragment responses.

Enhancements:
- Centralize reusable script and genre query-filter construction and add an index for findspot-based fragment searches.

Tests:
- Add coverage for findspot query parsing, repository and route searches, access control, and map-location domain and schema behavior.